### PR TITLE
Use name pointer for internal type identification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,267 @@
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+
+file(STRINGS "${CMAKE_CURRENT_LIST_DIR}/core/base/Environment.hpp" OATPP_VERSION_MACRO REGEX "#define OATPP_VERSION \"[0-9]+.[0-9]+.[0-9]+\"$")
+string(REGEX REPLACE "#define OATPP_VERSION \"([0-9]+.[0-9]+.[0-9]+)\"$" "\\1" oatpp_VERSION "${OATPP_VERSION_MACRO}")
+
+project(oatpp VERSION ${oatpp_VERSION} LANGUAGES CXX)
+
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+option(OATPP_INSTALL "Create installation target for oat++" ON)
+option(OATPP_BUILD_TESTS "Create test target for oat++" ON)
+
+add_library(oatpp 
+    algorithm/CRC.cpp
+    algorithm/CRC.hpp
+    codegen/codegen_define_ApiClient_.hpp
+    codegen/codegen_define_ApiController_.hpp
+    codegen/codegen_define_DTO_.hpp
+    codegen/codegen_undef_ApiClient_.hpp
+    codegen/codegen_undef_ApiController_.hpp
+    codegen/codegen_undef_DTO_.hpp
+    core/async/Coroutine.cpp
+    core/async/Coroutine.hpp
+    core/async/Processor.cpp
+    core/async/Processor.hpp
+    core/base/Config.hpp
+    core/base/Controllable.cpp
+    core/base/Controllable.hpp
+    core/base/Environment.cpp
+    core/base/Environment.hpp
+    core/base/memory/Allocator.cpp
+    core/base/memory/Allocator.hpp
+    core/base/memory/MemoryPool.cpp
+    core/base/memory/MemoryPool.hpp
+    core/base/memory/ObjectPool.cpp
+    core/base/memory/ObjectPool.hpp
+    core/base/StrBuffer.cpp
+    core/base/StrBuffer.hpp
+    core/collection/FastQueue.cpp
+    core/collection/FastQueue.hpp
+    core/collection/LinkedList.cpp
+    core/collection/LinkedList.hpp
+    core/collection/ListMap.cpp
+    core/collection/ListMap.hpp
+    core/concurrency/Runnable.cpp
+    core/concurrency/Runnable.hpp
+    core/concurrency/SpinLock.cpp
+    core/concurrency/SpinLock.hpp
+    core/concurrency/Thread.cpp
+    core/concurrency/Thread.hpp
+    core/data/buffer/FIFOBuffer.cpp
+    core/data/buffer/FIFOBuffer.hpp
+    core/data/buffer/IOBuffer.cpp
+    core/data/buffer/IOBuffer.hpp
+    core/data/mapping/ObjectMapper.cpp
+    core/data/mapping/ObjectMapper.hpp
+    core/data/mapping/type/List.cpp
+    core/data/mapping/type/List.hpp
+    core/data/mapping/type/ListMap.cpp
+    core/data/mapping/type/ListMap.hpp
+    core/data/mapping/type/Object.cpp
+    core/data/mapping/type/Object.hpp
+    core/data/mapping/type/Primitive.cpp
+    core/data/mapping/type/Primitive.hpp
+    core/data/mapping/type/Type.cpp
+    core/data/mapping/type/Type.hpp
+    core/data/stream/ChunkedBuffer.cpp
+    core/data/stream/ChunkedBuffer.hpp
+    core/data/stream/Delegate.cpp
+    core/data/stream/Delegate.hpp
+    core/data/stream/Stream.cpp
+    core/data/stream/Stream.hpp
+    core/data/stream/StreamBufferedProxy.cpp
+    core/data/stream/StreamBufferedProxy.hpp
+    core/macro/basic.hpp
+    core/macro/codegen.hpp
+    core/macro/component.hpp
+    core/os/io/Library.cpp
+    core/os/io/Library.hpp
+    core/parser/ParsingCaret.cpp
+    core/parser/ParsingCaret.hpp
+    core/Types.cpp
+    core/Types.hpp
+    core/utils/ConversionUtils.cpp
+    core/utils/ConversionUtils.hpp
+    encoding/Base64.cpp
+    encoding/Base64.hpp
+    encoding/Hex.cpp
+    encoding/Hex.hpp
+    encoding/Unicode.cpp
+    encoding/Unicode.hpp
+    network/client/SimpleTCPConnectionProvider.cpp
+    network/client/SimpleTCPConnectionProvider.hpp
+    network/Connection.cpp
+    network/Connection.hpp
+    network/ConnectionProvider.cpp
+    network/ConnectionProvider.hpp
+    network/server/ConnectionHandler.cpp
+    network/server/ConnectionHandler.hpp
+    network/server/Server.cpp
+    network/server/Server.hpp
+    network/server/SimpleTCPConnectionProvider.cpp
+    network/server/SimpleTCPConnectionProvider.hpp
+    network/Url.cpp
+    network/Url.hpp
+    network/virtual_/Pipe.cpp
+    network/virtual_/Pipe.hpp
+    network/virtual_/Socket.cpp
+    network/virtual_/Socket.hpp
+    parser/json/mapping/Deserializer.cpp
+    parser/json/mapping/Deserializer.hpp
+    parser/json/mapping/ObjectMapper.cpp
+    parser/json/mapping/ObjectMapper.hpp
+    parser/json/mapping/Serializer.cpp
+    parser/json/mapping/Serializer.hpp
+    parser/json/Utils.cpp
+    parser/json/Utils.hpp
+    web/client/ApiClient.cpp
+    web/client/ApiClient.hpp
+    web/client/HttpRequestExecutor.cpp
+    web/client/HttpRequestExecutor.hpp
+    web/client/RequestExecutor.cpp
+    web/client/RequestExecutor.hpp
+    web/protocol/http/Http.cpp
+    web/protocol/http/Http.hpp
+    web/protocol/http/incoming/BodyDecoder.cpp
+    web/protocol/http/incoming/BodyDecoder.hpp
+    web/protocol/http/incoming/Request.cpp
+    web/protocol/http/incoming/Request.hpp
+    web/protocol/http/incoming/Response.cpp
+    web/protocol/http/incoming/Response.hpp
+    web/protocol/http/outgoing/Body.cpp
+    web/protocol/http/outgoing/Body.hpp
+    web/protocol/http/outgoing/BufferBody.cpp
+    web/protocol/http/outgoing/BufferBody.hpp
+    web/protocol/http/outgoing/ChunkedBufferBody.cpp
+    web/protocol/http/outgoing/ChunkedBufferBody.hpp
+    web/protocol/http/outgoing/CommunicationUtils.cpp
+    web/protocol/http/outgoing/CommunicationUtils.hpp
+    web/protocol/http/outgoing/DtoBody.cpp
+    web/protocol/http/outgoing/DtoBody.hpp
+    web/protocol/http/outgoing/Request.cpp
+    web/protocol/http/outgoing/Request.hpp
+    web/protocol/http/outgoing/Response.cpp
+    web/protocol/http/outgoing/Response.hpp
+    web/protocol/http/outgoing/ResponseFactory.cpp
+    web/protocol/http/outgoing/ResponseFactory.hpp
+    web/server/api/ApiController.cpp
+    web/server/api/ApiController.hpp
+    web/server/api/Endpoint.cpp
+    web/server/api/Endpoint.hpp
+    web/server/AsyncHttpConnectionHandler.cpp
+    web/server/AsyncHttpConnectionHandler.hpp
+    web/server/handler/ErrorHandler.cpp
+    web/server/handler/ErrorHandler.hpp
+    web/server/handler/Interceptor.cpp
+    web/server/handler/Interceptor.hpp
+    web/server/HttpConnectionHandler.cpp
+    web/server/HttpConnectionHandler.hpp
+    web/server/HttpError.cpp
+    web/server/HttpError.hpp
+    web/server/HttpProcessor.cpp
+    web/server/HttpProcessor.hpp
+    web/server/HttpRouter.cpp
+    web/server/HttpRouter.hpp
+    web/url/mapping/Pattern.cpp
+    web/url/mapping/Pattern.hpp
+    web/url/mapping/Router.cpp
+    web/url/mapping/Router.hpp
+    web/url/mapping/Subscriber.cpp
+    web/url/mapping/Subscriber.hpp
+)
+
+set(CMAKE_THREAD_PREFER_PTHREAD ON)
+find_package(Threads REQUIRED)
+target_link_libraries(oatpp PUBLIC ${CMAKE_THREAD_LIBS_INIT})
+target_include_directories(oatpp PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+set_target_properties(oatpp PROPERTIES
+    CXX_STANDARD 11
+    CXX_EXTENSIONS OFF
+    CXX_STANDARD_REQUIRED ON
+)
+add_library(oatpp::oatpp ALIAS oatpp)
+
+if(OATPP_INSTALL)
+    include(GNUInstallDirs)
+
+    install(TARGETS oatpp
+        EXPORT oatpp-targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+    install(DIRECTORY algorithm codegen core encoding network parser web
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/oatpp
+        FILES_MATCHING PATTERN "*.hpp"
+    )
+    install(EXPORT oatpp-targets
+        FILE oatppTargets.cmake
+        NAMESPACE oatpp::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/oatpp
+    )
+    include(CMakePackageConfigHelpers)
+    string(CONCAT oatppConfig_cmake_in
+        "@PACKAGE_INIT@\n"
+        "\n"
+        "set_and_check(oatpp_INCLUDE_DIRS \"\$\{PACKAGE_PREFIX_DIR\}/include\")\n"
+        "if(NOT TARGET oatpp::oatpp)\n"
+        "    include(\"\$\{CMAKE_CURRENT_LIST_DIR\}/oatppTargets.cmake\")\n"
+        "endif()\n"
+        "set(oatpp_LIBRARIES \"oatpp::oatpp\")\n"
+    )
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/oatppConfig.cmake.in" "${oatppConfig_cmake_in}")
+
+    configure_package_config_file(${CMAKE_CURRENT_BINARY_DIR}/oatppConfig.cmake.in
+        oatppConfig.cmake
+        INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/oatpp"
+        NO_CHECK_REQUIRED_COMPONENTS_MACRO
+    )
+    write_basic_package_version_file(oatppConfigVersion.cmake
+        VERSION ${oatpp_VERSION}
+        COMPATIBILITY SameMajorVersion
+    )
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/oatppConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/oatppConfigVersion.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/oatpp"
+    )
+endif()
+
+if(OATPP_BUILD_TESTS)
+    enable_testing()
+
+    add_executable(oatppAllTests
+        test/AllTestsMain.cpp
+        test/Checker.cpp
+        test/Checker.hpp
+        test/UnitTest.cpp
+        test/UnitTest.hpp
+        test/core/base/collection/LinkedListTest.cpp
+        test/core/base/collection/LinkedListTest.hpp
+        test/core/base/memory/MemoryPoolTest.cpp
+        test/core/base/memory/MemoryPoolTest.hpp
+        test/core/base/memory/PerfTest.cpp
+        test/core/base/memory/PerfTest.hpp
+        test/core/base/RegRuleTest.cpp
+        test/core/base/RegRuleTest.hpp
+        test/encoding/UnicodeTest.cpp
+        test/encoding/UnicodeTest.hpp
+        test/parser/json/mapping/DeserializerTest.cpp
+        test/parser/json/mapping/DeserializerTest.hpp
+        test/parser/json/mapping/DTOMapperPerfTest.cpp
+        test/parser/json/mapping/DTOMapperPerfTest.hpp
+        test/parser/json/mapping/DTOMapperTest.cpp
+        test/parser/json/mapping/DTOMapperTest.hpp
+    )
+    target_link_libraries(oatppAllTests PRIVATE oatpp)
+    set_target_properties(oatppAllTests PROPERTIES
+        CXX_STANDARD 11
+        CXX_EXTENSIONS OFF
+        CXX_STANDARD_REQUIRED ON
+    )
+    target_compile_definitions(oatppAllTests
+        PRIVATE OATPP_ENABLE_ALL_TESTS_MAIN
+    )
+    add_test(oatppAllTests oatppAllTests)
+endif()

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 - Website: [https://oatpp.io](https://oatpp.io)
 - Docs: [https://oatpp.io/docs/start](https://oatpp.io/docs/start)
-- Benchmarks: [https://oatpp.io/benchmark/aws](https://oatpp.io/benchmark/aws)
+- Benchmarks: [https://oatpp.io/benchmark/digital-ocean](https://oatpp.io/benchmark/digital-ocean)
 
 Zero-Dependency. Performance oriented web-service-development framework.
 Organic. Pure C++.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,134 @@ Organic. Pure C++.
 - Simple Test framework
 - HTTP_1.1 (2.0 comes shortly)
 
+## Simple API overview
+"Simple API" refers to as API used together with ```oatpp::web::server::HttpConnectionHandler``` utilizing multithreading plus blocking-IO approach. 
+
+### Create Endpoint
+
+```c++
+ENDPOINT("GET", "demo/api/hello", hello) {
+  return createResponse(Status::CODE_200, "Hello World!");
+}
+```
+
+### Pass parameters to endpoint
+
+```c++
+ENDPOINT("GET", "demo/api/param/{param}", getWithParams,
+         PATH(String, param)) {
+  return createResponse(Status::CODE_200, "param=" + param);
+}
+```
+
+### Return JSON
+
+```c++
+ENDPOINT("GET", "demo/api/json", getJson) {
+  auto dto = MyDto::createShared();
+  dto->statusCode = 200;
+  dto->message = "Hello json";
+  return createDtoResponse(Status::CODE_200, dto);
+}
+```
+**Output:**
+```
+{"message": "Hello json", "statusCode": 200}
+```
+
+### Post JSON body
+
+```c++
+ENDPOINT("POST", "demo/api/json", postJson,
+         BODY_DTO(MyDto::ObjectWrapper, dto)) {
+  auto dtoMessage = dto->message;
+  return createResponse(Status::CODE_200, "dtoMessage: " + dtoMessage);
+}
+```
+
+**Terminal:**
+
+```
+$ curl -X POST "localhost:8001/demo/api/json" -d '{"message": "hello json post"}'
+dtoMessage: hello json post
+```
+
+## Async API overview
+"Async API" refers to as API used together with ```oatpp::web::server::AsyncHttpConnectionHandler``` utilizing oatpp-coroutines plus non-blocking-IO approach. 
+
+### Create Endpoint Async
+```c++
+ENDPOINT_ASYNC("GET", "demo/api_async/hello", HelloAsync) {
+
+  ENDPOINT_ASYNC_INIT(HelloAsync)
+
+  Action act() override {
+    return _return(controller->createResponse(Status::CODE_200, "Hello World Async API!"));
+  }
+
+};
+```
+
+### Pass parameters to endpoint Async
+```c++
+ENDPOINT_ASYNC("GET", "demo/api_async/param/{param}", GetWithParamsAsync) {
+
+  ENDPOINT_ASYNC_INIT(GetWithParamsAsync)
+
+  Action act() override {
+    auto param = request->getPathVariable("param");
+    return _return(controller->createResponse(Status::CODE_200, "param=" + param));
+  }
+
+};
+```
+
+### Return JSON Async
+```c++
+ENDPOINT_ASYNC("GET", "demo/api_async/json", GetJSONAsync) {
+
+  ENDPOINT_ASYNC_INIT(GetJSONAsync)
+
+  Action act() override {
+    auto dto = MyDto::createShared();
+    dto->statusCode = 200;
+    dto->message = "Hello json";
+    return _return(controller->createDtoResponse(Status::CODE_200, dto));
+  }
+
+};
+```
+
+**Output:**
+```
+{"message": "Hello json", "statusCode": 200}
+```
+
+### Post JSON body Async
+```c++
+ENDPOINT_ASYNC("POST", "demo/api_async/json", PostJSONAsync) {
+
+  ENDPOINT_ASYNC_INIT(PostJSONAsync)
+
+  Action act() override {
+    return request->readBodyToDtoAsync<MyDto>(this,
+                                              &PostJSONAsync::onBodyObtained,
+                                              controller->getDefaultObjectMapper());
+  }
+
+  Action onBodyObtained(const MyDto::ObjectWrapper& dto) {
+    return _return(controller->createResponse(Status::CODE_200, "dtoMessage: " + dto->message));
+  }
+
+};
+```
+
+**Terminal:**
+```
+$ curl -X POST "localhost:8001/demo/api_async/json" -d '{"message": "hello json post"}'
+dtoMessage: hello json post
+```
+
 ## How to start
 
 Grab any project from [examples](https://github.com/oatpp/oatpp-examples), and follow README

--- a/codegen/codegen_define_ApiClient_.hpp
+++ b/codegen/codegen_define_ApiClient_.hpp
@@ -50,7 +50,7 @@ public: \
 public: \
   static std::shared_ptr<NAME> createShared(const std::shared_ptr<oatpp::web::client::RequestExecutor>& requestExecutor, \
                                       const std::shared_ptr<oatpp::data::mapping::ObjectMapper>& objectMapper){ \
-    return std::shared_ptr<NAME>(new NAME(requestExecutor, objectMapper)); \
+    return std::make_shared<NAME>(requestExecutor, objectMapper); \
   }
 
 // HEADER MACRO

--- a/codegen/codegen_define_ApiController_.hpp
+++ b/codegen/codegen_define_ApiController_.hpp
@@ -48,18 +48,6 @@ OATPP_MACRO_API_CONTROLLER_PARAM(OATPP_MACRO_API_CONTROLLER_BODY_STRING, OATPP_M
 #define BODY_DTO(TYPE, NAME) \
 OATPP_MACRO_API_CONTROLLER_PARAM(OATPP_MACRO_API_CONTROLLER_BODY_DTO, OATPP_MACRO_API_CONTROLLER_BODY_DTO_INFO, TYPE, NAME, ())
 
-// INIT // ------------------------------------------------------
-
-#define REST_CONTROLLER_INIT(NAME) \
-public: \
-  NAME() \
-  {} \
-public: \
-\
-  static std::shared_ptr<NAME> createShared(){ \
-    return std::shared_ptr<>(new NAME(); \
-    return object->getSharedPtr<NAME>(); \
-  }
 
 // REQUEST MACRO // ------------------------------------------------------
 

--- a/core/base/Controllable.hpp
+++ b/core/base/Controllable.hpp
@@ -43,7 +43,7 @@ public:
   virtual ~Controllable();
   
   static std::shared_ptr<Controllable> createShared(){
-    return std::shared_ptr<Controllable>(new Controllable);
+    return std::make_shared<Controllable>();
   }
   
 };

--- a/core/data/mapping/type/List.cpp
+++ b/core/data/mapping/type/List.cpp
@@ -27,6 +27,6 @@
 
 namespace oatpp { namespace data { namespace mapping { namespace type {
 
-  constexpr const char* const __class::AbstractList::CLASS_NAME_NONCONSTEXPR = "List";
+  const char* const __class::AbstractList::CLASS_NAME_NONCONSTEXPR = "List";
 
 }}}}

--- a/core/data/mapping/type/List.cpp
+++ b/core/data/mapping/type/List.cpp
@@ -23,3 +23,10 @@
  ***************************************************************************/
 
 #include "./List.hpp"
+
+
+namespace oatpp { namespace data { namespace mapping { namespace type {
+
+  constexpr const char* const __class::AbstractList::CLASS_NAME_NONCONSTEXPR = "List";
+
+}}}}

--- a/core/data/mapping/type/List.hpp
+++ b/core/data/mapping/type/List.hpp
@@ -38,7 +38,8 @@ namespace __class {
   
   class AbstractList {
   public:
-    constexpr static const char* const CLASS_NAME = "List";
+   static const char* const CLASS_NAME_NONCONSTEXPR;
+    constexpr static const char* const * const CLASS_NAME = &CLASS_NAME_NONCONSTEXPR;
   };
   
   template<class T>

--- a/core/data/mapping/type/ListMap.cpp
+++ b/core/data/mapping/type/ListMap.cpp
@@ -23,3 +23,10 @@
  ***************************************************************************/
 
 #include "ListMap.hpp"
+
+
+namespace oatpp { namespace data { namespace mapping { namespace type {
+
+  constexpr const char* const __class::AbstractListMap::CLASS_NAME_NONCONSTEXPR = "ListMap";
+
+}}}}

--- a/core/data/mapping/type/ListMap.cpp
+++ b/core/data/mapping/type/ListMap.cpp
@@ -27,6 +27,6 @@
 
 namespace oatpp { namespace data { namespace mapping { namespace type {
 
-  constexpr const char* const __class::AbstractListMap::CLASS_NAME_NONCONSTEXPR = "ListMap";
+  const char* const __class::AbstractListMap::CLASS_NAME_NONCONSTEXPR = "ListMap";
 
 }}}}

--- a/core/data/mapping/type/ListMap.hpp
+++ b/core/data/mapping/type/ListMap.hpp
@@ -34,7 +34,8 @@ namespace __class {
   
   class AbstractListMap {
   public:
-    constexpr static const char* const CLASS_NAME = "ListMap";
+    static const char* const CLASS_NAME_NONCONSTEXPR;
+    constexpr static const char* const * const CLASS_NAME = &CLASS_NAME_NONCONSTEXPR;
   };
   
   template<class Key, class Value>

--- a/core/data/mapping/type/Object.cpp
+++ b/core/data/mapping/type/Object.cpp
@@ -23,3 +23,10 @@
  ***************************************************************************/
 
 #include "./Object.hpp"
+
+
+namespace oatpp { namespace data { namespace mapping { namespace type {
+
+  constexpr const char* const __class::AbstractObject::CLASS_NAME_NONCONSTEXPR = "Object";
+
+}}}}

--- a/core/data/mapping/type/Object.cpp
+++ b/core/data/mapping/type/Object.cpp
@@ -27,6 +27,6 @@
 
 namespace oatpp { namespace data { namespace mapping { namespace type {
 
-  constexpr const char* const __class::AbstractObject::CLASS_NAME_NONCONSTEXPR = "Object";
+  const char* const __class::AbstractObject::CLASS_NAME_NONCONSTEXPR = "Object";
 
 }}}}

--- a/core/data/mapping/type/Object.hpp
+++ b/core/data/mapping/type/Object.hpp
@@ -40,7 +40,8 @@ namespace __class {
   
   class AbstractObject {
   public:
-    constexpr static const char* const CLASS_NAME = "Object";
+    static const char* const CLASS_NAME_NONCONSTEXPR;
+    constexpr static const char* const * const CLASS_NAME = &CLASS_NAME_NONCONSTEXPR;
   };
   
   template<class T>

--- a/core/data/mapping/type/Primitive.cpp
+++ b/core/data/mapping/type/Primitive.cpp
@@ -28,14 +28,14 @@
 
 namespace oatpp { namespace data { namespace mapping { namespace type {
 
-  constexpr const char* const __class::String::CLASS_NAME_NONCONSTEXPR = "String";
-  constexpr const char* const __class::Int8::CLASS_NAME_NONCONSTEXPR = "Int8";
-  constexpr const char* const __class::Int16::CLASS_NAME_NONCONSTEXPR = "Int16";
-  constexpr const char* const __class::Int32::CLASS_NAME_NONCONSTEXPR = "Int32";
-  constexpr const char* const __class::Int64::CLASS_NAME_NONCONSTEXPR = "Int64";
-  constexpr const char* const __class::Float32::CLASS_NAME_NONCONSTEXPR = "Float32";
-  constexpr const char* const __class::Float64::CLASS_NAME_NONCONSTEXPR = "Float64";
-  constexpr const char* const __class::Boolean::CLASS_NAME_NONCONSTEXPR = "Boolean";
+  const char* const __class::String::CLASS_NAME_NONCONSTEXPR = "String";
+  const char* const __class::Int8::CLASS_NAME_NONCONSTEXPR = "Int8";
+  const char* const __class::Int16::CLASS_NAME_NONCONSTEXPR = "Int16";
+  const char* const __class::Int32::CLASS_NAME_NONCONSTEXPR = "Int32";
+  const char* const __class::Int64::CLASS_NAME_NONCONSTEXPR = "Int64";
+  const char* const __class::Float32::CLASS_NAME_NONCONSTEXPR = "Float32";
+  const char* const __class::Float64::CLASS_NAME_NONCONSTEXPR = "Float64";
+  const char* const __class::Boolean::CLASS_NAME_NONCONSTEXPR = "Boolean";
 
 String::String(const std::shared_ptr<oatpp::base::StrBuffer>& ptr, const type::Type* const valueType)
   : oatpp::data::mapping::type::ObjectWrapper<oatpp::base::StrBuffer, __class::String>(ptr)

--- a/core/data/mapping/type/Primitive.cpp
+++ b/core/data/mapping/type/Primitive.cpp
@@ -28,6 +28,15 @@
 
 namespace oatpp { namespace data { namespace mapping { namespace type {
 
+  constexpr const char* const __class::String::CLASS_NAME_NONCONSTEXPR = "String";
+  constexpr const char* const __class::Int8::CLASS_NAME_NONCONSTEXPR = "Int8";
+  constexpr const char* const __class::Int16::CLASS_NAME_NONCONSTEXPR = "Int16";
+  constexpr const char* const __class::Int32::CLASS_NAME_NONCONSTEXPR = "Int32";
+  constexpr const char* const __class::Int64::CLASS_NAME_NONCONSTEXPR = "Int64";
+  constexpr const char* const __class::Float32::CLASS_NAME_NONCONSTEXPR = "Float32";
+  constexpr const char* const __class::Float64::CLASS_NAME_NONCONSTEXPR = "Float64";
+  constexpr const char* const __class::Boolean::CLASS_NAME_NONCONSTEXPR = "Boolean";
+
 String::String(const std::shared_ptr<oatpp::base::StrBuffer>& ptr, const type::Type* const valueType)
   : oatpp::data::mapping::type::ObjectWrapper<oatpp::base::StrBuffer, __class::String>(ptr)
 {

--- a/core/data/mapping/type/Primitive.hpp
+++ b/core/data/mapping/type/Primitive.hpp
@@ -240,7 +240,8 @@ namespace __class {
   
   class String {
   public:
-    constexpr static const char* const CLASS_NAME = "String";
+    static const char* const CLASS_NAME_NONCONSTEXPR;
+    constexpr static const char* const * const CLASS_NAME = &(CLASS_NAME_NONCONSTEXPR);
     
     static Type* getType(){
       static Type type(CLASS_NAME, nullptr);
@@ -256,7 +257,8 @@ namespace __class {
   
   class Int8 {
   public:
-    constexpr static const char* const CLASS_NAME = "Int8";
+    static const char* const CLASS_NAME_NONCONSTEXPR;
+    constexpr static const char* const * const CLASS_NAME = &CLASS_NAME_NONCONSTEXPR;
     
     static Type* getType(){
       static Type type(CLASS_NAME, nullptr);
@@ -269,7 +271,8 @@ namespace __class {
   
   class Int16 {
   public:
-    constexpr static const char* const CLASS_NAME = "Int16";
+    static const char* const CLASS_NAME_NONCONSTEXPR;
+    constexpr static const char* const * const CLASS_NAME = &CLASS_NAME_NONCONSTEXPR;
     
     static Type* getType(){
       static Type type(CLASS_NAME, nullptr);
@@ -282,7 +285,8 @@ namespace __class {
   
   class Int32 {
   public:
-    constexpr static const char* const CLASS_NAME = "Int32";
+    static const char* const CLASS_NAME_NONCONSTEXPR;
+    constexpr static const char* const * const CLASS_NAME = &CLASS_NAME_NONCONSTEXPR;
     
     static Type* getType(){
       static Type type(CLASS_NAME, nullptr);
@@ -295,7 +299,8 @@ namespace __class {
   
   class Int64 {
   public:
-    constexpr static const char* const CLASS_NAME = "Int64";
+    static const char* const CLASS_NAME_NONCONSTEXPR;
+    constexpr static const char* const * const CLASS_NAME = &CLASS_NAME_NONCONSTEXPR;
     
     static Type* getType(){
       static Type type(CLASS_NAME, nullptr);
@@ -308,7 +313,8 @@ namespace __class {
   
   class Float32 {
   public:
-    constexpr static const char* const CLASS_NAME = "Float32";
+    static const char* const CLASS_NAME_NONCONSTEXPR;
+    constexpr static const char* const * const CLASS_NAME = &CLASS_NAME_NONCONSTEXPR;
     
     static Type* getType(){
       static Type type(CLASS_NAME, nullptr);
@@ -321,7 +327,8 @@ namespace __class {
   
   class Float64 {
   public:
-    constexpr static const char* const CLASS_NAME = "Float64";
+    static const char* const CLASS_NAME_NONCONSTEXPR;
+    constexpr static const char* const * const CLASS_NAME = &CLASS_NAME_NONCONSTEXPR;
     
     static Type* getType(){
       static Type type(CLASS_NAME, nullptr);
@@ -334,7 +341,8 @@ namespace __class {
   
   class Boolean {
   public:
-    constexpr static const char* const CLASS_NAME = "Boolean";
+    static const char* const CLASS_NAME_NONCONSTEXPR;
+    constexpr static const char* const * const CLASS_NAME = &CLASS_NAME_NONCONSTEXPR;
     
     static Type* getType(){
       static Type type(CLASS_NAME, nullptr);

--- a/core/data/mapping/type/Type.cpp
+++ b/core/data/mapping/type/Type.cpp
@@ -27,7 +27,7 @@
 
 namespace oatpp { namespace data { namespace mapping { namespace type {
 
-  constexpr const char* const __class::Void::CLASS_NAME_NONCONSTEXPR = "Void";
+  const char* const __class::Void::CLASS_NAME_NONCONSTEXPR = "Void";
 
 namespace __class {
   

--- a/core/data/mapping/type/Type.cpp
+++ b/core/data/mapping/type/Type.cpp
@@ -26,7 +26,9 @@
 
 
 namespace oatpp { namespace data { namespace mapping { namespace type {
-  
+
+  constexpr const char* const __class::Void::CLASS_NAME_NONCONSTEXPR = "Void";
+
 namespace __class {
   
   Type* Void::getType(){

--- a/core/data/mapping/type/Type.hpp
+++ b/core/data/mapping/type/Type.hpp
@@ -38,7 +38,8 @@ class Type; // FWD
 namespace __class {
   class Void {
   public:
-    constexpr static const char* const CLASS_NAME = "Void";
+    static const char* const CLASS_NAME_NONCONSTEXPR;
+    constexpr static const char* const * const CLASS_NAME = &CLASS_NAME_NONCONSTEXPR;
     static Type* getType();
   };
 }
@@ -274,27 +275,31 @@ public:
   
 public:
   
-  Type(const char* pName, const char* pNameQualifier)
-    : name(pName)
+  Type(const char* const * pNamePtr, const char* pNameQualifier)
+    : namePtr(pNamePtr)
+    , name(*pNamePtr)
     , nameQualifier(pNameQualifier)
     , creator(nullptr)
     , properties(nullptr)
   {}
   
-  Type(const char* pName, const char* pNameQualifier, Creator pCreator)
-    : name(pName)
+  Type(const char* const * pNamePtr, const char* pNameQualifier, Creator pCreator)
+    : namePtr(pNamePtr)
+    , name(*pNamePtr)
     , nameQualifier(pNameQualifier)
     , creator(pCreator)
     , properties(nullptr)
   {}
   
-  Type(const char* pName, const char* pNameQualifier, Creator pCreator, Properties* pProperties)
-    : name(pName)
+  Type(const char* const * pNamePtr, const char* pNameQualifier, Creator pCreator, Properties* pProperties)
+    : namePtr(pNamePtr)
+    , name(*pNamePtr)
     , nameQualifier(pNameQualifier)
     , creator(pCreator)
     , properties(pProperties)
   {}
   
+  const char* const * const namePtr;
   const char* const name;
   const char* const nameQualifier;
   std::list<Type*> params;

--- a/core/parser/ParsingCaret.cpp
+++ b/core/parser/ParsingCaret.cpp
@@ -59,15 +59,15 @@ namespace oatpp { namespace parser {
   {}
   
   std::shared_ptr<ParsingCaret> ParsingCaret::createShared(const char* text){
-    return std::shared_ptr<ParsingCaret>(new ParsingCaret(text));
+    return std::make_shared<ParsingCaret>(text);
   }
   
   std::shared_ptr<ParsingCaret> ParsingCaret::createShared(p_char8 parseData, v_int32 dataSize){
-    return std::shared_ptr<ParsingCaret>(new ParsingCaret(parseData, dataSize));
+    return std::make_shared<ParsingCaret>(parseData, dataSize);
   }
   
   std::shared_ptr<ParsingCaret> ParsingCaret::createShared(const oatpp::String& str){
-    return std::shared_ptr<ParsingCaret>(new ParsingCaret(str->getData(), str->getSize()));
+    return std::make_shared<ParsingCaret>(str->getData(), str->getSize());
   }
   
   ParsingCaret::~ParsingCaret(){

--- a/network/client/SimpleTCPConnectionProvider.hpp
+++ b/network/client/SimpleTCPConnectionProvider.hpp
@@ -41,7 +41,7 @@ public:
   
   static std::shared_ptr<SimpleTCPConnectionProvider>
   createShared(const oatpp::String& host, v_int32 port){
-    return std::shared_ptr<SimpleTCPConnectionProvider>(new SimpleTCPConnectionProvider(host, port));
+    return std::make_shared<SimpleTCPConnectionProvider>(host, port);
   }
   
   std::shared_ptr<IOStream> getConnection() override;

--- a/network/server/Server.hpp
+++ b/network/server/Server.hpp
@@ -81,7 +81,7 @@ public:
   
   static std::shared_ptr<Server> createShared(const std::shared_ptr<ServerConnectionProvider>& connectionProvider,
                                         const std::shared_ptr<ConnectionHandler>& connectionHandler){
-    return std::shared_ptr<Server>(new Server(connectionProvider, connectionHandler));
+    return std::make_shared<Server>(connectionProvider, connectionHandler);
   }
   
   void run() override;

--- a/network/server/SimpleTCPConnectionProvider.hpp
+++ b/network/server/SimpleTCPConnectionProvider.hpp
@@ -49,7 +49,7 @@ public:
 public:
   
   static std::shared_ptr<SimpleTCPConnectionProvider> createShared(v_word16 port, bool nonBlocking = false){
-    return std::shared_ptr<SimpleTCPConnectionProvider>(new SimpleTCPConnectionProvider(port, nonBlocking));
+    return std::make_shared<SimpleTCPConnectionProvider>(port, nonBlocking);
   }
   
   ~SimpleTCPConnectionProvider() {

--- a/parser/json/mapping/Deserializer.cpp
+++ b/parser/json/mapping/Deserializer.cpp
@@ -199,24 +199,24 @@ Deserializer::AbstractObjectWrapper Deserializer::readValue(const Type* const ty
                                                   oatpp::parser::ParsingCaret& caret,
                                                   const std::shared_ptr<Config>& config){
   
-  auto typeName = type->name;
-  if(typeName == oatpp::data::mapping::type::__class::String::CLASS_NAME){
+  auto typeNamePtr = type->namePtr;
+  if(typeNamePtr == oatpp::data::mapping::type::__class::String::CLASS_NAME){
     return readStringValue(caret);
-  } else if(typeName == oatpp::data::mapping::type::__class::Int32::CLASS_NAME){
+  } else if(typeNamePtr == oatpp::data::mapping::type::__class::Int32::CLASS_NAME){
     return readInt32Value(caret);
-  } else if(typeName == oatpp::data::mapping::type::__class::Int64::CLASS_NAME){
+  } else if(typeNamePtr == oatpp::data::mapping::type::__class::Int64::CLASS_NAME){
     return readInt64Value(caret);
-  } else if(typeName == oatpp::data::mapping::type::__class::Float32::CLASS_NAME){
+  } else if(typeNamePtr == oatpp::data::mapping::type::__class::Float32::CLASS_NAME){
     return readFloat32Value(caret);
-  } else if(typeName == oatpp::data::mapping::type::__class::Float64::CLASS_NAME){
+  } else if(typeNamePtr == oatpp::data::mapping::type::__class::Float64::CLASS_NAME){
     return readFloat64Value(caret);
-  } else if(typeName == oatpp::data::mapping::type::__class::Boolean::CLASS_NAME){
+  } else if(typeNamePtr == oatpp::data::mapping::type::__class::Boolean::CLASS_NAME){
     return readBooleanValue(caret);
-  } else if(typeName == oatpp::data::mapping::type::__class::AbstractObject::CLASS_NAME){
+  } else if(typeNamePtr == oatpp::data::mapping::type::__class::AbstractObject::CLASS_NAME){
     return readObjectValue(type, caret, config);
-  } else if(typeName == oatpp::data::mapping::type::__class::AbstractList::CLASS_NAME){
+  } else if(typeNamePtr == oatpp::data::mapping::type::__class::AbstractList::CLASS_NAME){
     return readListValue(type, caret, config);
-  } else if(typeName == oatpp::data::mapping::type::__class::AbstractListMap::CLASS_NAME){
+  } else if(typeNamePtr == oatpp::data::mapping::type::__class::AbstractListMap::CLASS_NAME){
     return readListMapValue(type, caret, config);
   } else {
     skipValue(caret);
@@ -280,7 +280,7 @@ Deserializer::AbstractObjectWrapper Deserializer::readListMap(const Type* type,
     
     auto it = type->params.begin();
     Type* keyType = *it ++;
-    if(keyType->name != oatpp::data::mapping::type::__class::String::CLASS_NAME){
+    if(keyType->namePtr != oatpp::data::mapping::type::__class::String::CLASS_NAME){
       throw std::runtime_error("[oatpp::parser::json::mapping::Deserializer::readListMap()]: Invalid json map key. Key should be String");
     }
     Type* valueType = *it;

--- a/parser/json/mapping/Deserializer.hpp
+++ b/parser/json/mapping/Deserializer.hpp
@@ -125,11 +125,11 @@ public:
   static AbstractObjectWrapper deserialize(oatpp::parser::ParsingCaret& caret,
                                            const std::shared_ptr<Config>& config,
                                            const Type* const type) {
-    if(type->name == oatpp::data::mapping::type::__class::AbstractObject::CLASS_NAME){
+    if(type->namePtr == oatpp::data::mapping::type::__class::AbstractObject::CLASS_NAME){
       return readObject(type, caret, config);
-    } else if(type->name == oatpp::data::mapping::type::__class::AbstractList::CLASS_NAME){
+    } else if(type->namePtr == oatpp::data::mapping::type::__class::AbstractList::CLASS_NAME){
       return readList(type, caret, config);
-    } else if(type->name == oatpp::data::mapping::type::__class::AbstractListMap::CLASS_NAME){
+    } else if(type->namePtr == oatpp::data::mapping::type::__class::AbstractListMap::CLASS_NAME){
       return readListMap(type, caret, config);
     }
     return AbstractObjectWrapper::empty();

--- a/parser/json/mapping/Deserializer.hpp
+++ b/parser/json/mapping/Deserializer.hpp
@@ -66,7 +66,7 @@ public:
   public:
     
     static std::shared_ptr<Config> createShared(){
-      return std::shared_ptr<Config>(new Config());
+      return std::make_shared<Config>();
     }
     
     bool allowUnknownFields = true;

--- a/parser/json/mapping/ObjectMapper.hpp
+++ b/parser/json/mapping/ObjectMapper.hpp
@@ -50,7 +50,7 @@ public:
   static std::shared_ptr<ObjectMapper>
   createShared(const std::shared_ptr<Serializer::Config>& serializerConfig = Serializer::Config::createShared(),
          const std::shared_ptr<Deserializer::Config>& deserializerConfig = Deserializer::Config::createShared()){
-    return std::shared_ptr<ObjectMapper>(new ObjectMapper(serializerConfig, deserializerConfig));
+    return std::make_shared<ObjectMapper>(serializerConfig, deserializerConfig);
   }
   
   void write(const std::shared_ptr<oatpp::data::stream::OutputStream>& stream,

--- a/parser/json/mapping/Serializer.cpp
+++ b/parser/json/mapping/Serializer.cpp
@@ -107,31 +107,31 @@ void Serializer::writeValue(oatpp::data::stream::OutputStream* stream, const Abs
     return;
   }
   
-  const char* typeName = polymorph.valueType->name;
+  const char* const * typeNamePtr = polymorph.valueType->namePtr;
   
-  if(typeName == oatpp::data::mapping::type::__class::String::CLASS_NAME) {
+  if(typeNamePtr == oatpp::data::mapping::type::__class::String::CLASS_NAME) {
     auto str = oatpp::data::mapping::type::static_wrapper_cast<oatpp::base::StrBuffer>(polymorph);
     writeString(stream, str->getData(), str->getSize());
-  } else if(typeName == oatpp::data::mapping::type::__class::Int8::CLASS_NAME) {
+  } else if(typeNamePtr == oatpp::data::mapping::type::__class::Int8::CLASS_NAME) {
     writeSimpleData(stream, oatpp::data::mapping::type::static_wrapper_cast<Int8::ObjectType>(polymorph));
-  } else if(typeName == oatpp::data::mapping::type::__class::Int16::CLASS_NAME) {
+  } else if(typeNamePtr == oatpp::data::mapping::type::__class::Int16::CLASS_NAME) {
     writeSimpleData(stream, oatpp::data::mapping::type::static_wrapper_cast<Int16::ObjectType>(polymorph));
-  } else if(typeName == oatpp::data::mapping::type::__class::Int32::CLASS_NAME) {
+  } else if(typeNamePtr == oatpp::data::mapping::type::__class::Int32::CLASS_NAME) {
     writeSimpleData(stream, oatpp::data::mapping::type::static_wrapper_cast<Int32::ObjectType>(polymorph));
-  } else if(typeName == oatpp::data::mapping::type::__class::Int64::CLASS_NAME) {
+  } else if(typeNamePtr == oatpp::data::mapping::type::__class::Int64::CLASS_NAME) {
     writeSimpleData(stream, oatpp::data::mapping::type::static_wrapper_cast<Int64::ObjectType>(polymorph));
-  } else if(typeName == oatpp::data::mapping::type::__class::Float32::CLASS_NAME) {
+  } else if(typeNamePtr == oatpp::data::mapping::type::__class::Float32::CLASS_NAME) {
     writeSimpleData(stream, oatpp::data::mapping::type::static_wrapper_cast<Float32::ObjectType>(polymorph));
-  } else if(typeName == oatpp::data::mapping::type::__class::Float64::CLASS_NAME) {
+  } else if(typeNamePtr == oatpp::data::mapping::type::__class::Float64::CLASS_NAME) {
     writeSimpleData(stream, oatpp::data::mapping::type::static_wrapper_cast<Float64::ObjectType>(polymorph));
-  } else if(typeName == oatpp::data::mapping::type::__class::Boolean::CLASS_NAME) {
+  } else if(typeNamePtr == oatpp::data::mapping::type::__class::Boolean::CLASS_NAME) {
     writeSimpleData(stream, oatpp::data::mapping::type::static_wrapper_cast<Boolean::ObjectType>(polymorph));
-  } else if(typeName == oatpp::data::mapping::type::__class::AbstractList::CLASS_NAME) {
+  } else if(typeNamePtr == oatpp::data::mapping::type::__class::AbstractList::CLASS_NAME) {
     writeList(stream, oatpp::data::mapping::type::static_wrapper_cast<AbstractList>(polymorph), config);
-  } else if(typeName == oatpp::data::mapping::type::__class::AbstractListMap::CLASS_NAME) {
+  } else if(typeNamePtr == oatpp::data::mapping::type::__class::AbstractListMap::CLASS_NAME) {
     // TODO Assert that key is String
     writeFieldsMap(stream, oatpp::data::mapping::type::static_wrapper_cast<AbstractFieldsMap>(polymorph), config);
-  } else if(typeName == oatpp::data::mapping::type::__class::AbstractObject::CLASS_NAME) {
+  } else if(typeNamePtr == oatpp::data::mapping::type::__class::AbstractObject::CLASS_NAME) {
     writeObject(stream, oatpp::data::mapping::type::static_wrapper_cast<Object>(polymorph), config);
   } else {
     if(config->throwOnUnknownTypes) {

--- a/parser/json/mapping/Serializer.hpp
+++ b/parser/json/mapping/Serializer.hpp
@@ -98,11 +98,11 @@ public:
                         const oatpp::data::mapping::type::AbstractObjectWrapper& polymorph,
                         const std::shared_ptr<Config>& config){
     auto type = polymorph.valueType;
-    if(type->name == oatpp::data::mapping::type::__class::AbstractObject::CLASS_NAME) {
+    if(type->namePtr == oatpp::data::mapping::type::__class::AbstractObject::CLASS_NAME) {
       writeObject(stream.get(), oatpp::data::mapping::type::static_wrapper_cast<Object>(polymorph), config);
-    } else if(type->name == oatpp::data::mapping::type::__class::AbstractList::CLASS_NAME) {
+    } else if(type->namePtr == oatpp::data::mapping::type::__class::AbstractList::CLASS_NAME) {
       writeList(stream.get(), oatpp::data::mapping::type::static_wrapper_cast<AbstractList>(polymorph), config);
-    } else if(type->name == oatpp::data::mapping::type::__class::AbstractListMap::CLASS_NAME) {
+    } else if(type->namePtr == oatpp::data::mapping::type::__class::AbstractListMap::CLASS_NAME) {
       writeFieldsMap(stream.get(), oatpp::data::mapping::type::static_wrapper_cast<AbstractFieldsMap>(polymorph), config);
     } else {
       throw std::runtime_error("[oatpp::parser::json::mapping::Serializer::serialize()]: Unknown parameter type");

--- a/parser/json/mapping/Serializer.hpp
+++ b/parser/json/mapping/Serializer.hpp
@@ -58,13 +58,13 @@ public:
 public:
   
   class Config : public oatpp::base::Controllable {
-  protected:
+  public:
     Config()
     {}
   public:
     
     static std::shared_ptr<Config> createShared(){
-      return std::shared_ptr<Config>(new Config());
+      return std::make_shared<Config>();
     }
     
     bool includeNullFields = true;

--- a/test/AllTestsMain.cpp
+++ b/test/AllTestsMain.cpp
@@ -1,0 +1,22 @@
+#include "oatpp/test/core/base/collection/LinkedListTest.hpp"
+#include "oatpp/test/core/base/memory/MemoryPoolTest.hpp"
+#include "oatpp/test/core/base/memory/PerfTest.hpp"
+#include "oatpp/test/encoding/UnicodeTest.hpp"
+#include "oatpp/test/parser/json/mapping/DeserializerTest.hpp"
+#include "oatpp/test/parser/json/mapping/DTOMapperPerfTest.hpp"
+#include "oatpp/test/parser/json/mapping/DTOMapperTest.hpp"
+
+#ifdef OATPP_ENABLE_ALL_TESTS_MAIN
+int main() {
+  oatpp::base::Environment::init();
+  OATPP_RUN_TEST(oatpp::test::collection::LinkedListTest);
+  OATPP_RUN_TEST(oatpp::test::memory::MemoryPoolTest);
+  OATPP_RUN_TEST(oatpp::test::memory::PerfTest);
+  OATPP_RUN_TEST(oatpp::test::encoding::UnicodeTest);
+  OATPP_RUN_TEST(oatpp::test::parser::json::mapping::DeserializerTest);
+  OATPP_RUN_TEST(oatpp::test::parser::json::mapping::DTOMapperPerfTest);
+  OATPP_RUN_TEST(oatpp::test::parser::json::mapping::DTOMapperTest);
+  oatpp::base::Environment::destroy();
+  return 0;
+}
+#endif

--- a/test/core/base/collection/LinkedListTest.cpp
+++ b/test/core/base/collection/LinkedListTest.cpp
@@ -42,7 +42,7 @@ public:
 public:
   
   static std::shared_ptr<TestObject> createShared2(){
-    return std::shared_ptr<TestObject>(new TestObject);
+    return std::make_shared<TestObject>();
   }
   
   static std::shared_ptr<TestObject> createShared(){

--- a/test/core/base/memory/PerfTest.cpp
+++ b/test/core/base/memory/PerfTest.cpp
@@ -77,7 +77,7 @@ namespace {
     {}
     
     static std::shared_ptr<Task> createShared(const std::shared_ptr<TestBase>& shared){
-      return std::shared_ptr<Task>(new Task(shared));
+      return std::make_shared<Task>(shared);
     }
     
     void run() override {

--- a/web/client/ApiClient.hpp
+++ b/web/client/ApiClient.hpp
@@ -128,7 +128,7 @@ public:
   
   static std::shared_ptr<ApiClient> createShared(const std::shared_ptr<RequestExecutor>& requestExecutor,
                                            const std::shared_ptr<oatpp::data::mapping::ObjectMapper>& objectMapper) {
-    return std::shared_ptr<ApiClient>(new ApiClient(requestExecutor, objectMapper));
+    return std::make_shared<ApiClient>(requestExecutor, objectMapper);
   }
   
 protected:

--- a/web/client/HttpRequestExecutor.hpp
+++ b/web/client/HttpRequestExecutor.hpp
@@ -33,7 +33,7 @@ namespace oatpp { namespace web { namespace client {
 class HttpRequestExecutor : public oatpp::base::Controllable, public RequestExecutor {
 protected:
   std::shared_ptr<oatpp::network::ClientConnectionProvider> m_connectionProvider;
-protected:
+public:
   HttpRequestExecutor(const std::shared_ptr<oatpp::network::ClientConnectionProvider>& connectionProvider)
     : m_connectionProvider(connectionProvider)
   {}
@@ -41,7 +41,7 @@ public:
   
   static std::shared_ptr<HttpRequestExecutor>
   createShared(const std::shared_ptr<oatpp::network::ClientConnectionProvider>& connectionProvider){
-    return std::shared_ptr<HttpRequestExecutor>(new HttpRequestExecutor(connectionProvider));
+    return std::make_shared<HttpRequestExecutor>(connectionProvider);
   }
   
   /**

--- a/web/server/AsyncHttpConnectionHandler.hpp
+++ b/web/server/AsyncHttpConnectionHandler.hpp
@@ -119,7 +119,7 @@ public:
 public:
   
   static std::shared_ptr<AsyncHttpConnectionHandler> createShared(const std::shared_ptr<HttpRouter>& router){
-    return std::shared_ptr<AsyncHttpConnectionHandler>(new AsyncHttpConnectionHandler(router));
+    return std::make_shared<AsyncHttpConnectionHandler>(router);
   }
   
   ~AsyncHttpConnectionHandler(){

--- a/web/server/HttpConnectionHandler.hpp
+++ b/web/server/HttpConnectionHandler.hpp
@@ -87,7 +87,7 @@ public:
 public:
   
   static std::shared_ptr<HttpConnectionHandler> createShared(const std::shared_ptr<HttpRouter>& router){
-    return std::shared_ptr<HttpConnectionHandler>(new HttpConnectionHandler(router));
+    return std::make_shared<HttpConnectionHandler>(router);
   }
   
   void setErrorHandler(const std::shared_ptr<handler::ErrorHandler>& errorHandler){

--- a/web/server/HttpRouter.hpp
+++ b/web/server/HttpRouter.hpp
@@ -53,14 +53,14 @@ protected:
     return entry->getValue();
   }
   
-protected:
+public:
   HttpRouter()
     : m_branchMap(BranchMap::createShared())
   {}
 public:
   
   static std::shared_ptr<HttpRouter> createShared() {
-    return std::shared_ptr<HttpRouter>(new HttpRouter());
+    return std::make_shared<HttpRouter>();
   }
   
   void addSubscriber(const oatpp::String& method,

--- a/web/server/api/ApiController.hpp
+++ b/web/server/api/ApiController.hpp
@@ -104,7 +104,7 @@ protected:
     T* m_controller;
     Method m_method;
     MethodAsync m_methodAsync;
-  protected:
+  public:
     Handler(T* controller, Method method, MethodAsync methodAsync)
       : m_controller(controller)
       , m_method(method)
@@ -113,7 +113,7 @@ protected:
   public:
     
     static std::shared_ptr<Handler> createShared(T* controller, Method method, MethodAsync methodAsync){
-      return std::shared_ptr<Handler>(new Handler(controller, method, methodAsync));
+      return std::make_shared<Handler>(controller, method, methodAsync);
     }
     
     std::shared_ptr<OutgoingResponse> processUrl(const std::shared_ptr<protocol::http::incoming::Request>& request) override {

--- a/web/server/api/Endpoint.hpp
+++ b/web/server/api/Endpoint.hpp
@@ -74,7 +74,7 @@ public:
     {}
   public:
     static std::shared_ptr<Info> createShared(){
-      return std::shared_ptr<Info>(new Info());
+      return std::make_shared<Info>();
     }
     
     oatpp::String name;
@@ -121,7 +121,7 @@ public:
   
   static std::shared_ptr<Endpoint> createShared(const std::shared_ptr<RequestHandler>& handler,
                                                 const std::shared_ptr<Info>& info){
-    return std::shared_ptr<Endpoint>(new Endpoint(handler, info));
+    return std::make_shared<Endpoint>(handler, info);
   }
   
   const std::shared_ptr<RequestHandler> handler;

--- a/web/server/handler/ErrorHandler.hpp
+++ b/web/server/handler/ErrorHandler.hpp
@@ -46,7 +46,7 @@ public:
 public:
   
   static std::shared_ptr<DefaultErrorHandler> createShared() {
-    return std::shared_ptr<DefaultErrorHandler>(new DefaultErrorHandler());
+    return std::make_shared<DefaultErrorHandler>();
   }
   
   std::shared_ptr<protocol::http::outgoing::Response>

--- a/web/url/mapping/Pattern.hpp
+++ b/web/url/mapping/Pattern.hpp
@@ -38,7 +38,7 @@ public:
   class MatchMap : public base::Controllable{
   public:
     typedef oatpp::collection::ListMap<oatpp::String, oatpp::String> Variables;
-  protected:
+  public:
     MatchMap(const std::shared_ptr<Variables>& vars, const oatpp::String& urlTail)
       : variables(vars)
       , tail(urlTail)
@@ -47,7 +47,7 @@ public:
     
     static std::shared_ptr<MatchMap> createShared(const std::shared_ptr<Variables>& vars,
                                                   const oatpp::String& tail){
-      return std::shared_ptr<MatchMap>(new MatchMap(vars, tail));
+      return std::make_shared<MatchMap>(vars, tail);
     }
     
     const Variables::Entry* getVariable(const oatpp::String& key){
@@ -62,7 +62,7 @@ public:
 private:
   
   class Part : public base::Controllable{
-  protected:
+  public:
     Part(const char* pFunction, const oatpp::String& pText)
       : function(pFunction)
       , text(pText)
@@ -74,7 +74,7 @@ private:
     static const char* FUNCTION_ANY_END;
     
     static std::shared_ptr<Part> createShared(const char* function, const oatpp::String& text){
-      return std::shared_ptr<Part>(new Part(function, text));
+      return std::make_shared<Part>(function, text);
     }
     
     const char* function;
@@ -86,14 +86,14 @@ private:
   std::shared_ptr<oatpp::collection::LinkedList<std::shared_ptr<Part>>> m_parts;
 private:
   v_char8 findSysChar(oatpp::parser::ParsingCaret& caret);
-protected:
+public:
   Pattern()
     : m_parts(oatpp::collection::LinkedList<std::shared_ptr<Part>>::createShared())
   {}
 public:
   
   static std::shared_ptr<Pattern> createShared(){
-    return std::shared_ptr<Pattern>(new Pattern());
+    return std::make_shared<Pattern>();
   }
   
   static std::shared_ptr<Pattern> parse(p_char8 data, v_int32 size);

--- a/web/url/mapping/Router.hpp
+++ b/web/url/mapping/Router.hpp
@@ -80,7 +80,7 @@ public:
 public:
   
   class Pair : public base::Controllable{
-  protected:
+  public:
     Pair(const std::shared_ptr<Pattern>& pPattern, const std::shared_ptr<UrlSubscriber>& pSubscriber)
       : pattern(pPattern)
       , subscriber(pSubscriber)
@@ -88,7 +88,7 @@ public:
   public:
     
     static std::shared_ptr<Pair> createShared(const std::shared_ptr<Pattern>& pattern, const std::shared_ptr<UrlSubscriber>& subscriber){
-      return std::shared_ptr<Pair>(new Pair(pattern, subscriber));
+      return std::make_shared<Pair>(pattern, subscriber);
     }
     
     const std::shared_ptr<Pattern> pattern;
@@ -98,14 +98,14 @@ public:
   
 private:
   std::shared_ptr<oatpp::collection::LinkedList<std::shared_ptr<Pair>>> m_subscribers;
-protected:
+public:
   Router()
     : m_subscribers(oatpp::collection::LinkedList<std::shared_ptr<Pair>>::createShared())
   {}
 public:
   
   static std::shared_ptr<Router> createShared(){
-    return std::shared_ptr<Router>(new Router());
+    return std::make_shared<Router>();
   }
   
   void addSubscriber(const oatpp::String& urlPattern,


### PR DESCRIPTION
This is a possible solution to the problem with `CLASS_NAME`s in shared libraries discussed in #7.  Types have the string as a non-`constexpr` static member and have a pointer to that static member as the `constexpr` that is used in comparisons etc. This way you have both a human-readable representation and a `constexpr`, with the difference that it must work thanks to the one definition rule.

A few things you might want to do differently to this branch:
- I have added the `namePtr` to `Type` and kept the `name` for the sake of simplicity. If you don't want to waste the memory of keeping `name` around, it could be a method that simply dereferences `namePtr`.
- I have kept the name `CLASS_NAME` and called the non-`constexpr` string `CLASS_NAME_NONCONSTEXPR`. `CLASS_NAMEPTR` and `CLASS_NAME` might be better names, but they would require larger changes to the existing code.