### PR TITLE
Fix typo in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,7 @@ if(OATPP_BUILD_TESTS)
     enable_testing()
 
     add_executable(oatppAllTests
-        test/AllTestsMain.cpp.cpp
+        test/AllTestsMain.cpp
         test/Checker.cpp
         test/Checker.hpp
         test/UnitTest.cpp


### PR DESCRIPTION
Hey @lganzzzo,
I just noticed a typo that got in when I renamed `test/main.cpp` to `test/AllTestsMain.cpp`. This is just a one-line fix for that, sorry for the hassle.

As a side note, do you plan on setting up CI for oat++?