### PR TITLE
Warningless in -Wextra, hardened sprintf-calls.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 file(STRINGS "${CMAKE_CURRENT_LIST_DIR}/src/oatpp/core/base/Environment.hpp" OATPP_VERSION_MACRO REGEX "#define OATPP_VERSION \"[0-9]+.[0-9]+.[0-9]+\"$")
 string(REGEX REPLACE "#define OATPP_VERSION \"([0-9]+.[0-9]+.[0-9]+)\"$" "\\1" oatpp_VERSION "${OATPP_VERSION_MACRO}")
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
+
 ###################################################################################################
 ## These variables are passed to oatpp-module-install.cmake script
 ## use these variables to configure module installation
@@ -74,7 +76,7 @@ endif()
 if (MSVC)
     # Add compilerswitch to allow pointer-to-members
     # https://docs.microsoft.com/en-us/cpp/preprocessor/pointers-to-members?view=vs-2019
-    add_compile_options(/vmg /wd4996)
+    add_compile_options(/vmg)
 endif(MSVC)
 
 message("\n############################################################################\n")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,6 @@ cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 file(STRINGS "${CMAKE_CURRENT_LIST_DIR}/src/oatpp/core/base/Environment.hpp" OATPP_VERSION_MACRO REGEX "#define OATPP_VERSION \"[0-9]+.[0-9]+.[0-9]+\"$")
 string(REGEX REPLACE "#define OATPP_VERSION \"([0-9]+.[0-9]+.[0-9]+)\"$" "\\1" oatpp_VERSION "${OATPP_VERSION_MACRO}")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
-
 ###################################################################################################
 ## These variables are passed to oatpp-module-install.cmake script
 ## use these variables to configure module installation

--- a/src/oatpp-test/web/ClientServerTestRunner.hpp
+++ b/src/oatpp-test/web/ClientServerTestRunner.hpp
@@ -111,7 +111,6 @@ public:
 
     std::thread timerThread([&timeout, &startTime, &running, &timeoutMutex, &timeoutCondition]{
 
-      auto end = startTime + timeout;
       std::unique_lock<std::mutex> lock(timeoutMutex);
       while(running) {
         timeoutCondition.wait_for(lock, std::chrono::seconds(1));

--- a/src/oatpp/codegen/codegen_define_ApiController_.hpp
+++ b/src/oatpp/codegen/codegen_define_ApiController_.hpp
@@ -318,6 +318,7 @@ void Z__ENDPOINT_ADD_INFO_##NAME(const std::shared_ptr<Endpoint::Info>& info)
 \
 template<class T> \
 static typename Handler<T>::Method Z__ENDPOINT_METHOD_##NAME(T* controller) { \
+  (void)controller; \
   return &T::Z__PROXY_METHOD_##NAME; \
 } \
 \
@@ -353,6 +354,7 @@ OATPP_MACRO_API_CONTROLLER_ENDPOINT_DECL_0(NAME, METHOD, PATH, LIST) \
 std::shared_ptr<oatpp::web::protocol::http::outgoing::Response> \
 Z__PROXY_METHOD_##NAME(const std::shared_ptr<oatpp::web::protocol::http::incoming::Request>& __request) \
 { \
+  (void)__request; \
   return NAME(); \
 } \
 \
@@ -430,6 +432,7 @@ OATPP_MACRO_API_CONTROLLER_ENDPOINT___(NAME, METHOD, PATH, (__VA_ARGS__))
 #define OATPP_MACRO_API_CONTROLLER_ENDPOINT_ASYNC_DECL_DEFAULTS(NAME, METHOD, PATH) \
 template<class T> \
 static typename Handler<T>::MethodAsync Z__ENDPOINT_METHOD_##NAME(T* controller) { \
+  (void)controller; \
   return &T::Z__PROXY_METHOD_##NAME; \
 } \
 \

--- a/src/oatpp/core/async/Coroutine.cpp
+++ b/src/oatpp/core/async/Coroutine.cpp
@@ -275,6 +275,7 @@ Action AbstractCoroutine::takeAction(Action&& action) {
 }
 
 Action AbstractCoroutine::handleError(const std::shared_ptr<const Error>& error) {
+  (void)error;
   return Action::TYPE_ERROR;
 }
 

--- a/src/oatpp/core/async/Coroutine.hpp
+++ b/src/oatpp/core/async/Coroutine.hpp
@@ -525,6 +525,7 @@ public:
   }
 
   static void operator delete(void* ptr, std::size_t sz) {
+    (void)sz;
     ::operator delete(ptr);
   }
 
@@ -721,6 +722,7 @@ public:
   }
 
   static void operator delete(void* ptr, std::size_t sz) {
+    (void)sz;
     ::operator delete(ptr);
   }
 public:

--- a/src/oatpp/core/async/Executor.cpp
+++ b/src/oatpp/core/async/Executor.cpp
@@ -53,10 +53,12 @@ void Executor::SubmissionProcessor::run() {
 }
 
 void Executor::SubmissionProcessor::pushTasks(oatpp::collection::FastQueue<AbstractCoroutine>& tasks) {
+  (void)tasks;
   std::runtime_error("[oatpp::async::Executor::SubmissionProcessor::pushTasks]: Error. This method does nothing.");
 }
 
 void Executor::SubmissionProcessor::pushOneTask(AbstractCoroutine* task) {
+  (void)task;
   std::runtime_error("[oatpp::async::Executor::SubmissionProcessor::pushOneTask]: Error. This method does nothing.");
 }
 
@@ -119,9 +121,8 @@ void Executor::linkWorkers(const std::vector<std::shared_ptr<worker::Worker>>& w
 
   if(m_processorWorkers.size() > workers.size() && (m_processorWorkers.size() % workers.size()) == 0) {
 
-    v_int32 wi = 0;
-    for(v_int32 i = 0; i < m_processorWorkers.size(); i ++) {
-      auto& p = m_processorWorkers[i];
+    size_t wi = 0;
+    for(auto & p : m_processorWorkers) {
       p->getProcessor().addWorker(workers[wi]);
       wi ++;
       if(wi == workers.size()) {
@@ -131,10 +132,10 @@ void Executor::linkWorkers(const std::vector<std::shared_ptr<worker::Worker>>& w
 
   } else if ((workers.size() % m_processorWorkers.size()) == 0) {
 
-    v_int32 pi = 0;
-    for(v_int32 i = 0; i < workers.size(); i ++) {
+    size_t pi = 0;
+    for(const auto & worker : workers) {
       auto& p = m_processorWorkers[pi];
-      p->getProcessor().addWorker(workers[i]);
+      p->getProcessor().addWorker(worker);
       pi ++;
       if(pi == m_processorWorkers.size()) {
         pi = 0;
@@ -143,8 +144,7 @@ void Executor::linkWorkers(const std::vector<std::shared_ptr<worker::Worker>>& w
 
   } else {
 
-    for(v_int32 i = 0; i < m_processorWorkers.size(); i ++) {
-      auto& p = m_processorWorkers[i];
+    for(auto & p : m_processorWorkers) {
       for(auto& w : workers) {
         p->getProcessor().addWorker(w);
       }

--- a/src/oatpp/core/async/Processor.cpp
+++ b/src/oatpp/core/async/Processor.cpp
@@ -137,13 +137,13 @@ void Processor::waitForTasks() {
 
 void Processor::popTasks() {
 
-  for(v_int32 i = 0; i < m_ioWorkers.size(); i++) {
+  for(size_t i = 0; i < m_ioWorkers.size(); i++) {
     auto& worker = m_ioWorkers[i];
     auto& popQueue = m_ioPopQueues[i];
     worker->pushTasks(popQueue);
   }
 
-  for(v_int32 i = 0; i < m_timerWorkers.size(); i++) {
+  for(size_t i = 0; i < m_timerWorkers.size(); i++) {
     auto& worker = m_timerWorkers[i];
     auto& popQueue = m_timerPopQueues[i];
     worker->pushTasks(popQueue);

--- a/src/oatpp/core/async/worker/IOEventWorker_kqueue.cpp
+++ b/src/oatpp/core/async/worker/IOEventWorker_kqueue.cpp
@@ -82,6 +82,7 @@ void IOEventWorker::setTriggerEvent(p_char8 eventPtr) {
 
 void IOEventWorker::setCoroutineEvent(AbstractCoroutine* coroutine, int operation, p_char8 eventPtr) {
 
+  (void)operation;
   auto& action = getCoroutineScheduledAction(coroutine);
 
   switch(action.getType()) {

--- a/src/oatpp/core/base/Countable.cpp
+++ b/src/oatpp/core/base/Countable.cpp
@@ -33,6 +33,7 @@ Countable::Countable() {
 }
 
 Countable::Countable(const Countable& other) {
+  (void)other;
 #ifndef OATPP_DISABLE_ENV_OBJECT_COUNTERS
   Environment::incObjects();
 #endif

--- a/src/oatpp/core/base/memory/Allocator.hpp
+++ b/src/oatpp/core/base/memory/Allocator.hpp
@@ -81,10 +81,12 @@ public:
   {};
   
   T* allocate(std::size_t n) {
+    (void)n;
     return static_cast<T*>(getPool(m_poolInfo).obtain());
   }
   
   void deallocate(T* ptr, size_t n) {
+    (void)n;
     oatpp::base::memory::MemoryPool::free(ptr);
   }
   
@@ -131,10 +133,12 @@ public:
   {};
   
   T* allocate(std::size_t n) {
+    (void)n;
     return static_cast<T*>(getPool(m_poolInfo).obtain());
   }
   
   void deallocate(T* ptr, size_t n) {
+    (void)n;
     oatpp::base::memory::MemoryPool::free(ptr);
   }
   
@@ -187,6 +191,7 @@ public:
   {};
   
   T* allocate(std::size_t n) {
+    (void)n;
     void* mem = ::operator new(sizeof(T) + m_info.extraWanted);
     m_info.baseSize = sizeof(T);
     m_info.extraPtr = &((p_char8) mem)[sizeof(T)];
@@ -194,6 +199,7 @@ public:
   }
   
   void deallocate(T* ptr, size_t n) {
+    (void)n;
     ::operator delete(ptr);
   }
   
@@ -225,6 +231,7 @@ public:
   {};
   
   T* allocate(std::size_t n) {
+    (void)n;
     void* mem = m_pool.obtain();
     m_info.baseSize = sizeof(T);
     m_info.extraPtr = &((p_char8) mem)[sizeof(T)];
@@ -232,6 +239,7 @@ public:
   }
   
   void deallocate(T* ptr, size_t n) {
+    (void)n;
     oatpp::base::memory::MemoryPool::free(ptr);
   }
   

--- a/src/oatpp/core/base/memory/ObjectPool.hpp
+++ b/src/oatpp/core/base/memory/ObjectPool.hpp
@@ -132,6 +132,8 @@ static void* operator new(std::size_t sz, void* entry) { \
 } \
 \
 static void operator delete(void* ptr, void* entry) { \
+  (void)ptr; \
+  (void)entry; \
 }
 
 #ifndef OATPP_COMPAT_BUILD_NO_THREAD_LOCAL
@@ -178,6 +180,8 @@ static void operator delete(void* ptr, void* entry) { \
   } \
   \
   static void operator delete(void* ptr, void* entry) { \
+    (void)ptr; \
+    (void)entry; \
   }
 #else
   #define OBJECT_POOL_THREAD_LOCAL(POOL_NAME, TYPE, CHUNK_SIZE) \

--- a/src/oatpp/core/concurrency/Thread.cpp
+++ b/src/oatpp/core/concurrency/Thread.cpp
@@ -67,6 +67,9 @@ v_int32 setThreadAffinityToCpuRange(std::thread::native_handle_type nativeHandle
   #endif
 
 #else
+  (void)nativeHandle;
+  (void)firstCpuIndex;
+  (void)lastCpuIndex;
   return -1;
 #endif
 }

--- a/src/oatpp/core/data/mapping/type/Type.hpp
+++ b/src/oatpp/core/data/mapping/type/Type.hpp
@@ -202,7 +202,7 @@ public:
   
   ObjectWrapper(std::nullptr_t nullptrt)
     : PolymorphicWrapper<T>(nullptr, Class::getType())
-  {}
+  {(void)nullptrt;}
   
   ObjectWrapper(const std::shared_ptr<T>& ptr)
     : PolymorphicWrapper<T>(ptr, Class::getType())

--- a/src/oatpp/core/data/stream/Stream.cpp
+++ b/src/oatpp/core/data/stream/Stream.cpp
@@ -47,8 +47,8 @@ oatpp::async::Action ConsistentOutputStream::suggestOutputStreamAction(data::v_i
 }
 
 data::v_io_size ConsistentOutputStream::writeAsString(v_int32 value){
-  v_char8 a[100];
-  v_int32 size = utils::conversion::int32ToCharSequence(value, &a[0]);
+  v_char8 a[16];
+  v_int32 size = utils::conversion::int32ToCharSequence(value, &a[0], 16);
   if(size > 0){
     return write(&a[0], size);
   }
@@ -56,8 +56,8 @@ data::v_io_size ConsistentOutputStream::writeAsString(v_int32 value){
 }
 
 data::v_io_size ConsistentOutputStream::writeAsString(v_int64 value){
-  v_char8 a[100];
-  v_int32 size = utils::conversion::int64ToCharSequence(value, &a[0]);
+  v_char8 a[32];
+  v_int32 size = utils::conversion::int64ToCharSequence(value, &a[0], 32);
   if(size > 0){
     return write(&a[0], size);
   }
@@ -66,7 +66,7 @@ data::v_io_size ConsistentOutputStream::writeAsString(v_int64 value){
 
 data::v_io_size ConsistentOutputStream::writeAsString(v_float32 value){
   v_char8 a[100];
-  v_int32 size = utils::conversion::float32ToCharSequence(value, &a[0]);
+  v_int32 size = utils::conversion::float32ToCharSequence(value, &a[0], 100);
   if(size > 0){
     return write(&a[0], size);
   }
@@ -75,7 +75,7 @@ data::v_io_size ConsistentOutputStream::writeAsString(v_float32 value){
 
 data::v_io_size ConsistentOutputStream::writeAsString(v_float64 value){
   v_char8 a[100];
-  v_int32 size = utils::conversion::float64ToCharSequence(value, &a[0]);
+  v_int32 size = utils::conversion::float64ToCharSequence(value, &a[0], 100);
   if(size > 0){
     return write(&a[0], size);
   }
@@ -153,6 +153,7 @@ oatpp::async::Action AsyncWriteCallbackWithCoroutineStarter::writeAsyncInline(oa
                                                                               AsyncInlineWriteData& inlineData,
                                                                               oatpp::async::Action&& nextAction)
 {
+  (void)coroutine;
   auto coroutineStarter = writeAsync(inlineData.currBufferPtr, inlineData.bytesLeft);
   inlineData.setEof();
   return coroutineStarter.next(std::forward<async::Action>(nextAction));
@@ -408,6 +409,7 @@ oatpp::async::CoroutineStarter transferAsync(const std::shared_ptr<InputStream>&
     }
     
     Action handleError(const std::shared_ptr<const Error>& error) override {
+      (void)error;
       if(m_transferSize == 0) {
         return finish();
       }

--- a/src/oatpp/core/utils/ConversionUtils.cpp
+++ b/src/oatpp/core/utils/ConversionUtils.cpp
@@ -52,17 +52,17 @@ namespace oatpp { namespace utils { namespace conversion {
     return result;
   }
   
-  v_int32 int32ToCharSequence(v_int32 value, p_char8 data){
-    return sprintf((char*)data, "%d", value);
+  v_int32 int32ToCharSequence(v_int32 value, p_char8 data, v_int32 n) {
+    return snprintf((char*)data, n, "%d", value);
   }
   
-  v_int32 int64ToCharSequence(v_int64 value, p_char8 data){
-    return sprintf((char*)data, "%lld", value);
+  v_int32 int64ToCharSequence(v_int64 value, p_char8 data, v_int32 n) {
+    return snprintf((char*)data, n, "%lld", value);
   }
   
   oatpp::String int32ToStr(v_int32 value){
-    v_char8 buff [100];
-    v_int32 size = int32ToCharSequence(value, &buff[0]);
+    v_char8 buff [16]; // Max 10 digits with 1 sign. 16 is plenty enough.
+    v_int32 size = int32ToCharSequence(value, &buff[0], 16);
     if(size > 0){
       return oatpp::String((const char*)&buff[0], size, true);
     }
@@ -70,8 +70,8 @@ namespace oatpp { namespace utils { namespace conversion {
   }
   
   oatpp::String int64ToStr(v_int64 value){
-    v_char8 buff [100];
-    v_int32 size = int64ToCharSequence(value, &buff[0]);
+    v_char8 buff [32]; // Max 20 digits unsigned, 19 digits +1 sign signed.
+    v_int32 size = int64ToCharSequence(value, &buff[0], 32);
     if(size > 0){
       return oatpp::String((const char*)&buff[0], size, true);
     }
@@ -79,8 +79,8 @@ namespace oatpp { namespace utils { namespace conversion {
   }
   
   std::string int32ToStdStr(v_int32 value){
-    v_char8 buff [100];
-    v_int32 size = int32ToCharSequence(value, &buff[0]);
+    v_char8 buff [16];
+    v_int32 size = int32ToCharSequence(value, &buff[0], 16);
     if(size > 0){
       return std::string((const char*)buff, size);
     }
@@ -88,8 +88,8 @@ namespace oatpp { namespace utils { namespace conversion {
   }
   
   std::string int64ToStdStr(v_int64 value){
-    v_char8 buff [100];
-    v_int32 size = int64ToCharSequence(value, &buff[0]);
+    v_char8 buff [32];
+    v_int32 size = int64ToCharSequence(value, &buff[0], 32);
     if(size > 0){
       return std::string((const char*)buff, size);
     }
@@ -120,17 +120,17 @@ namespace oatpp { namespace utils { namespace conversion {
     return result;
   }
   
-  v_int32 float32ToCharSequence(v_float32 value, p_char8 data){
-    return sprintf((char*)data, "%f", value);
+  v_int32 float32ToCharSequence(v_float32 value, p_char8 data, v_int32 n) {
+    return snprintf((char*)data, n, "%f", value);
   }
   
-  v_int32 float64ToCharSequence(v_float64 value, p_char8 data){
-    return sprintf((char*)data, "%f", value);
+  v_int32 float64ToCharSequence(v_float64 value, p_char8 data, v_int32 n) {
+    return snprintf((char*)data, n, "%f", value);
   }
   
   oatpp::String float32ToStr(v_float32 value){
     v_char8 buff [100];
-    v_int32 size = float32ToCharSequence(value, &buff[0]);
+    v_int32 size = float32ToCharSequence(value, &buff[0], 100);
     if(size > 0){
       return oatpp::String((const char*)&buff[0], size, true);
     }
@@ -139,7 +139,7 @@ namespace oatpp { namespace utils { namespace conversion {
   
   oatpp::String float64ToStr(v_float64 value){
     v_char8 buff [100];
-    v_int32 size = float64ToCharSequence(value, &buff[0]);
+    v_int32 size = float64ToCharSequence(value, &buff[0], 100);
     if(size > 0){
       return oatpp::String((const char*)&buff[0], size, true);
     }

--- a/src/oatpp/core/utils/ConversionUtils.hpp
+++ b/src/oatpp/core/utils/ConversionUtils.hpp
@@ -70,17 +70,19 @@ namespace oatpp { namespace utils { namespace conversion {
    * Convert 32-bit integer to it's string representation.
    * @param value - 32-bit integer value.
    * @param data - buffer to write data to.
+   * @param n - buffer size.
    * @return - length of the resultant string.
    */
-  v_int32 int32ToCharSequence(v_int32 value, p_char8 data);
+  v_int32 int32ToCharSequence(v_int32 value, p_char8 data, v_int32 n);
 
  /**
   * Convert 64-bit integer to it's string representation.
   * @param value - 64-bit integer value.
   * @param data - buffer to write data to.
+  * @param n - buffer size.
   * @return - length of the resultant string.
   */
-  v_int32 int64ToCharSequence(v_int64 value, p_char8 data);
+ v_int32 int64ToCharSequence(v_int64 value, p_char8 data, v_int32 n);
 
   /**
    * Convert 32-bit integer to it's string representation.
@@ -115,12 +117,13 @@ namespace oatpp { namespace utils { namespace conversion {
    * @tparam T - primitive value type (int, float, etc.).
    * @param value - actual value.
    * @param data - buffer to write data to.
-   * @param pattern - pattern as for `sprintf`.
+   * @param n - buffer size.
+   * @param pattern - pattern as for `snprintf`.
    * @return - length of the resultant string.
    */
   template<typename T>
-  v_int32 primitiveToCharSequence(T value, p_char8 data, const char* pattern){
-    return sprintf((char*)data, pattern, value);
+  v_int32 primitiveToCharSequence(T value, p_char8 data, v_int32 n, const char *pattern) {
+    return snprintf((char*)data, n, pattern, value);
   }
 
   /**
@@ -133,7 +136,7 @@ namespace oatpp { namespace utils { namespace conversion {
   template<typename T>
   oatpp::String primitiveToStr(T value, const char* pattern){
     v_char8 buff [100];
-    v_int32 size = primitiveToCharSequence(value, &buff[0], pattern);
+    v_int32 size = primitiveToCharSequence(value, &buff[0], 100, pattern);
     if(size > 0){
       return oatpp::String((const char*)&buff[0], size, true);
     }
@@ -174,17 +177,19 @@ namespace oatpp { namespace utils { namespace conversion {
    * Convert 32-bit float to it's string representation.
    * @param value - 32-bit float value.
    * @param data - buffer to write data to.
+   * @param n - buffer size.
    * @return - length of the resultant string.
    */
-  v_int32 float32ToCharSequence(v_float32 value, p_char8 data);
+  v_int32 float32ToCharSequence(v_float32 value, p_char8 data, v_int32 n);
 
   /**
    * Convert 64-bit float to it's string representation.
    * @param value - 64-bit float value.
    * @param data - buffer to write data to.
+   * @param n - buffer size.
    * @return - length of the resultant string.
    */
-  v_int32 float64ToCharSequence(v_float64 value, p_char8 data);
+  v_int32 float64ToCharSequence(v_float64 value, p_char8 data, v_int32 n);
 
   /**
    * Convert 32-bit float to it's string representation.

--- a/src/oatpp/web/mime/multipart/FileStreamProvider.cpp
+++ b/src/oatpp/web/mime/multipart/FileStreamProvider.cpp
@@ -33,10 +33,12 @@ FileStreamProvider::FileStreamProvider(const oatpp::String& filename)
 {}
 
 std::shared_ptr<FileStreamProvider::OutputStream> FileStreamProvider::getOutputStream(const std::shared_ptr<Part>& part) {
+  (void)part;
   return std::make_shared<data::stream::FileOutputStream>(m_filename->c_str());
 }
 
 std::shared_ptr<FileStreamProvider::InputStream> FileStreamProvider::getInputStream(const std::shared_ptr<Part>& part) {
+  (void)part;
   return std::make_shared<data::stream::FileInputStream>(m_filename->c_str());
 }
 
@@ -48,6 +50,7 @@ AsyncFileStreamProvider::AsyncFileStreamProvider(const oatpp::String& filename)
 async::CoroutineStarter AsyncFileStreamProvider::getOutputStreamAsync(const std::shared_ptr<Part>& part,
                                                                       std::shared_ptr<data::stream::OutputStream>& stream)
 {
+  (void)part;
   stream = std::make_shared<data::stream::FileOutputStream>(m_filename->c_str());
   return nullptr;
 }
@@ -56,6 +59,7 @@ async::CoroutineStarter AsyncFileStreamProvider::getOutputStreamAsync(const std:
 async::CoroutineStarter AsyncFileStreamProvider::getInputStreamAsync(const std::shared_ptr<Part>& part,
                                                                      std::shared_ptr<data::stream::InputStream>& stream)
 {
+  (void)part;
   stream = std::make_shared<data::stream::FileInputStream>(m_filename->c_str());
   return nullptr;
 }

--- a/src/oatpp/web/mime/multipart/StatefulParser.cpp
+++ b/src/oatpp/web/mime/multipart/StatefulParser.cpp
@@ -349,6 +349,8 @@ async::Action StatefulParser::parseNextAsyncInline(async::AbstractCoroutine* cor
                                                    async::Action&& nextAction)
 {
 
+  (void)coroutine;
+
   class ParseCoroutine : public async::Coroutine<ParseCoroutine> {
   private:
     StatefulParser* m_this;

--- a/src/oatpp/web/protocol/http/Http.cpp
+++ b/src/oatpp/web/protocol/http/Http.cpp
@@ -388,7 +388,7 @@ void Parser::parseHeaderValueData(HeaderValueData& data, const oatpp::data::shar
         label = caret.parseStringEnclosed('\'', '\'', '\\');
       } else {
         label = caret.putLabel();
-        auto r = caret.findCharFromSet(charSet2, 4);
+        caret.findCharFromSet(charSet2, 4);
       }
 
       data.titleParams[key] = data::share::StringKeyLabel(headerValue.getMemoryHandle(), label.getData(),

--- a/src/oatpp/web/protocol/http/outgoing/ChunkedBufferBody.cpp
+++ b/src/oatpp/web/protocol/http/outgoing/ChunkedBufferBody.cpp
@@ -79,7 +79,8 @@ async::Action ChunkedBufferBody::WriteToStreamCoroutine::act() {
 }
 
 async::Action ChunkedBufferBody::WriteToStreamCoroutine::writeChunkSize() {
-  m_inlineWriteData.set(m_buffer, oatpp::utils::conversion::primitiveToCharSequence(m_currChunk->getData()->size, m_buffer, "%X\r\n"));
+  m_inlineWriteData.set(m_buffer, oatpp::utils::conversion::primitiveToCharSequence(m_currChunk->getData()->size,
+                                                                                    m_buffer, 16, "%X\r\n"));
   m_nextAction = yieldTo(&WriteToStreamCoroutine::writeChunkData);
   return yieldTo(&WriteToStreamCoroutine::writeCurrData);
 }

--- a/src/oatpp/web/protocol/http/outgoing/MultipartBody.cpp
+++ b/src/oatpp/web/protocol/http/outgoing/MultipartBody.cpp
@@ -125,6 +125,7 @@ oatpp::async::Action MultipartBody::AsyncMultipartReadCallback::readAsyncInline(
                                                                                 oatpp::data::stream::AsyncInlineReadData& inlineData,
                                                                                 oatpp::async::Action&& nextAction)
 {
+  (void)coroutine;
 
   class ReadCoroutine : public oatpp::async::Coroutine<ReadCoroutine> {
   private:
@@ -277,6 +278,8 @@ data::v_io_size MultipartBody::readHeaders(const std::shared_ptr<Multipart>& mul
                                            void *buffer,
                                            data::v_io_size count)
 {
+  (void) multipart;
+
   if (!readStream.getDataMemoryHandle()) {
 
     oatpp::data::stream::ChunkedBuffer stream;

--- a/src/oatpp/web/server/AsyncHttpConnectionHandler.cpp
+++ b/src/oatpp/web/server/AsyncHttpConnectionHandler.cpp
@@ -69,6 +69,8 @@ void AsyncHttpConnectionHandler::handleConnection(const std::shared_ptr<IOStream
                                                   const std::shared_ptr<const ParameterMap>& params)
 {
 
+  (void)params;
+
   connection->setOutputStreamIOMode(oatpp::data::stream::IOMode::NON_BLOCKING);
   connection->setInputStreamIOMode(oatpp::data::stream::IOMode::NON_BLOCKING);
   

--- a/src/oatpp/web/server/HttpConnectionHandler.cpp
+++ b/src/oatpp/web/server/HttpConnectionHandler.cpp
@@ -114,6 +114,8 @@ void HttpConnectionHandler::handleConnection(const std::shared_ptr<oatpp::data::
                                              const std::shared_ptr<const ParameterMap>& params)
 {
 
+  (void)params;
+
   connection->setOutputStreamIOMode(oatpp::data::stream::IOMode::BLOCKING);
   connection->setInputStreamIOMode(oatpp::data::stream::IOMode::BLOCKING);
 

--- a/src/oatpp/web/server/HttpRequestHandler.hpp
+++ b/src/oatpp/web/server/HttpRequestHandler.hpp
@@ -86,6 +86,7 @@ public:
    * @return - outgoing http response. &id:oatpp::web::protocol::http::outgoing::Response;.
    */
   virtual std::shared_ptr<OutgoingResponse> handle(const std::shared_ptr<IncomingRequest>& request) {
+    (void)request;
     throw HttpError(Status::CODE_501, "Endpoint not implemented.");
   }
 
@@ -97,8 +98,14 @@ public:
    */
   virtual oatpp::async::CoroutineStarterForResult<const std::shared_ptr<OutgoingResponse>&>
   handleAsync(const std::shared_ptr<IncomingRequest>& request) {
+    (void)request;
     throw HttpError(Status::CODE_501, "Asynchronous endpoint not implemented.");
   }
+
+  /**
+   * You have to provide a definition for destructors, otherwise its undefined behaviour.
+   */
+  virtual ~HttpRequestHandler() = default;
 };
 
 }}}

--- a/test/oatpp/core/base/memory/MemoryPoolTest.cpp
+++ b/test/oatpp/core/base/memory/MemoryPoolTest.cpp
@@ -60,7 +60,9 @@ void doGarbageAllocsStdNew(v_int32 garbageNumber){
 }
   
 void testStdNew(v_int32 objectsNumber, v_int32 garbageNumber, v_int32 chunkSize){
-  
+
+  (void)chunkSize;
+
   TestClass** objects = new TestClass* [objectsNumber];
   
   for(v_int32 i = 0; i < objectsNumber; i++){

--- a/test/oatpp/core/base/memory/PerfTest.cpp
+++ b/test/oatpp/core/base/memory/PerfTest.cpp
@@ -61,6 +61,7 @@ namespace {
     }
 
     static void operator delete(void* ptr, std::size_t sz) {
+      (void)sz;
       ::operator delete(ptr);
     }
 

--- a/test/oatpp/web/app/Controller.hpp
+++ b/test/oatpp/web/app/Controller.hpp
@@ -147,6 +147,7 @@ public:
     {}
 
     data::v_io_size read(void *buffer, data::v_io_size count) override {
+      (void)count;
       if(m_counter < m_iterations) {
         std::memcpy(buffer, m_text->getData(), m_text->getSize());
         m_counter ++;

--- a/test/oatpp/web/app/ControllerAsync.hpp
+++ b/test/oatpp/web/app/ControllerAsync.hpp
@@ -153,6 +153,7 @@ public:
                                            oatpp::data::stream::AsyncInlineReadData& inlineData,
                                            oatpp::async::Action&& nextAction) override
       {
+        (void)coroutine;
         if(m_counter < m_iterations) {
           std::memcpy(inlineData.currBufferPtr, m_text->getData(), m_text->getSize());
           inlineData.inc(m_text->getSize());


### PR DESCRIPTION
Our code policy requires us to not use `sprintf` (only `snprintf` allowed) as well to write warningless code with `-Wextra` (and listen to clang-tidy as much as possible). I thought this may be relevant for code-quality/hardening of oatpp-upstream as well. 