### PR TITLE
Link against libatomic

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -231,7 +231,7 @@ find_package(Threads REQUIRED)
 if(MSVC)
     target_link_libraries(oatpp PUBLIC ${CMAKE_THREAD_LIBS_INIT} wsock32 ws2_32)
 else(MSVC)
-    target_link_libraries(oatpp PUBLIC ${CMAKE_THREAD_LIBS_INIT})
+    target_link_libraries(oatpp PUBLIC ${CMAKE_THREAD_LIBS_INIT} atomic)
 endif(MSVC)
 
 target_include_directories(oatpp PUBLIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -230,6 +230,8 @@ find_package(Threads REQUIRED)
 
 if(MSVC)
     target_link_libraries(oatpp PUBLIC ${CMAKE_THREAD_LIBS_INIT} wsock32 ws2_32)
+elseif(APPLE)
+    target_link_libraries(oatpp PUBLIC ${CMAKE_THREAD_LIBS_INIT})
 else(MSVC)
     target_link_libraries(oatpp PUBLIC ${CMAKE_THREAD_LIBS_INIT} atomic)
 endif(MSVC)


### PR DESCRIPTION
In some environments, libatomic is not part of threads/stdlib/whatsoever. So for these environments, the libatomic needs specific linking. This is (for example) the case in some armvX and mips environments or openwrt.