### PR TITLE
 Fix. Fixed crash happening when debuggng via GDB.

### DIFF
--- a/src/oatpp/core/async/worker/IOEventWorker_epoll.cpp
+++ b/src/oatpp/core/async/worker/IOEventWorker_epoll.cpp
@@ -152,7 +152,7 @@ void IOEventWorker::waitEvents() {
   struct epoll_event* outEvents = (struct epoll_event*)m_outEvents.get();
   auto eventsCount = epoll_wait(m_eventQueueHandle, outEvents, MAX_EVENTS, -1);
 
-  if(eventsCount < 0) {
+  if((eventsCount < 0) && (errno != EINTR)) {
     OATPP_LOGE("[oatpp::async::worker::IOEventWorker::waitEvents()]", "Error. errno=%d", errno);
     throw std::runtime_error("[oatpp::async::worker::IOEventWorker::waitEvents()]: Error. Event loop failed.");
   }


### PR DESCRIPTION
Problem: Crash seen when loading build with oatpp.

Root Cause: When loading the build in gdb process gets EINTR and eventsCount is -1, hence crashing.

Fix: Its good to check EINTR before throwing error, hence added the same..

rgds
Balaji Kamal Kannadassan