### PR TITLE
Clean some warnings in Clang 10/Xcode 10.3

### DIFF
--- a/src/oatpp/network/Url.cpp
+++ b/src/oatpp/network/Url.cpp
@@ -135,13 +135,13 @@ void Url::Parser::parseQueryParams(Url::Parameters& params, const oatpp::String&
 Url::Parameters Url::Parser::parseQueryParams(oatpp::parser::Caret& caret) {
   Url::Parameters params;
   parseQueryParams(params, caret);
-  return std::move(params);
+  return params;
 }
 
 Url::Parameters Url::Parser::parseQueryParams(const oatpp::String& str) {
   Url::Parameters params;
   parseQueryParams(params, str);
-  return std::move(params);
+  return params;
 }
 
 Url Url::Parser::parseUrl(oatpp::parser::Caret& caret) {

--- a/src/oatpp/web/client/ApiClient.cpp
+++ b/src/oatpp/web/client/ApiClient.cpp
@@ -122,7 +122,7 @@ oatpp::web::protocol::http::Headers ApiClient::convertParamsMap(const std::share
       curr = curr->getNext();
     }
   }
-  return std::move(result);
+  return result;
 }
 
 oatpp::String ApiClient::formatPath(const PathPattern& pathPattern,

--- a/src/oatpp/web/protocol/http/incoming/RequestHeadersReader.cpp
+++ b/src/oatpp/web/protocol/http/incoming/RequestHeadersReader.cpp
@@ -108,8 +108,8 @@ RequestHeadersReader::readHeadersAsync(const std::shared_ptr<data::stream::Input
     
     ReaderCoroutine(RequestHeadersReader* _this,
                     const std::shared_ptr<data::stream::InputStreamBufferedProxy>& stream)
-      : m_this(_this)
-      , m_stream(stream)
+      : m_stream(stream)
+      , m_this(_this)
       , m_accumulator(0)
     {
       m_this->m_bufferStream->setCurrentPosition(0);

--- a/src/oatpp/web/protocol/http/incoming/RequestHeadersReader.hpp
+++ b/src/oatpp/web/protocol/http/incoming/RequestHeadersReader.hpp
@@ -64,9 +64,9 @@ public:
 private:
   data::v_io_size readHeadersSection(data::stream::InputStreamBufferedProxy* stream, Result& result);
 private:
+  oatpp::data::stream::BufferOutputStream* m_bufferStream;
   v_int32 m_readChunkSize;
   v_int32 m_maxHeadersSize;
-  oatpp::data::stream::BufferOutputStream* m_bufferStream;
 public:
 
   /**

--- a/src/oatpp/web/server/HttpProcessor.cpp
+++ b/src/oatpp/web/server/HttpProcessor.cpp
@@ -57,8 +57,6 @@ HttpProcessor::processRequest(HttpRouter* router,
     return errorHandler->handleError(protocol::http::Status::CODE_404, "Current url has no mapping");
   }
   
-  auto& bodyStream = inStream;
-  
   auto request = protocol::http::incoming::Request::createShared(headersReadResult.startingLine,
                                                                  route.matchMap,
                                                                  headersReadResult.headers,


### PR DESCRIPTION
Don't use std::move when it prevents copy elision (RVO?)
Reorder some initialization statements. 
and remove an unused variable.