### PR TITLE
Move string to int64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ cmake-build-debug/
 
 # local build
 build/
+build-xcode/
 srt/build/
 test/build/
 

--- a/src/oatpp/core/base/StrBuffer.cpp
+++ b/src/oatpp/core/base/StrBuffer.cpp
@@ -28,13 +28,13 @@
 
 namespace oatpp { namespace base {
   
-void StrBuffer::set(const void* data, v_int32 size, bool hasOwnData) {
+void StrBuffer::set(const void* data, v_int64 size, bool hasOwnData) {
   m_data = (p_char8) data;
   m_size = size;
   m_hasOwnData = hasOwnData;
 }
   
-void StrBuffer::setAndCopy(const void* data, const void* originData, v_int32 size){
+void StrBuffer::setAndCopy(const void* data, const void* originData, v_int64 size){
   m_data = (p_char8) data;
   m_size = size;
   //m_hasOwnData = false;
@@ -44,7 +44,7 @@ void StrBuffer::setAndCopy(const void* data, const void* originData, v_int32 siz
   m_data[size] = 0;
 }
 
-std::shared_ptr<StrBuffer> StrBuffer::allocShared(const void* data, v_int32 size, bool copyAsOwnData) {
+std::shared_ptr<StrBuffer> StrBuffer::allocShared(const void* data, v_int64 size, bool copyAsOwnData) {
   if(copyAsOwnData) {
     memory::AllocationExtras extras(size + 1);
     std::shared_ptr<StrBuffer> ptr;
@@ -59,7 +59,7 @@ std::shared_ptr<StrBuffer> StrBuffer::allocShared(const void* data, v_int32 size
   return std::make_shared<StrBuffer>(data, size, copyAsOwnData);
 }
   
-p_char8 StrBuffer::allocStrBuffer(const void* originData, v_int32 size, bool copyAsOwnData) {
+p_char8 StrBuffer::allocStrBuffer(const void* originData, v_int64 size, bool copyAsOwnData) {
   if(copyAsOwnData) {
     p_char8 data = new v_char8[size + 1];
     data[size] = 0;
@@ -77,7 +77,7 @@ StrBuffer::StrBuffer()
   , m_hasOwnData(false)
 {}
 
-StrBuffer::StrBuffer(const void* data, v_int32 size, bool copyAsOwnData)
+StrBuffer::StrBuffer(const void* data, v_int64 size, bool copyAsOwnData)
   : m_data(allocStrBuffer(data, size, copyAsOwnData))
   , m_size(size)
   , m_hasOwnData(copyAsOwnData)
@@ -90,23 +90,23 @@ StrBuffer::~StrBuffer() {
   m_data = nullptr;
 }
   
-std::shared_ptr<StrBuffer> StrBuffer::createShared(const void* data, v_int32 size, bool copyAsOwnData) {
+std::shared_ptr<StrBuffer> StrBuffer::createShared(const void* data, v_int64 size, bool copyAsOwnData) {
   return allocShared(data, size, copyAsOwnData);
 }
   
 std::shared_ptr<StrBuffer> StrBuffer::createShared(const char* data, bool copyAsOwnData) {
-  return allocShared(data, (v_int32) std::strlen(data), copyAsOwnData);
+  return allocShared(data, (v_int64) std::strlen(data), copyAsOwnData);
 }
 
 std::shared_ptr<StrBuffer> StrBuffer::createShared(StrBuffer* other, bool copyAsOwnData) {
   return allocShared(other->getData(), other->getSize(), copyAsOwnData);
 }
 
-std::shared_ptr<StrBuffer> StrBuffer::createShared(v_int32 size) {
+std::shared_ptr<StrBuffer> StrBuffer::createShared(v_int64 size) {
   return allocShared(nullptr, size, true);
 }
 
-std::shared_ptr<StrBuffer> StrBuffer::createSharedConcatenated(const void* data1, v_int32 size1, const void* data2, v_int32 size2) {
+std::shared_ptr<StrBuffer> StrBuffer::createSharedConcatenated(const void* data1, v_int64 size1, const void* data2, v_int64 size2) {
   const auto& ptr = allocShared(nullptr, size1 + size2, true);
   std::memcpy(ptr->m_data, data1, size1);
   std::memcpy(ptr->m_data + size1, data2, size2);
@@ -116,7 +116,7 @@ std::shared_ptr<StrBuffer> StrBuffer::createSharedConcatenated(const void* data1
 std::shared_ptr<StrBuffer> StrBuffer::loadFromFile(const char* filename) {
   std::ifstream file (filename, std::ios::in|std::ios::binary|std::ios::ate);
   if (file.is_open()) {
-    auto result = createShared((v_int32) file.tellg());
+    auto result = createShared(file.tellg());
     file.seekg(0, std::ios::beg);
     file.read((char*)result->getData(), result->getSize());
     file.close();
@@ -136,7 +136,7 @@ p_char8 StrBuffer::getData() const {
   return m_data;
 }
 
-v_int32 StrBuffer::getSize() const {
+v_int64 StrBuffer::getSize() const {
   return m_size;
 }
 
@@ -164,7 +164,7 @@ std::shared_ptr<StrBuffer> StrBuffer::toUpperCase() const {
   return ptr;
 }
   
-bool StrBuffer::equals(const void* data, v_int32 size) const {
+bool StrBuffer::equals(const void* data, v_int64 size) const {
   if(m_size == size) {
     return equals(m_data, data, size);
   }
@@ -172,7 +172,7 @@ bool StrBuffer::equals(const void* data, v_int32 size) const {
 }
 
 bool StrBuffer::equals(const char* data) const {
-  if(m_size == (v_int32) std::strlen(data)) {
+  if(m_size ==  std::strlen(data)) {
     return equals(m_data, data, m_size);
   }
   return false;
@@ -182,7 +182,7 @@ bool StrBuffer::equals(StrBuffer* other) const {
   return equals((StrBuffer*) this, other);
 }
 
-bool StrBuffer::startsWith(const void* data, v_int32 size) const {
+bool StrBuffer::startsWith(const void* data, v_int64 size) const {
   if(m_size >= size) {
     return equals(m_data, data, size);
   }
@@ -190,7 +190,7 @@ bool StrBuffer::startsWith(const void* data, v_int32 size) const {
 }
 
 bool StrBuffer::startsWith(const char* data) const {
-  v_int32 length = (v_int32) std::strlen(data);
+  v_int64 length = std::strlen(data);
   if(m_size >= length) {
     return equals(m_data, data, length);
   }
@@ -206,11 +206,11 @@ bool StrBuffer::startsWith(StrBuffer* data) const {
 
 // static
   
-v_int32 StrBuffer::compare(const void* data1, const void* data2, v_int32 size) {
+v_int64 StrBuffer::compare(const void* data1, const void* data2, v_int64 size) {
   return std::memcmp(data1, data2, size);
 }
 
-v_int32 StrBuffer::compare(StrBuffer* str1, StrBuffer* str2) {
+v_int64 StrBuffer::compare(StrBuffer* str1, StrBuffer* str2) {
   if(str1 == str2) {
     return 0;
   }
@@ -221,15 +221,15 @@ v_int32 StrBuffer::compare(StrBuffer* str1, StrBuffer* str2) {
   }
 }
 
-bool StrBuffer::equals(const void* data1, const void* data2, v_int32 size) {
+bool StrBuffer::equals(const void* data1, const void* data2, v_int64 size) {
   return (data1 == data2) || (std::memcmp(data1, data2, size) == 0);
 }
   
 bool StrBuffer::equals(const char* data1, const char* data2) {
   if(data1 == data2) return true;
   if(data1 == nullptr && data2 == nullptr) return false;
-  v_int32 size = (v_int32) std::strlen(data1);
-  return (size == (v_int32) std::strlen(data2) && std::memcmp(data1, data2, size) == 0);
+  v_int64 size = std::strlen(data1);
+  return (size == std::strlen(data2) && std::memcmp(data1, data2, size) == 0);
 }
   
 bool StrBuffer::equals(StrBuffer* str1, StrBuffer* str2) {
@@ -239,8 +239,8 @@ bool StrBuffer::equals(StrBuffer* str1, StrBuffer* str2) {
           );
 }
 
-bool StrBuffer::equalsCI(const void* data1, const void* data2, v_int32 size) {
-  for(v_int32 i = 0; i < size; i++) {
+bool StrBuffer::equalsCI(const void* data1, const void* data2, v_int64 size) {
+  for(v_int64 i = 0; i < size; i++) {
     v_char8 a = ((p_char8) data1) [i];
     v_char8 b = ((p_char8) data2) [i];
     if(a >= 'A' && a <= 'Z') a |= 32;
@@ -255,8 +255,8 @@ bool StrBuffer::equalsCI(const void* data1, const void* data2, v_int32 size) {
 bool StrBuffer::equalsCI(const char* data1, const char* data2) {
   if(data1 == data2) return true;
   if(data1 == nullptr && data2 == nullptr) return false;
-  v_int32 size = (v_int32) std::strlen(data1);
-  return (size == (v_int32) std::strlen(data2) && equalsCI(data1, data2, size) == 0);
+  v_int64 size = std::strlen(data1);
+  return (size == std::strlen(data2) && equalsCI(data1, data2, size) == 0);
 }
   
 bool StrBuffer::equalsCI(StrBuffer* str1, StrBuffer* str2) {
@@ -266,8 +266,8 @@ bool StrBuffer::equalsCI(StrBuffer* str1, StrBuffer* str2) {
           );
 }
 
-bool StrBuffer::equalsCI_FAST(const void* data1, const void* data2, v_int32 size) {
-  for(v_int32 i = 0; i < size; i++) {
+bool StrBuffer::equalsCI_FAST(const void* data1, const void* data2, v_int64 size) {
+  for(v_int64 i = 0; i < size; i++) {
     if((((p_char8) data1) [i] | 32) != (((p_char8) data2) [i] | 32)) {
       return false;
     }
@@ -278,8 +278,8 @@ bool StrBuffer::equalsCI_FAST(const void* data1, const void* data2, v_int32 size
 bool StrBuffer::equalsCI_FAST(const char* data1, const char* data2) {
   if(data1 == data2) return true;
   if(data1 == nullptr && data2 == nullptr) return false;
-  v_int32 size = (v_int32) std::strlen(data1);
-  return (size == (v_int32) std::strlen(data2) && equalsCI_FAST(data1, data2, size) == 0);
+  v_int64 size = std::strlen(data1);
+  return (size == std::strlen(data2) && equalsCI_FAST(data1, data2, size) == 0);
 }
 
 bool StrBuffer::equalsCI_FAST(StrBuffer* str1, StrBuffer* str2) {
@@ -290,19 +290,19 @@ bool StrBuffer::equalsCI_FAST(StrBuffer* str1, StrBuffer* str2) {
 }
   
 bool StrBuffer::equalsCI_FAST(StrBuffer* str1, const char* str2) {
-  v_int32 len = (v_int32) std::strlen(str2);
+  v_int64 len = std::strlen(str2);
   return (str1->getSize() == len && equalsCI_FAST(str1->m_data, str2, str1->m_size));
 }
 
-void StrBuffer::lowerCase(const void* data, v_int32 size) {
-  for(v_int32 i = 0; i < size; i++) {
+void StrBuffer::lowerCase(const void* data, v_int64 size) {
+  for(v_int64 i = 0; i < size; i++) {
     v_char8 a = ((p_char8) data)[i];
     if(a >= 'A' && a <= 'Z') ((p_char8) data)[i] = a | 32;
   }
 }
 
-void StrBuffer::upperCase(const void* data, v_int32 size) {
-  for(v_int32 i = 0; i < size; i++) {
+void StrBuffer::upperCase(const void* data, v_int64 size) {
+  for(v_int64 i = 0; i < size; i++) {
     v_char8 a = ((p_char8) data)[i];
     if(a >= 'a' && a <= 'z') ((p_char8) data)[i] = a & 223;
   }

--- a/src/oatpp/core/base/StrBuffer.hpp
+++ b/src/oatpp/core/base/StrBuffer.hpp
@@ -38,39 +38,39 @@ namespace oatpp { namespace base {
 class StrBuffer : public oatpp::base::Countable {  
 private:
 
-  static constexpr v_int32 SM_STRING_POOL_ENTRY_SIZE = 256;
+  static constexpr v_int64 SM_STRING_POOL_ENTRY_SIZE = 256;
   
   static oatpp::base::memory::ThreadDistributedMemoryPool& getSmallStringPool() {
     static oatpp::base::memory::ThreadDistributedMemoryPool pool("Small_String_Pool", SM_STRING_POOL_ENTRY_SIZE, 16);
     return pool;
   }
   
-  static v_int32 getSmStringBaseSize() {
+  static v_int64 getSmStringBaseSize() {
     memory::AllocationExtras extras(0);
     auto ptr = memory::customPoolAllocateSharedWithExtras<StrBuffer>(extras, getSmallStringPool());
     return extras.baseSize;
   }
   
-  static v_int32 getSmStringSize() {
-    static v_int32 size = SM_STRING_POOL_ENTRY_SIZE - getSmStringBaseSize();
+  static v_int64 getSmStringSize() {
+    static v_int64 size = SM_STRING_POOL_ENTRY_SIZE - getSmStringBaseSize();
     return size;
   }
 
 private:
   p_char8 m_data;
-  v_int32 m_size;
+  v_int64 m_size;
   bool m_hasOwnData;
 private:
   
-  void set(const void* data, v_int32 size, bool hasOwnData);
-  void setAndCopy(const void* data, const void* originData, v_int32 size);
-  static std::shared_ptr<StrBuffer> allocShared(const void* data, v_int32 size, bool copyAsOwnData);
+  void set(const void* data, v_int64 size, bool hasOwnData);
+  void setAndCopy(const void* data, const void* originData, v_int64 size);
+  static std::shared_ptr<StrBuffer> allocShared(const void* data, v_int64 size, bool copyAsOwnData);
 
   /*
    * Allocate memory for string or use originData<br>
    * if copyAsOwnData == false return originData
    */
-  static p_char8 allocStrBuffer(const void* originData, v_int32 size, bool copyAsOwnData);
+  static p_char8 allocStrBuffer(const void* originData, v_int64 size, bool copyAsOwnData);
   
 public:
   /**
@@ -84,7 +84,7 @@ public:
    * @param size - size of the data.
    * @param copyAsOwnData - if true then allocate own buffer and copy data to that buffer.
    */
-  StrBuffer(const void* data, v_int32 size, bool copyAsOwnData);
+  StrBuffer(const void* data, v_int64 size, bool copyAsOwnData);
 public:
 
   /**
@@ -97,7 +97,7 @@ public:
    * @param size - size of the buffer.
    * @return - shared_ptr to StrBuffer.
    */
-  static std::shared_ptr<StrBuffer> createShared(v_int32 size);
+  static std::shared_ptr<StrBuffer> createShared(v_int64 size);
 
   /**
    * Create shared StrBuffer with data, size, and copyAsOwnData parameters.
@@ -106,7 +106,7 @@ public:
    * @param copyAsOwnData - if true then allocate own buffer and copy data to that buffer.
    * @return - shared_ptr to StrBuffer.
    */
-  static std::shared_ptr<StrBuffer> createShared(const void* data, v_int32 size, bool copyAsOwnData = true);
+  static std::shared_ptr<StrBuffer> createShared(const void* data, v_int64 size, bool copyAsOwnData = true);
 
   /**
    * Create shared StrBuffer with data, and copyAsOwnData parameters.
@@ -132,7 +132,7 @@ public:
    * @param size2 - size of the data2.
    * @return - shared_ptr to StrBuffer.
    */
-  static std::shared_ptr<StrBuffer> createSharedConcatenated(const void* data1, v_int32 size1, const void* data2, v_int32 size2);
+  static std::shared_ptr<StrBuffer> createSharedConcatenated(const void* data1, v_int64 size1, const void* data2, v_int64 size2);
 
   /**
    * Create shared StrBuffer from c-string.
@@ -142,7 +142,7 @@ public:
    */
   static std::shared_ptr<StrBuffer> createFromCString(const char* data, bool copyAsOwnData = true) {
     if(data != nullptr) {
-      return allocShared(data, (v_int32) std::strlen(data), copyAsOwnData);
+      return allocShared(data, std::strlen(data), copyAsOwnData);
     }
     return nullptr;
   }
@@ -170,7 +170,7 @@ public:
    * Get buffer size.
    * @return - buffer size.
    */
-  v_int32 getSize() const;
+  v_int64 getSize() const;
 
   /**
    * Get pointer to data of the buffer as `const* char`.
@@ -210,7 +210,7 @@ public:
    * @param size - size of the data.
    * @return - true if all chars of buffer are same as in data, and size == this.getSize().
    */
-  bool equals(const void* data, v_int32 size) const;
+  bool equals(const void* data, v_int64 size) const;
 
   /**
    * Check string equality of the buffer to data of specified size.
@@ -232,7 +232,7 @@ public:
    * @param size - size of the data.
    * @return - true if buffer starts with specified data.
    */
-  bool startsWith(const void* data, v_int32 size) const;
+  bool startsWith(const void* data, v_int64 size) const;
 
   /**
    * Check if buffer starts with specified data.
@@ -260,7 +260,7 @@ public:
    * ​0​ if all count bytes of data1 and data2 are equal.<br>
    * Positive value if the first differing byte in data1 is greater than the corresponding byte in data2.
    */
-  static v_int32 compare(const void* data1, const void* data2, v_int32 size);
+  static v_int64 compare(const void* data1, const void* data2, v_int64 size);
 
   /**
    * Compare data1, data2 using `std::memcmp`.
@@ -270,7 +270,7 @@ public:
    * ​0​ if all count bytes of data1 and data2 are equal.<br>
    * Positive value if the first differing byte in data1 is greater than the corresponding byte in data2.
    */
-  static v_int32 compare(StrBuffer* data1, StrBuffer* data2);
+  static v_int64 compare(StrBuffer* data1, StrBuffer* data2);
 
   /**
    * Check string equality of data1 to data2.
@@ -279,7 +279,7 @@ public:
    * @param size - number of characters to compare.
    * @return - `true` if equals.
    */
-  static bool equals(const void* data1, const void* data2, v_int32 size);
+  static bool equals(const void* data1, const void* data2, v_int64 size);
 
   /**
    * Check string equality of data1 to data2.
@@ -304,7 +304,7 @@ public:
    * @param size - number of characters to compare.
    * @return - `true` if equals.
    */
-  static bool equalsCI(const void* data1, const void* data2, v_int32 size);
+  static bool equalsCI(const void* data1, const void* data2, v_int64 size);
 
   /**
    * Check Case Insensitive string equality of data1 to data2.
@@ -329,7 +329,7 @@ public:
    * @param size - number of characters to compare.
    * @return - `true` if equals.
    */
-  static bool equalsCI_FAST(const void* data1, const void* data2, v_int32 size);
+  static bool equalsCI_FAST(const void* data1, const void* data2, v_int64 size);
 
   /**
    * Check Case Insensitive string equality of data1 to data2. (ASCII only, correct compare if one of strings contains letters only)
@@ -360,14 +360,14 @@ public:
    * @param data - pointer to data.
    * @param size - size of the data.
    */
-  static void lowerCase(const void* data, v_int32 size);
+  static void lowerCase(const void* data, v_int64 size);
 
   /**
    * Change characters in data to uppercase.
    * @param data - pointer to data.
    * @param size - size of the data.
    */
-  static void upperCase(const void* data, v_int32 size);
+  static void upperCase(const void* data, v_int64 size);
   
 };
   

--- a/src/oatpp/core/base/memory/Allocator.cpp
+++ b/src/oatpp/core/base/memory/Allocator.cpp
@@ -26,7 +26,7 @@
 
 namespace oatpp { namespace base { namespace memory {
 
-AllocatorPoolInfo::AllocatorPoolInfo(const char* pPoolName, v_int32 pPoolChunkSize)
+AllocatorPoolInfo::AllocatorPoolInfo(const char* pPoolName, v_int64 pPoolChunkSize)
   : poolName(pPoolName)
   , poolChunkSize(pPoolChunkSize)
 {}

--- a/src/oatpp/core/base/memory/Allocator.hpp
+++ b/src/oatpp/core/base/memory/Allocator.hpp
@@ -40,7 +40,7 @@ public:
    * @param pPoolName - memory pool name.
    * @param pPoolChunkSize - memory pool chunk size. For more about chunk size see &id:oatpp::base::memory::MemoryPool::MemoryPool;.
    */
-  AllocatorPoolInfo(const char* pPoolName, v_int32 pPoolChunkSize);
+  AllocatorPoolInfo(const char* pPoolName, v_int64 pPoolChunkSize);
 
   /**
    * Memory pool name.
@@ -51,7 +51,7 @@ public:
    * Memory pool chunk size.
    * For more about chunk size see &id:oatpp::base::memory::MemoryPool::MemoryPool;.
    */
-  const v_int32 poolChunkSize;
+  const v_int64 poolChunkSize;
 };
 
 /**
@@ -160,12 +160,12 @@ inline bool operator != (const ThreadLocalPoolSharedObjectAllocator<T>& a, const
  */
 class AllocationExtras {
 public:
-  AllocationExtras(v_int32 pExtraWanted)
+  AllocationExtras(v_int64 pExtraWanted)
     : extraWanted(pExtraWanted)
   {}
-  const v_int32 extraWanted;
+  const v_int64 extraWanted;
   void* extraPtr;
-  v_int32 baseSize;
+  v_int64 baseSize;
 };
 
 /**

--- a/src/oatpp/core/base/memory/MemoryPool.cpp
+++ b/src/oatpp/core/base/memory/MemoryPool.cpp
@@ -30,7 +30,7 @@
 
 namespace oatpp { namespace base { namespace  memory {
 
-MemoryPool::MemoryPool(const std::string& name, v_int32 entrySize, v_int32 chunkSize)
+MemoryPool::MemoryPool(const std::string& name, v_int64 entrySize, v_int64 chunkSize)
   : m_name(name)
   , m_entrySize(entrySize)
   , m_chunkSize(chunkSize)
@@ -58,11 +58,11 @@ void MemoryPool::allocChunk() {
 #ifdef OATPP_DISABLE_POOL_ALLOCATIONS
   // DO NOTHING
 #else
-  v_int32 entryBlockSize = sizeof(EntryHeader) + m_entrySize;
-  v_int32 chunkMemSize = entryBlockSize * m_chunkSize;
+  v_int64 entryBlockSize = sizeof(EntryHeader) + m_entrySize;
+  v_int64 chunkMemSize = entryBlockSize * m_chunkSize;
   p_char8 mem = new v_char8[chunkMemSize];
   m_chunks.push_back(mem);
-  for(v_int32 i = 0; i < m_chunkSize; i++){
+  for(v_int64 i = 0; i < m_chunkSize; i++){
     EntryHeader* entry = new (mem + i * entryBlockSize) EntryHeader(this, m_id, m_rootEntry);
     m_rootEntry = entry;
   }
@@ -118,7 +118,7 @@ std::string MemoryPool::getName(){
   return m_name;
 }
 
-v_int32 MemoryPool::getEntrySize(){
+v_int64 MemoryPool::getEntrySize(){
   return m_entrySize;
 }
 
@@ -126,7 +126,7 @@ v_int64 MemoryPool::getSize(){
   return m_chunks.size() * m_chunkSize;
 }
 
-v_int32 MemoryPool::getObjectsCount(){
+v_int64 MemoryPool::getObjectsCount(){
   return m_objectsCount;
 }
 
@@ -134,33 +134,33 @@ oatpp::concurrency::SpinLock MemoryPool::POOLS_SPIN_LOCK;
 std::unordered_map<v_int64, MemoryPool*> MemoryPool::POOLS;
 std::atomic<v_int64> MemoryPool::poolIdCounter(0);
 
-const v_int32 ThreadDistributedMemoryPool::SHARDS_COUNT_DEFAULT = OATPP_THREAD_DISTRIBUTED_MEM_POOL_SHARDS_COUNT;
+const v_int64 ThreadDistributedMemoryPool::SHARDS_COUNT_DEFAULT = OATPP_THREAD_DISTRIBUTED_MEM_POOL_SHARDS_COUNT;
 
 #if defined(OATPP_DISABLE_POOL_ALLOCATIONS) || defined(OATPP_COMPAT_BUILD_NO_THREAD_LOCAL)
-ThreadDistributedMemoryPool::ThreadDistributedMemoryPool(const std::string& name, v_int32 entrySize, v_int32 chunkSize, v_int32 shardsCount)
+ThreadDistributedMemoryPool::ThreadDistributedMemoryPool(const std::string& name, v_int64 entrySize, v_int64 chunkSize, v_int64 shardsCount)
   : m_shardsCount(1)
   , m_shards(new MemoryPool*[1])
   , m_deleted(false)
 {
-  for(v_int32 i = 0; i < m_shardsCount; i++){
+  for(v_int64 i = 0; i < m_shardsCount; i++){
     m_shards[i] = new MemoryPool(name + "_" + oatpp::utils::conversion::int32ToStdStr(i), entrySize, chunkSize);
   }
 }
 #else
-ThreadDistributedMemoryPool::ThreadDistributedMemoryPool(const std::string& name, v_int32 entrySize, v_int32 chunkSize, v_int32 shardsCount)
+ThreadDistributedMemoryPool::ThreadDistributedMemoryPool(const std::string& name, v_int64 entrySize, v_int64 chunkSize, v_int64 shardsCount)
   : m_shardsCount(shardsCount)
   , m_shards(new MemoryPool*[m_shardsCount])
   , m_deleted(false)
 {
-  for(v_int32 i = 0; i < m_shardsCount; i++){
-    m_shards[i] = new MemoryPool(name + "_" + oatpp::utils::conversion::int32ToStdStr(i), entrySize, chunkSize);
+  for(v_int64 i = 0; i < m_shardsCount; i++){
+    m_shards[i] = new MemoryPool(name + "_" + oatpp::utils::conversion::int64ToStdStr(i), entrySize, chunkSize);
   }
 }
 #endif
 
 ThreadDistributedMemoryPool::~ThreadDistributedMemoryPool(){
   m_deleted = true;
-  for(v_int32 i = 0; i < m_shardsCount; i++){
+  for(v_int64 i = 0; i < m_shardsCount; i++){
     delete m_shards[i];
   }
   delete [] m_shards;

--- a/src/oatpp/core/base/memory/MemoryPool.hpp
+++ b/src/oatpp/core/base/memory/MemoryPool.hpp
@@ -66,12 +66,12 @@ private:
   void freeByEntryHeader(EntryHeader* entry);
 private:
   std::string m_name;
-  v_int32 m_entrySize;
-  v_int32 m_chunkSize;
+  v_int64 m_entrySize;
+  v_int64 m_chunkSize;
   v_int64 m_id;
   std::list<p_char8> m_chunks;
   EntryHeader* m_rootEntry;
-  v_int32 m_objectsCount;
+  v_int64 m_objectsCount;
   oatpp::concurrency::SpinLock m_lock;
 public:
 
@@ -81,7 +81,7 @@ public:
    * @param entrySize - size of the entry in bytes returned in call to &l:MemoryPool::obtain ();.
    * @param chunkSize - number of entries in one chunk.
    */
-  MemoryPool(const std::string& name, v_int32 entrySize, v_int32 chunkSize);
+  MemoryPool(const std::string& name, v_int64 entrySize, v_int64 chunkSize);
 
   /**
    * Deleted copy-constructor.
@@ -117,7 +117,7 @@ public:
    * Get size of the memory entry in bytes which can be obtained by call to &l:MemoryPool::obtain ();.
    * @return - size of the enrty in bytes.
    */
-  v_int32 getEntrySize();
+  v_int64 getEntrySize();
 
   /**
    * Get size of the memory allocated by memory pool.
@@ -129,7 +129,7 @@ public:
    * Get number of entries currently in use.
    * @return - number of entries currently in use.
    */
-  v_int32 getObjectsCount();
+  v_int64 getObjectsCount();
   
 };
 
@@ -138,7 +138,7 @@ public:
  */
 class ThreadDistributedMemoryPool {
 private:
-  v_int32 m_shardsCount;
+  v_int64 m_shardsCount;
   MemoryPool** m_shards;
   bool m_deleted;
 public:
@@ -146,7 +146,7 @@ public:
   /**
    * Default number of MemoryPools (&l:MemoryPool;) "shards" to create.
    */
-  static const v_int32 SHARDS_COUNT_DEFAULT;
+  static const v_int64 SHARDS_COUNT_DEFAULT;
 public:
 
   /**
@@ -156,8 +156,8 @@ public:
    * @param chunkSize - number of entries in chunk.
    * @param shardsCount - number of MemoryPools (&l:MemoryPool;) "shards" to create.
    */
-  ThreadDistributedMemoryPool(const std::string& name, v_int32 entrySize, v_int32 chunkSize,
-                              v_int32 shardsCount = SHARDS_COUNT_DEFAULT);
+  ThreadDistributedMemoryPool(const std::string& name, v_int64 entrySize, v_int64 chunkSize,
+                              v_int64 shardsCount = SHARDS_COUNT_DEFAULT);
 
   /**
    * Deleted copy-constructor.
@@ -197,13 +197,13 @@ private:
   
   void grow(){
     
-    v_int32 newSize = m_size + m_growSize;
+    v_int64 newSize = m_size + m_growSize;
     T** newIndex = new T*[newSize];
     std::memcpy(newIndex, m_index, m_size);
     
     Block* b = new Block(new v_char8 [m_growSize * sizeof(T)], m_blocks);
     m_blocks = b;
-    for(v_int32 i = 0; i < m_growSize; i++) {
+    for(v_int64 i = 0; i < m_growSize; i++) {
       newIndex[m_size + i] = (T*) (&b->memory[i * sizeof(T)]);
     }
     
@@ -214,9 +214,9 @@ private:
   }
   
 private:
-  v_int32 m_growSize;
-  v_int32 m_size;
-  v_int32 m_indexPosition;
+  v_int64 m_growSize;
+  v_int64 m_size;
+  v_int64 m_indexPosition;
   Block* m_blocks;
   T** m_index;
 public:
@@ -225,7 +225,7 @@ public:
    * Constructor.
    * @param growSize - number of objects to allocate when no free objects left.
    */
-  Bench(v_int32 growSize)
+  Bench(v_int64 growSize)
     : m_growSize(growSize)
     , m_size(0)
     , m_indexPosition(0)

--- a/src/oatpp/core/data/mapping/type/Primitive.hpp
+++ b/src/oatpp/core/data/mapping/type/Primitive.hpp
@@ -58,15 +58,15 @@ public:
   
   String() {}
   
-  String(v_int32 size)
+  String(v_int64 size)
     : oatpp::data::mapping::type::ObjectWrapper<oatpp::base::StrBuffer, __class::String>(oatpp::base::StrBuffer::createShared(size))
   {}
   
-  String(const char* data, v_int32 size, bool copyAsOwnData = true)
+  String(const char* data, v_int64 size, bool copyAsOwnData = true)
     : oatpp::data::mapping::type::ObjectWrapper<oatpp::base::StrBuffer, __class::String>(oatpp::base::StrBuffer::createShared(data, size, copyAsOwnData))
   {}
   
-  String(const char* data1, v_int32 size1, const char* data2, v_int32 size2)
+  String(const char* data1, v_int64 size1, const char* data2, v_int64 size2)
     : oatpp::data::mapping::type::ObjectWrapper<oatpp::base::StrBuffer, __class::String>(oatpp::base::StrBuffer::createSharedConcatenated(data1, size1, data2, size2))
   {}
   
@@ -130,7 +130,7 @@ String operator + (const String& a, const String& b);
 
 /**
  * Template for primitive mapping-enabled types.
- * @tparam ValueType - type of the value ex.: v_int32.
+ * @tparam ValueType - type of the value ex.: v_int64.
  * @tparam Clazz - Class holding static class information.
  */
 template<typename ValueType, class Clazz>
@@ -420,16 +420,16 @@ namespace std {
     result_type operator()(oatpp::data::mapping::type::String const& s) const noexcept {
       
       p_char8 data = s->getData();
-      v_int32 size4 = s->getSize() >> 2;
+      v_int64 size4 = s->getSize() >> 2;
       
       result_type result = 0;
       
-      for(v_int32 i = 0; i < size4; i++) {
+      for(v_int64 i = 0; i < size4; i++) {
         result ^= *((p_word32) data);
         data += 4;
       }
       
-      for(v_int32 i = 0; i < s->getSize() - (size4 << 2); i++ ) {
+      for(v_int64 i = 0; i < s->getSize() - (size4 << 2); i++ ) {
         ((p_char8) &result)[i] ^= data[i];
       }
       

--- a/src/oatpp/core/data/share/MemoryLabel.cpp
+++ b/src/oatpp/core/data/share/MemoryLabel.cpp
@@ -28,42 +28,42 @@
 
 namespace oatpp { namespace data { namespace share {
 
-MemoryLabel::MemoryLabel(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int32 size)
+MemoryLabel::MemoryLabel(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int64 size)
   : m_memoryHandle(memHandle)
   , m_data(data)
   , m_size(size)
 {}
   
-StringKeyLabel::StringKeyLabel(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int32 size)
+StringKeyLabel::StringKeyLabel(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int64 size)
   : oatpp::data::share::MemoryLabel(memHandle, data, size)
 {}
   
 StringKeyLabel::StringKeyLabel(const char* constText)
-  : oatpp::data::share::MemoryLabel(nullptr, (p_char8)constText, (v_int32)std::strlen(constText))
+  : oatpp::data::share::MemoryLabel(nullptr, (p_char8)constText, std::strlen(constText))
 {}
   
 StringKeyLabel::StringKeyLabel(const oatpp::String& str)
   : oatpp::data::share::MemoryLabel(str.getPtr(), str->getData(), str->getSize())
 {}
   
-StringKeyLabelCI::StringKeyLabelCI(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int32 size)
+StringKeyLabelCI::StringKeyLabelCI(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int64 size)
   : oatpp::data::share::MemoryLabel(memHandle, data, size)
 {}
 
 StringKeyLabelCI::StringKeyLabelCI(const char* constText)
-  : oatpp::data::share::MemoryLabel(nullptr, (p_char8)constText, (v_int32)std::strlen(constText))
+  : oatpp::data::share::MemoryLabel(nullptr, (p_char8)constText, std::strlen(constText))
 {}
 
 StringKeyLabelCI::StringKeyLabelCI(const oatpp::String& str)
   : oatpp::data::share::MemoryLabel(str.getPtr(), str->getData(), str->getSize())
 {}
   
-StringKeyLabelCI_FAST::StringKeyLabelCI_FAST(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int32 size)
+StringKeyLabelCI_FAST::StringKeyLabelCI_FAST(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int64 size)
   : oatpp::data::share::MemoryLabel(memHandle, data, size)
 {}
 
 StringKeyLabelCI_FAST::StringKeyLabelCI_FAST(const char* constText)
-  : oatpp::data::share::MemoryLabel(nullptr, (p_char8)constText, (v_int32)std::strlen(constText))
+  : oatpp::data::share::MemoryLabel(nullptr, (p_char8)constText, std::strlen(constText))
 {}
 
 StringKeyLabelCI_FAST::StringKeyLabelCI_FAST(const oatpp::String& str)

--- a/src/oatpp/core/data/share/MemoryLabel.hpp
+++ b/src/oatpp/core/data/share/MemoryLabel.hpp
@@ -39,7 +39,7 @@ class MemoryLabel {
 protected:
   mutable std::shared_ptr<base::StrBuffer> m_memoryHandle;
   mutable p_char8 m_data;
-  v_int32 m_size;
+  v_int64 m_size;
 public:
 
   /**
@@ -63,7 +63,7 @@ public:
    * @param data - pointer to data.
    * @param size - size of the data in bytes.
    */
-  MemoryLabel(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int32 size);
+  MemoryLabel(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int64 size);
 
   /**
    * Get pointer to labeled data.
@@ -77,7 +77,7 @@ public:
    * Get data size.
    * @return - size of the data.
    */
-  v_int32 getSize() const {
+  v_int64 getSize() const {
     return m_size;
   }
 
@@ -106,7 +106,7 @@ public:
    * @return - `true` if equals.
    */
   bool equals(const char* data) const {
-    v_int32 size = (v_int32) std::strlen(data);
+    v_int64 size = std::strlen(data);
     return m_size == size && base::StrBuffer::equals(m_data, data, m_size);
   }
 
@@ -117,7 +117,7 @@ public:
    * @param size - data size.
    * @return - `true` if equals.
    */
-  bool equals(const void* data, v_int32 size) const {
+  bool equals(const void* data, v_int64 size) const {
     return m_size == size && base::StrBuffer::equals(m_data, data, m_size);
   }
 
@@ -151,7 +151,7 @@ public:
   
   StringKeyLabel() : MemoryLabel() {};
   
-  StringKeyLabel(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int32 size);
+  StringKeyLabel(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int64 size);
   StringKeyLabel(const char* constText);
   StringKeyLabel(const oatpp::String& str);
   
@@ -173,7 +173,7 @@ public:
   
   StringKeyLabelCI() : MemoryLabel() {};
   
-  StringKeyLabelCI(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int32 size);
+  StringKeyLabelCI(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int64 size);
   StringKeyLabelCI(const char* constText);
   StringKeyLabelCI(const oatpp::String& str);
   
@@ -195,7 +195,7 @@ public:
 class StringKeyLabelCI_FAST : public MemoryLabel {
 public:
   
-  StringKeyLabelCI_FAST(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int32 size);
+  StringKeyLabelCI_FAST(const std::shared_ptr<base::StrBuffer>& memHandle, p_char8 data, v_int64 size);
   StringKeyLabelCI_FAST(const char* constText);
   StringKeyLabelCI_FAST(const oatpp::String& str);
   
@@ -222,16 +222,16 @@ namespace std {
     result_type operator()(oatpp::data::share::StringKeyLabel const& s) const noexcept {
       
       p_char8 data = s.getData();
-      v_int32 size4 = s.getSize() >> 2;
+      v_int64 size4 = s.getSize() >> 2;
       
       result_type result = 0;
       
-      for(v_int32 i = 0; i < size4; i++) {
+      for(v_int64 i = 0; i < size4; i++) {
         result ^= *((p_word32) data);
         data += 4;
       }
       
-      for(v_int32 i = 0; i < s.getSize() - (size4 << 2); i++ ) {
+      for(v_int64 i = 0; i < s.getSize() - (size4 << 2); i++ ) {
         ((p_char8) &result)[i] ^= data[i];
       }
       
@@ -248,16 +248,16 @@ namespace std {
     result_type operator()(oatpp::data::share::StringKeyLabelCI const& s) const noexcept {
       
       p_char8 data = s.getData();
-      v_int32 size4 = s.getSize() >> 2;
+      v_int64 size4 = s.getSize() >> 2;
       
       result_type result = 0;
       
-      for(v_int32 i = 0; i < size4; i++) {
+      for(v_int64 i = 0; i < size4; i++) {
         result ^= (*((p_word32) data) | 538976288); // 538976288 = 32 | (32 << 8) | (32 << 16) | (32 << 24);
         data += 4;
       }
       
-      for(v_int32 i = 0; i < s.getSize() - (size4 << 2); i++ ) {
+      for(v_int64 i = 0; i < s.getSize() - (size4 << 2); i++ ) {
         ((p_char8) &result)[i] ^= (data[i] | 32);
       }
       
@@ -274,16 +274,16 @@ namespace std {
     result_type operator()(oatpp::data::share::StringKeyLabelCI_FAST const& s) const noexcept {
       
       p_char8 data = s.getData();
-      v_int32 size4 = s.getSize() >> 2;
+      v_int64 size4 = s.getSize() >> 2;
       
       result_type result = 0;
       
-      for(v_int32 i = 0; i < size4; i++) {
+      for(v_int64 i = 0; i < size4; i++) {
         result ^= (*((p_word32) data) | 538976288); // 538976288 = 32 | (32 << 8) | (32 << 16) | (32 << 24);
         data += 4;
       }
       
-      for(v_int32 i = 0; i < s.getSize() - (size4 << 2); i++ ) {
+      for(v_int64 i = 0; i < s.getSize() - (size4 << 2); i++ ) {
         ((p_char8) &result)[i] ^= (data[i] | 32);
       }
       

--- a/src/oatpp/core/parser/Caret.cpp
+++ b/src/oatpp/core/parser/Caret.cpp
@@ -59,7 +59,7 @@ namespace oatpp { namespace parser {
     return &m_caret->m_data[m_start];
   }
 
-  v_int32 Caret::Label::getSize(){
+  v_int64 Caret::Label::getSize(){
     if(m_end == -1) {
       return m_caret->m_pos - m_start;
     }
@@ -67,7 +67,7 @@ namespace oatpp { namespace parser {
   }
 
   oatpp::String Caret::Label::toString(bool saveAsOwnData){
-    v_int32 end = m_end;
+    v_int64 end = m_end;
     if(end == -1){
       end = m_caret->m_pos;
     }
@@ -79,7 +79,7 @@ namespace oatpp { namespace parser {
   }
 
   std::string Caret::Label::std_str(){
-    v_int32 end = m_end;
+    v_int64 end = m_end;
     if(end == -1){
       end = m_caret->m_pos;
     }
@@ -106,7 +106,7 @@ Caret::StateSaveGuard::StateSaveGuard(Caret& caret)
   m_caret.m_errorCode = m_savedErrorCode;
 }
 
-v_int32 Caret::StateSaveGuard::getSavedPosition() {
+v_int64 Caret::StateSaveGuard::getSavedPosition() {
   return m_savedPosition;
 }
 
@@ -114,7 +114,7 @@ const char* Caret::StateSaveGuard::getSavedErrorMessage() {
   return m_savedErrorMessage;
 }
 
-v_int32 Caret::StateSaveGuard::getSavedErrorCode() {
+v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
   return m_savedErrorCode;
 }
 
@@ -122,10 +122,10 @@ v_int32 Caret::StateSaveGuard::getSavedErrorCode() {
 // Caret
 
   Caret::Caret(const char* text)
-    : Caret((p_char8)text, (v_int32) std::strlen(text))
+    : Caret((p_char8)text, std::strlen(text))
   {}
   
-  Caret::Caret(p_char8 parseData, v_int32 dataSize)
+  Caret::Caret(p_char8 parseData, v_int64 dataSize)
     : m_data(parseData)
     , m_size(dataSize)
     , m_pos(0)
@@ -143,7 +143,7 @@ v_int32 Caret::StateSaveGuard::getSavedErrorCode() {
     return std::make_shared<Caret>(text);
   }
   
-  std::shared_ptr<Caret> Caret::createShared(p_char8 parseData, v_int32 dataSize){
+  std::shared_ptr<Caret> Caret::createShared(p_char8 parseData, v_int64 dataSize){
     return std::make_shared<Caret>(parseData, dataSize);
   }
   
@@ -162,7 +162,7 @@ v_int32 Caret::StateSaveGuard::getSavedErrorCode() {
     return &m_data[m_pos];
   }
   
-  v_int32 Caret::getDataSize(){
+  v_int64 Caret::getDataSize(){
     return m_size;
   }
 
@@ -170,15 +170,15 @@ v_int32 Caret::StateSaveGuard::getSavedErrorCode() {
     return m_dataMemoryHandle;
   }
 
-  void Caret::setPosition(v_int32 position){
+  void Caret::setPosition(v_int64 position){
     m_pos = position;
   }
   
-  v_int32 Caret::getPosition(){
+  v_int64 Caret::getPosition(){
     return m_pos;
   }
   
-  void Caret::setError(const char* errorMessage, v_int32 errorCode){
+  void Caret::setError(const char* errorMessage, v_int64 errorCode){
     m_errorMessage = errorMessage;
     m_errorCode = errorCode;
   }
@@ -187,7 +187,7 @@ v_int32 Caret::StateSaveGuard::getSavedErrorCode() {
     return m_errorMessage;
   }
 
-  v_int32 Caret::getErrorCode() {
+  v_int64 Caret::getErrorCode() {
     return m_errorCode;
   }
   
@@ -208,7 +208,7 @@ v_int32 Caret::StateSaveGuard::getSavedErrorCode() {
     m_pos ++;
   }
   
-  void Caret::inc(v_int32 amount){
+  void Caret::inc(v_int64 amount){
     m_pos+= amount;
   }
   
@@ -245,10 +245,10 @@ v_int32 Caret::StateSaveGuard::getSavedErrorCode() {
   }
   
   bool Caret::skipCharsFromSet(const char* set){
-    return skipCharsFromSet((p_char8)set, (v_int32) std::strlen(set));
+    return skipCharsFromSet((p_char8)set, std::strlen(set));
   }
   
-  bool Caret::skipCharsFromSet(p_char8 set, v_int32 setSize){
+  bool Caret::skipCharsFromSet(p_char8 set, v_int64 setSize){
     
     while(m_pos < m_size){
       if(!isAtCharFromSet(set, setSize)){
@@ -261,17 +261,17 @@ v_int32 Caret::StateSaveGuard::getSavedErrorCode() {
     
   }
   
-  v_int32 Caret::findCharFromSet(const char* set){
-    return findCharFromSet((p_char8) set, (v_int32) std::strlen(set));
+  v_int64 Caret::findCharFromSet(const char* set){
+    return findCharFromSet((p_char8) set, std::strlen(set));
   }
   
-  v_int32 Caret::findCharFromSet(p_char8 set, v_int32 setSize){
+  v_int64 Caret::findCharFromSet(p_char8 set, v_int64 setSize){
     
     while(m_pos < m_size){
       
       v_char8 a = m_data[m_pos];
       
-      for(v_int32 i = 0; i < setSize; i++){
+      for(v_int64 i = 0; i < setSize; i++){
         if(set[i] == a)
           return a;
       }
@@ -354,7 +354,7 @@ v_int32 Caret::StateSaveGuard::getSavedErrorCode() {
     if(start == end){
       m_errorMessage = ERROR_INVALID_INTEGER;
     }
-    m_pos = (v_int32)((v_int64) end - (v_int64) m_data);
+    m_pos = ((v_int64) end - (v_int64) m_data);
     return result;
   }
 
@@ -365,7 +365,7 @@ v_int32 Caret::StateSaveGuard::getSavedErrorCode() {
     if(start == end){
       m_errorMessage = ERROR_INVALID_INTEGER;
     }
-    m_pos = (v_int32)((v_int64) end - (v_int64) m_data);
+    m_pos = ((v_int64) end - (v_int64) m_data);
     return result;
   }
   
@@ -376,7 +376,7 @@ v_int32 Caret::StateSaveGuard::getSavedErrorCode() {
     if(start == end){
       m_errorMessage = ERROR_INVALID_FLOAT;
     }
-    m_pos = (v_int32)((v_int64) end - (v_int64) m_data);
+    m_pos = ((v_int64) end - (v_int64) m_data);
     return result;
   }
   
@@ -387,19 +387,19 @@ v_int32 Caret::StateSaveGuard::getSavedErrorCode() {
     if(start == end){
       m_errorMessage = ERROR_INVALID_FLOAT;
     }
-    m_pos = (v_int32)((v_int64) end - (v_int64) m_data);
+    m_pos = ((v_int64) end - (v_int64) m_data);
     return result;
   }
   
   bool Caret::isAtText(const char* text, bool skipIfTrue){
-    return isAtText((p_char8)text, (v_int32) std::strlen(text), skipIfTrue);
+    return isAtText((p_char8)text, std::strlen(text), skipIfTrue);
   }
   
-  bool Caret::isAtText(p_char8 text, v_int32 textSize, bool skipIfTrue){
+  bool Caret::isAtText(p_char8 text, v_int64 textSize, bool skipIfTrue){
     
     if(textSize <= m_size - m_pos){
       
-      for(v_int32 i = 0; i < textSize; i++){
+      for(v_int64 i = 0; i < textSize; i++){
         
         if(text[i] != m_data[m_pos + i]){
           return false;
@@ -420,14 +420,14 @@ v_int32 Caret::StateSaveGuard::getSavedErrorCode() {
   }
   
   bool Caret::isAtTextNCS(const char* text, bool skipIfTrue){
-    return isAtTextNCS((p_char8)text, (v_int32) std::strlen(text), skipIfTrue);
+    return isAtTextNCS((p_char8)text, std::strlen(text), skipIfTrue);
   }
   
-  bool Caret::isAtTextNCS(p_char8 text, v_int32 textSize, bool skipIfTrue){
+  bool Caret::isAtTextNCS(p_char8 text, v_int64 textSize, bool skipIfTrue){
     
     if(textSize <= m_size - m_pos){
       
-      for(v_int32 i = 0; i < textSize; i++){
+      for(v_int64 i = 0; i < textSize; i++){
         
         v_char8 c1 = text[i];
         v_char8 c2 = m_data[m_pos + i];
@@ -489,23 +489,23 @@ v_int32 Caret::StateSaveGuard::getSavedErrorCode() {
   }
 
   bool Caret::findText(const char* text) {
-    return findText((p_char8) text, (v_int32) std::strlen(text));
+    return findText((p_char8) text, std::strlen(text));
   }
   
-  bool Caret::findText(p_char8 text, v_int32 textSize) {
-    m_pos = (v_int32)(std::search(&m_data[m_pos], &m_data[m_size], text, text + textSize) - m_data);
+  bool Caret::findText(p_char8 text, v_int64 textSize) {
+    m_pos = (std::search(&m_data[m_pos], &m_data[m_size], text, text + textSize) - m_data);
     return m_pos != m_size;
   }
 
   bool Caret::isAtCharFromSet(const char* set) const{
-    return isAtCharFromSet((p_char8)set, (v_int32) std::strlen(set));
+    return isAtCharFromSet((p_char8)set, std::strlen(set));
   }
   
-  bool Caret::isAtCharFromSet(p_char8 set, v_int32 setSize) const{
+  bool Caret::isAtCharFromSet(p_char8 set, v_int64 setSize) const{
     
     v_char8 a = m_data[m_pos];
     
-    for(v_int32 i = 0; i < setSize; i++){
+    for(v_int64 i = 0; i < setSize; i++){
       if(a == set[i]){
         return true;
       }
@@ -533,7 +533,7 @@ v_int32 Caret::StateSaveGuard::getSavedErrorCode() {
     return m_pos < m_size && m_errorMessage == nullptr && m_data[m_pos] == c;
   }
   
-  bool Caret::canContinueAtChar(v_char8 c, v_int32 skipChars){
+  bool Caret::canContinueAtChar(v_char8 c, v_int64 skipChars){
     
     if(m_pos < m_size && m_errorMessage == nullptr && m_data[m_pos] == c){
       m_pos = m_pos + skipChars;

--- a/src/oatpp/core/parser/Caret.hpp
+++ b/src/oatpp/core/parser/Caret.hpp
@@ -49,8 +49,8 @@ public:
   class Label {
   private:
     Caret* m_caret;
-    v_int32 m_start;
-    v_int32 m_end;
+    v_int64 m_start;
+    v_int64 m_end;
   public:
 
     /**
@@ -79,7 +79,7 @@ public:
      * Get size of labeled data.
      * @return
      */
-    v_int32 getSize();
+    v_int64 getSize();
 
     /**
      * Create &id:oatpp::String; from labeled data.
@@ -110,9 +110,9 @@ public:
   class StateSaveGuard {
   private:
     Caret& m_caret;
-    v_int32 m_savedPosition;
+    v_int64 m_savedPosition;
     const char* m_savedErrorMessage;
-    v_int32 m_savedErrorCode;
+    v_int64 m_savedErrorCode;
   public:
 
     /**
@@ -130,7 +130,7 @@ public:
      * Get caret saved position.
      * @return
      */
-    v_int32 getSavedPosition();
+    v_int64 getSavedPosition();
 
     /**
      * Get caret saved error message.
@@ -142,25 +142,25 @@ public:
      * Get caret saved error code.
      * @return
      */
-    v_int32 getSavedErrorCode();
+    v_int64 getSavedErrorCode();
 
   };
 
 private:
   p_char8 m_data;
-  v_int32 m_size;
-  v_int32 m_pos;
+  v_int64 m_size;
+  v_int64 m_pos;
   const char* m_errorMessage;
-  v_int32 m_errorCode;
+  v_int64 m_errorCode;
   std::shared_ptr<oatpp::base::StrBuffer> m_dataMemoryHandle;
 public:
   Caret(const char* text);
-  Caret(p_char8 parseData, v_int32 dataSize);
+  Caret(p_char8 parseData, v_int64 dataSize);
   Caret(const oatpp::String& str);
 public:
   
   static std::shared_ptr<Caret> createShared(const char* text);
-  static std::shared_ptr<Caret> createShared(p_char8 parseData, v_int32 dataSize);
+  static std::shared_ptr<Caret> createShared(p_char8 parseData, v_int64 dataSize);
   static std::shared_ptr<Caret> createShared(const oatpp::String& str);
 
   virtual ~Caret();
@@ -181,7 +181,7 @@ public:
    * Get size of a data
    * @return
    */
-  v_int32 getDataSize();
+  v_int64 getDataSize();
 
   /**
    * Get data memoryHandle.
@@ -193,13 +193,13 @@ public:
    * Set caret position relative to data
    * @param position
    */
-  void setPosition(v_int32 position);
+  void setPosition(v_int64 position);
 
   /**
    * Get caret position relative to data
    * @return
    */
-  v_int32 getPosition();
+  v_int64 getPosition();
 
   /**
    * Set error message and error code.
@@ -207,7 +207,7 @@ public:
    * @param errorMessage
    * @param errorCode
    */
-  void setError(const char* errorMessage, v_int32 errorCode = 0);
+  void setError(const char* errorMessage, v_int64 errorCode = 0);
 
   /**
    * Get error message
@@ -219,7 +219,7 @@ public:
    * Get error code
    * @return error code
    */
-  v_int32 getErrorCode();
+  v_int64 getErrorCode();
 
   /**
    * Check if error is set for the Caret
@@ -247,7 +247,7 @@ public:
    * Increase caret position by amount
    * @param amount
    */
-  void inc(v_int32 amount);
+  void inc(v_int64 amount);
 
   /**
    * Skip chars: [' ', '\t', '\n', '\r','\f']
@@ -285,14 +285,14 @@ public:
    * @param setSize
    * @return true if other char found
    */
-  bool skipCharsFromSet(p_char8 set, v_int32 setSize);
+  bool skipCharsFromSet(p_char8 set, v_int64 setSize);
 
   /**
    * Find one of chars defined by set.
    * @param set
    * @return char found or -1 if no char found
    */
-  v_int32 findCharFromSet(const char* set);
+  v_int64 findCharFromSet(const char* set);
 
   /**
    * Find one of chars defined by set.
@@ -300,7 +300,7 @@ public:
    * @param setSize
    * @return char found or -1 if no char found
    */
-  v_int32 findCharFromSet(p_char8 set, v_int32 setSize);
+  v_int64 findCharFromSet(p_char8 set, v_int64 setSize);
 
   /**
    * Find "\r\n" chars
@@ -396,7 +396,7 @@ public:
    * @param skipIfTrue - increase position if true
    * @return
    */
-  bool isAtText(p_char8 text, v_int32 textSize, bool skipIfTrue = false);
+  bool isAtText(p_char8 text, v_int64 textSize, bool skipIfTrue = false);
 
   /**
    * Check if follows text (Not Case Sensitive)
@@ -413,7 +413,7 @@ public:
    * @param skipIfTrue - increase position if true
    * @return
    */
-  bool isAtTextNCS(p_char8 text, v_int32 textSize, bool skipIfTrue = false);
+  bool isAtTextNCS(p_char8 text, v_int64 textSize, bool skipIfTrue = false);
 
   /**
    * Parse enclosed string.
@@ -439,7 +439,7 @@ public:
    * @param textSize
    * @return true if found
    */
-  bool findText(p_char8 text, v_int32 textSize);
+  bool findText(p_char8 text, v_int64 textSize);
 
   /**
    * Check if caret is at char defined by set
@@ -456,7 +456,7 @@ public:
    * @param setSize
    * @return
    */
-  bool isAtCharFromSet(p_char8 set, v_int32 setSize) const;
+  bool isAtCharFromSet(p_char8 set, v_int64 setSize) const;
 
   /**
    * Check if caret is at char
@@ -491,7 +491,7 @@ public:
    * @param skipChars
    * @return
    */
-  bool canContinueAtChar(v_char8 c, v_int32 skipChars);
+  bool canContinueAtChar(v_char8 c, v_int64 skipChars);
 
   /**
    * Check if caret position < dataSize and not error is set

--- a/src/oatpp/core/parser/ParsingError.cpp
+++ b/src/oatpp/core/parser/ParsingError.cpp
@@ -26,7 +26,7 @@
 
 namespace oatpp { namespace parser {
 
-ParsingError::ParsingError(const oatpp::String &message, v_int32 code, v_int32 position)
+ParsingError::ParsingError(const oatpp::String &message, v_int64 code, v_int64 position)
   :std::runtime_error(message->std_str())
   , m_message(message)
   , m_code(code)
@@ -37,11 +37,11 @@ oatpp::String ParsingError::getMessage() const {
   return m_message;
 }
 
-v_int32 ParsingError::getCode() const {
+v_int64 ParsingError::getCode() const {
   return m_code;
 }
 
-v_int32 ParsingError::getPosition() const {
+v_int64 ParsingError::getPosition() const {
   return m_position;
 }
 

--- a/src/oatpp/core/parser/ParsingError.hpp
+++ b/src/oatpp/core/parser/ParsingError.hpp
@@ -37,8 +37,8 @@ namespace oatpp { namespace parser {
 class ParsingError : public std::runtime_error {
 private:
   oatpp::String m_message;
-  v_int32 m_code;
-  v_int32 m_position;
+  v_int64 m_code;
+  v_int64 m_position;
 public:
 
   /**
@@ -46,7 +46,7 @@ public:
    * @param message
    * @param position
    */
-  ParsingError(const oatpp::String &message, v_int32 code, v_int32 position);
+  ParsingError(const oatpp::String &message, v_int64 code, v_int64 position);
 
   /**
    * get error message
@@ -58,13 +58,13 @@ public:
    * get error code
    * @return
    */
-  v_int32 getCode() const;
+  v_int64 getCode() const;
 
   /**
    * get parsing position of the error
    * @return
    */
-  v_int32 getPosition() const;
+  v_int64 getPosition() const;
 
 };
 

--- a/src/oatpp/core/utils/Random.cpp
+++ b/src/oatpp/core/utils/Random.cpp
@@ -42,7 +42,7 @@ void Random::randomBytes(p_char8 buffer, v_int32 bufferSize) {
   std::uniform_int_distribution<size_t> distribution(0, 255);
 
   for(v_int32 i = 0; i < bufferSize; i ++) {
-    buffer[i] = distribution(RANDOM_GENERATOR);
+    buffer[i] = (v_char8) distribution(RANDOM_GENERATOR);
   }
 
 }

--- a/src/oatpp/encoding/Base64.cpp
+++ b/src/oatpp/encoding/Base64.cpp
@@ -53,16 +53,16 @@ v_char8 Base64::getAlphabetCharIndex(v_char8 a, const char* auxiliaryChars) {
   return 255;
 }
   
-v_int32 Base64::calcEncodedStringSize(v_int32 size) {
-  v_int32 size3 = size / 3;
-  v_int32 rSize = size3 * 3;
+v_int64 Base64::calcEncodedStringSize(v_int64 size) {
+  v_int64 size3 = size / 3;
+  v_int64 rSize = size3 * 3;
   if(rSize < size){
     rSize += 4;
   }
   return rSize + size3; // resultSize = (size3 * 3 + size3) = size3 * 4
 }
   
-v_int32 Base64::calcDecodedStringSize(const char* data, v_int32 size, v_int32& base64StrLength, const char* auxiliaryChars) {
+v_int64 Base64::calcDecodedStringSize(const char* data, v_int64 size, v_int64& base64StrLength, const char* auxiliaryChars) {
   
   base64StrLength = size;
   
@@ -70,7 +70,7 @@ v_int32 Base64::calcDecodedStringSize(const char* data, v_int32 size, v_int32& b
   v_char8 auxChar2 = auxiliaryChars[1];
   v_char8 paddingChar = auxiliaryChars[2];
   
-  v_int32 i = 0;
+  v_int64 i = 0;
   while (i < size) {
     
     v_char8 a = data[i];
@@ -88,9 +88,9 @@ v_int32 Base64::calcDecodedStringSize(const char* data, v_int32 size, v_int32& b
     
   }
   
-  v_int32 size4 = i >> 2;
-  v_int32 size4d = i - (size4 << 2);
-  v_int32 resultSize = size4 * 3;
+  v_int64 size4 = i >> 2;
+  v_int64 size4d = i - (size4 << 2);
+  v_int64 resultSize = size4 * 3;
   if(size4d > 0) {
     resultSize += size4d - 1;
   }
@@ -98,12 +98,12 @@ v_int32 Base64::calcDecodedStringSize(const char* data, v_int32 size, v_int32& b
   
 }
   
-bool Base64::isBase64String(const char* data, v_int32 size, const char* auxiliaryChars) {
-  v_int32 base64StrLength;
+bool Base64::isBase64String(const char* data, v_int64 size, const char* auxiliaryChars) {
+  v_int64 base64StrLength;
   return (calcDecodedStringSize(data, size, base64StrLength, auxiliaryChars) >= 0);
 }
   
-oatpp::String Base64::encode(const void* data, v_int32 size, const char* alphabet) {
+oatpp::String Base64::encode(const void* data, v_int64 size, const char* alphabet) {
   
   auto resultSize = calcEncodedStringSize(size);
   
@@ -112,7 +112,7 @@ oatpp::String Base64::encode(const void* data, v_int32 size, const char* alphabe
   p_char8 bdata = (p_char8) data;
   p_char8 resultData = result->getData();
   
-  v_int32 pos = 0;
+  v_int64 pos = 0;
   while (pos + 2 < size) {
     
     v_char8 b0 = bdata[pos];
@@ -150,9 +150,9 @@ oatpp::String Base64::encode(const oatpp::String& data, const char* alphabet) {
   return encode(data->getData(), data->getSize(), alphabet);
 }
   
-oatpp::String Base64::decode(const char* data, v_int32 size, const char* auxiliaryChars) {
+oatpp::String Base64::decode(const char* data, v_int64 size, const char* auxiliaryChars) {
   
-  v_int32 base64StrLength;
+  v_int64 base64StrLength;
   auto resultSize = calcDecodedStringSize(data, size, base64StrLength, auxiliaryChars);
   if(resultSize < 0) {
     throw DecodingError("Data is no base64 string. Make sure that auxiliaryChars match with encoder alphabet");
@@ -160,7 +160,7 @@ oatpp::String Base64::decode(const char* data, v_int32 size, const char* auxilia
   
   auto result = oatpp::String(resultSize);
   p_char8 resultData = result->getData();
-  v_int32 pos = 0;
+  v_int64 pos = 0;
   while (pos + 3 < base64StrLength) {
     v_char8 b0 = getAlphabetCharIndex(data[pos], auxiliaryChars);
     v_char8 b1 = getAlphabetCharIndex(data[pos + 1], auxiliaryChars);
@@ -175,7 +175,7 @@ oatpp::String Base64::decode(const char* data, v_int32 size, const char* auxilia
     pos += 4;
   }
   
-  v_int32 posDiff = base64StrLength - pos;
+  v_int64 posDiff = base64StrLength - pos;
   if(posDiff == 3) {
     v_char8 b0 = getAlphabetCharIndex(data[pos], auxiliaryChars);
     v_char8 b1 = getAlphabetCharIndex(data[pos + 1], auxiliaryChars);

--- a/src/oatpp/encoding/Base64.hpp
+++ b/src/oatpp/encoding/Base64.hpp
@@ -97,7 +97,7 @@ public:
    * @param size - size of string to encode.
    * @return - size of encoding result of a string of the given size
    */
-  static v_int32 calcEncodedStringSize(v_int32 size);
+  static v_int64 calcEncodedStringSize(v_int64 size);
 
   /**
    * Calculate size of decoding result. this method assumes that data passed as a param consists of standard base64 set of chars
@@ -108,7 +108,7 @@ public:
    * @param auxiliaryChars - configurable auxiliary chars.
    * @return - size of decoded data. If data passed is not a base64 string then -1 is returned.
    */
-  static v_int32 calcDecodedStringSize(const char* data, v_int32 size, v_int32& base64StrLength, const char* auxiliaryChars = ALPHABET_BASE64_AUXILIARY_CHARS);
+  static v_int64 calcDecodedStringSize(const char* data, v_int64 size, v_int64& base64StrLength, const char* auxiliaryChars = ALPHABET_BASE64_AUXILIARY_CHARS);
 
   /**
    * Check if data is a valid base64 encoded string.
@@ -117,7 +117,7 @@ public:
    * @param auxiliaryChars - configurable auxiliary chars.
    * @return `(calcDecodedStringSize(data, size, base64StrLength, auxiliaryChars) >= 0)`.
    */
-  static bool isBase64String(const char* data, v_int32 size, const char* auxiliaryChars = ALPHABET_BASE64_AUXILIARY_CHARS);
+  static bool isBase64String(const char* data, v_int64 size, const char* auxiliaryChars = ALPHABET_BASE64_AUXILIARY_CHARS);
 
   /**
    * Encode data as base64 string.
@@ -126,7 +126,7 @@ public:
    * @param alphabet - base64 alphabet to use.
    * @return - encoded base64 string as &id:oatpp::String;.
    */
-  static oatpp::String encode(const void* data, v_int32 size, const char* alphabet = ALPHABET_BASE64);
+  static oatpp::String encode(const void* data, v_int64 size, const char* alphabet = ALPHABET_BASE64);
 
   /**
    * Encode data as base64 string.
@@ -145,7 +145,7 @@ public:
    * @return - decoded data as &id:oatpp::String;.
    * @throws - &l:Base64::DecodingError;
    */
-  static oatpp::String decode(const char* data, v_int32 size, const char* auxiliaryChars = ALPHABET_BASE64_AUXILIARY_CHARS);
+  static oatpp::String decode(const char* data, v_int64 size, const char* auxiliaryChars = ALPHABET_BASE64_AUXILIARY_CHARS);
   
   /**
    * Decode base64 encoded data. This method assumes that data passed as a param consists of standard base64 set of chars

--- a/src/oatpp/encoding/Unicode.cpp
+++ b/src/oatpp/encoding/Unicode.cpp
@@ -34,7 +34,7 @@
 
 namespace oatpp { namespace encoding {
   
-v_int32 Unicode::getUtf8CharSequenceLength(v_char8 firstByte) {
+v_int64 Unicode::getUtf8CharSequenceLength(v_char8 firstByte) {
   
   if(firstByte < 128){
     return 1;
@@ -60,7 +60,7 @@ v_int32 Unicode::getUtf8CharSequenceLength(v_char8 firstByte) {
   
 }
   
-v_int32 Unicode::getUtf8CharSequenceLengthForCode(v_word32 code){
+v_int64 Unicode::getUtf8CharSequenceLengthForCode(v_word32 code){
   if(code < 128) {
     return 1;
   } else if(code < 0x00000800){
@@ -77,7 +77,7 @@ v_int32 Unicode::getUtf8CharSequenceLengthForCode(v_word32 code){
   return 1;
 }
   
-v_int32 Unicode::encodeUtf8Char(p_char8 sequence, v_int32& length){
+v_int32 Unicode::encodeUtf8Char(p_char8 sequence, v_int64& length){
   v_char8 byte = sequence[0];
   if(byte > 127){
     v_int32 code;
@@ -107,7 +107,7 @@ v_int32 Unicode::encodeUtf8Char(p_char8 sequence, v_int32& length){
     }
     
     v_char8 bitIndex = 0;
-    for(v_int32 i = length; i > 1; i--){
+    for(v_int64 i = length; i > 1; i--){
       code |= (sequence[i - 1] & 63) << bitIndex;
       bitIndex += 6;
     }
@@ -118,7 +118,7 @@ v_int32 Unicode::encodeUtf8Char(p_char8 sequence, v_int32& length){
   }
 }
   
-v_int32 Unicode::decodeUtf8Char(v_int32 code, p_char8 buffer) {
+v_int64 Unicode::decodeUtf8Char(v_int32 code, p_char8 buffer) {
   if(code >= 0x00000080 && code < 0x00000800){
     *((p_int16) buffer) = htons(((((code >> 6) & 31) | 192) << 8) | ((code & 63) | 128));
     return 2;

--- a/src/oatpp/encoding/Unicode.hpp
+++ b/src/oatpp/encoding/Unicode.hpp
@@ -39,14 +39,14 @@ public:
    * @param firstByte - first byte of UTF-8 character.
    * @return - length in bytes of UTF-8 character.
    */
-  static v_int32 getUtf8CharSequenceLength(v_char8 firstByte);
+  static v_int64 getUtf8CharSequenceLength(v_char8 firstByte);
 
   /**
    * Get length in bytes of UTF-8 character by its code.
    * @param code - code of UTF-8 character.
    * @return - length in bytes of UTF-8 character.
    */
-  static v_int32 getUtf8CharSequenceLengthForCode(v_word32 code);
+  static v_int64 getUtf8CharSequenceLengthForCode(v_word32 code);
 
   /**
    * Get code of UTF-8 character.
@@ -54,7 +54,7 @@ public:
    * @param length - out parameter. Length in bytes of UTF-8 character.
    * @return - code of UTF-8 character.
    */
-  static v_int32 encodeUtf8Char(p_char8 sequence, v_int32& length);
+  static v_int32 encodeUtf8Char(p_char8 sequence, v_int64& length);
 
   /**
    * Write UTF-8 character to buffer.
@@ -62,7 +62,7 @@ public:
    * @param buffer - pointer to write UTF-8 character to.
    * @return - length in bytes of UTF-8 character.
    */
-  static v_int32 decodeUtf8Char(v_int32 code, p_char8 buffer);
+  static v_int64 decodeUtf8Char(v_int32 code, p_char8 buffer);
 
   /**
    * Get corresponding UTF-16 surrogate pair for symbol code.

--- a/src/oatpp/network/Connection.cpp
+++ b/src/oatpp/network/Connection.cpp
@@ -55,7 +55,7 @@ data::v_io_size Connection::write(const void *buff, data::v_io_size count){
 
 #if defined(WIN32) || defined(_WIN32)
 
-  auto result = ::send(m_handle, (const char*) buff, (size_t)count, 0);
+  auto result = ::send(m_handle, (const char*) buff, (int)count, 0);
 
   if(result == SOCKET_ERROR) {
 
@@ -106,7 +106,7 @@ data::v_io_size Connection::read(void *buff, data::v_io_size count){
 
 #if defined(WIN32) || defined(_WIN32)
 
-  auto result = ::recv(m_handle, (char*)buff, (size_t)count, 0);
+  auto result = ::recv(m_handle, (char*)buff, (int)count, 0);
 
   if(result == SOCKET_ERROR) {
 

--- a/src/oatpp/network/Url.cpp
+++ b/src/oatpp/network/Url.cpp
@@ -29,9 +29,9 @@
 namespace oatpp { namespace network {
 
 oatpp::String Url::Parser::parseScheme(oatpp::parser::Caret& caret) {
-  v_int32 pos0 = caret.getPosition();
+  v_int64 pos0 = caret.getPosition();
   caret.findChar(':');
-  v_int32 size = caret.getPosition() - pos0;
+  v_int64 size = caret.getPosition() - pos0;
   if(size > 0) {
     std::unique_ptr<v_char8> buff(new v_char8[size]);
     std::memcpy(buff.get(), &caret.getData()[pos0], size);
@@ -44,12 +44,12 @@ oatpp::String Url::Parser::parseScheme(oatpp::parser::Caret& caret) {
 Url::Authority Url::Parser::parseAuthority(oatpp::parser::Caret& caret) {
   
   p_char8 data = caret.getData();
-  v_int32 pos0 = caret.getPosition();
-  v_int32 pos = pos0;
+  v_int64 pos0 = caret.getPosition();
+  v_int64 pos = pos0;
   
-  v_int32 hostPos = pos0;
-  v_int32 atPos = -1;
-  v_int32 portPos = -1;
+  v_int64 hostPos = pos0;
+  v_int64 atPos = -1;
+  v_int64 portPos = -1;
   
   while (pos < caret.getDataSize()) {
     v_char8 a = data[pos];
@@ -81,7 +81,7 @@ Url::Authority Url::Parser::parseAuthority(oatpp::parser::Caret& caret) {
   if(portPos > hostPos) {
     result.host = oatpp::String((const char*)&data[hostPos], portPos - 1 - hostPos, true);
     char* end;
-    result.port = (v_int32) std::strtol((const char*)&data[portPos], &end, 10);
+    result.port = std::strtol((const char*)&data[portPos], &end, 10);
     bool success = (((v_int64)end - (v_int64)&data[portPos]) == pos - portPos);
     if(!success) {
       caret.setError("Invalid port string");
@@ -110,7 +110,7 @@ void Url::Parser::parseQueryParams(Url::Parameters& params, oatpp::parser::Caret
     do {
       caret.inc();
       auto nameLabel = caret.putLabel();
-      v_int32 charFound = caret.findCharFromSet("=&");
+      v_int64 charFound = caret.findCharFromSet("=&");
       if(charFound == '=') {
         nameLabel.end();
         caret.inc();

--- a/src/oatpp/network/client/SimpleTCPConnectionProvider.cpp
+++ b/src/oatpp/network/client/SimpleTCPConnectionProvider.cpp
@@ -82,7 +82,7 @@ std::shared_ptr<oatpp::data::stream::IOStream> SimpleTCPConnectionProvider::getC
 
     if(clientHandle >= 0) {
 
-      if(connect(clientHandle, currResult->ai_addr, currResult->ai_addrlen) == 0) {
+      if(connect(clientHandle, currResult->ai_addr, (int)currResult->ai_addrlen) == 0) {
         break;
       } else {
 #if defined(WIN32) || defined(_WIN32)
@@ -226,7 +226,7 @@ oatpp::async::CoroutineStarterForResult<const std::shared_ptr<oatpp::data::strea
     Action doConnect() {
       errno = 0;
 
-      auto res = connect(m_clientHandle, m_currentResult->ai_addr, m_currentResult->ai_addrlen);
+      auto res = connect(m_clientHandle, m_currentResult->ai_addr, (int)m_currentResult->ai_addrlen);
 
 #if defined(WIN32) || defined(_WIN32)
 

--- a/src/oatpp/parser/json/Utils.cpp
+++ b/src/oatpp/parser/json/Utils.cpp
@@ -29,9 +29,9 @@
 
 namespace oatpp { namespace parser { namespace json{
 
-v_int32 Utils::calcEscapedStringSize(p_char8 data, v_int32 size, v_int32& safeSize) {
-  v_int32 result = 0;
-  v_int32 i = 0;
+v_int64 Utils::calcEscapedStringSize(p_char8 data, v_int64 size, v_int64& safeSize) {
+  v_int64 result = 0;
+  v_int64 i = 0;
   safeSize = size;
   while (i < size) {
     v_char8 a = data[i];
@@ -50,7 +50,7 @@ v_int32 Utils::calcEscapedStringSize(p_char8 data, v_int32 size, v_int32& safeSi
         result ++;
       }
     } else {
-      v_int32 charSize = oatpp::encoding::Unicode::getUtf8CharSequenceLength(a);
+      v_int64 charSize = oatpp::encoding::Unicode::getUtf8CharSequenceLength(a);
       if(charSize != 0) {
         if(i + charSize > size) {
           safeSize = i;
@@ -73,10 +73,10 @@ v_int32 Utils::calcEscapedStringSize(p_char8 data, v_int32 size, v_int32& safeSi
   return result;
 }
 
-v_int32 Utils::calcUnescapedStringSize(p_char8 data, v_int32 size, v_int32& errorCode, v_int32& errorPosition) {
+v_int64 Utils::calcUnescapedStringSize(p_char8 data, v_int64 size, v_int64& errorCode, v_int64& errorPosition) {
   errorCode = 0;
-  v_int32 result = 0;
-  v_int32 i = 0;
+  v_int64 result = 0;
+  v_int64 i = 0;
   
   while (i < size) {
     v_char8 a = data[i];
@@ -168,8 +168,8 @@ v_int32 Utils::calcUnescapedStringSize(p_char8 data, v_int32 size, v_int32& erro
   return result;
 }
   
-v_int32 Utils::escapeUtf8Char(p_char8 sequence, p_char8 buffer){
-  v_int32 length;
+v_int64 Utils::escapeUtf8Char(p_char8 sequence, p_char8 buffer){
+  v_int64 length;
   v_int32 code = oatpp::encoding::Unicode::encodeUtf8Char(sequence, length);
   if(code < 0x00010000) {
     buffer[0] = '\\';
@@ -196,16 +196,16 @@ v_int32 Utils::escapeUtf8Char(p_char8 sequence, p_char8 buffer){
   }
 }
   
-oatpp::String Utils::escapeString(p_char8 data, v_int32 size, bool copyAsOwnData) {
-  v_int32 safeSize;
-  v_int32 escapedSize = calcEscapedStringSize(data, size, safeSize);
+oatpp::String Utils::escapeString(p_char8 data, v_int64 size, bool copyAsOwnData) {
+  v_int64 safeSize;
+  v_int64 escapedSize = calcEscapedStringSize(data, size, safeSize);
   if(escapedSize == size) {
     return String((const char*)data, size, copyAsOwnData);
   }
   auto result = String(escapedSize);
-  v_int32 i = 0;
+  v_int64 i = 0;
   p_char8 resultData = result->getData();
-  v_int32 pos = 0;
+  v_int64 pos = 0;
   
   while (i < safeSize) {
     v_char8 a = data[i];
@@ -240,7 +240,7 @@ oatpp::String Utils::escapeString(p_char8 data, v_int32 size, bool copyAsOwnData
       }
       i ++;
     } else {
-      v_int32 charSize = oatpp::encoding::Unicode::getUtf8CharSequenceLength(a);
+      v_int64 charSize = oatpp::encoding::Unicode::getUtf8CharSequenceLength(a);
       if(charSize != 0) {
         pos += escapeUtf8Char(&data[i], &resultData[pos]);
         i += charSize;
@@ -254,7 +254,7 @@ oatpp::String Utils::escapeString(p_char8 data, v_int32 size, bool copyAsOwnData
   }
   
   if(size > safeSize){
-    for(v_int32 i = pos; i < result->getSize(); i ++){
+    for(v_int64 i = pos; i < result->getSize(); i ++){
       resultData[i] = '?';
     }
   }
@@ -262,10 +262,10 @@ oatpp::String Utils::escapeString(p_char8 data, v_int32 size, bool copyAsOwnData
   return result;
 }
 
-void Utils::unescapeStringToBuffer(p_char8 data, v_int32 size, p_char8 resultData){
+void Utils::unescapeStringToBuffer(p_char8 data, v_int64 size, p_char8 resultData){
   
-  v_int32 i = 0;
-  v_int32 pos = 0;
+  v_int64 i = 0;
+  v_int64 pos = 0;
   
   while (i < size) {
     v_char8 a = data[i];
@@ -318,9 +318,9 @@ void Utils::unescapeStringToBuffer(p_char8 data, v_int32 size, p_char8 resultDat
   
 }
   
-oatpp::String Utils::unescapeString(p_char8 data, v_int32 size, v_int32& errorCode, v_int32& errorPosition) {
+oatpp::String Utils::unescapeString(p_char8 data, v_int64 size, v_int64& errorCode, v_int64& errorPosition) {
   
-  v_int32 unescapedSize = calcUnescapedStringSize(data, size, errorCode, errorPosition);
+  v_int64 unescapedSize = calcUnescapedStringSize(data, size, errorCode, errorPosition);
   if(errorCode != 0){
     return nullptr;
   }
@@ -334,9 +334,9 @@ oatpp::String Utils::unescapeString(p_char8 data, v_int32 size, v_int32& errorCo
   
 }
   
-std::string Utils::unescapeStringToStdString(p_char8 data, v_int32 size, v_int32& errorCode, v_int32& errorPosition){
+std::string Utils::unescapeStringToStdString(p_char8 data, v_int64 size, v_int64& errorCode, v_int64& errorPosition){
   
-  v_int32 unescapedSize = calcUnescapedStringSize(data, size, errorCode, errorPosition);
+  v_int64 unescapedSize = calcUnescapedStringSize(data, size, errorCode, errorPosition);
   if(errorCode != 0){
     return "";
   }
@@ -351,14 +351,14 @@ std::string Utils::unescapeStringToStdString(p_char8 data, v_int32 size, v_int32
   
 }
   
-p_char8 Utils::preparseString(ParsingCaret& caret, v_int32& size){
+p_char8 Utils::preparseString(ParsingCaret& caret, v_int64& size){
   
   if(caret.canContinueAtChar('"', 1)){
     
     const p_char8 data = caret.getData();
-    v_int32 pos = caret.getPosition();
-    v_int32 pos0 = pos;
-    v_int32 length = caret.getDataSize();
+    v_int64 pos = caret.getPosition();
+    v_int64 pos0 = pos;
+    v_int64 length = caret.getDataSize();
     
     while (pos < length) {
       v_char8 a = data[pos];
@@ -383,15 +383,15 @@ p_char8 Utils::preparseString(ParsingCaret& caret, v_int32& size){
   
 oatpp::String Utils::parseString(ParsingCaret& caret) {
   
-  v_int32 size;
+  v_int64 size;
   p_char8 data = preparseString(caret, size);
   
   if(data != nullptr) {
   
-    v_int32 pos = caret.getPosition();
+    v_int64 pos = caret.getPosition();
     
-    v_int32 errorCode;
-    v_int32 errorPosition;
+    v_int64 errorCode;
+    v_int64 errorPosition;
     auto result = unescapeString(data, size, errorCode, errorPosition);
     if(errorCode != 0){
       caret.setError("[oatpp::parser::json::Utils::parseString()]: Error. Call to unescapeString() failed", errorCode);
@@ -410,15 +410,15 @@ oatpp::String Utils::parseString(ParsingCaret& caret) {
   
 std::string Utils::parseStringToStdString(ParsingCaret& caret){
   
-  v_int32 size;
+  v_int64 size;
   p_char8 data = preparseString(caret, size);
   
   if(data != nullptr) {
     
-    v_int32 pos = caret.getPosition();
+    v_int64 pos = caret.getPosition();
     
-    v_int32 errorCode;
-    v_int32 errorPosition;
+    v_int64 errorCode;
+    v_int64 errorPosition;
     const std::string& result = unescapeStringToStdString(data, size, errorCode, errorPosition);
     if(errorCode != 0){
       caret.setError("[oatpp::parser::json::Utils::parseStringToStdString()]: Error. Call to unescapeStringToStdString() failed", errorCode);

--- a/src/oatpp/parser/json/Utils.hpp
+++ b/src/oatpp/parser/json/Utils.hpp
@@ -42,28 +42,28 @@ public:
   /**
    * ERROR_CODE_INVALID_ESCAPED_CHAR
    */
-  static constexpr v_int32 ERROR_CODE_INVALID_ESCAPED_CHAR = 1;
+  static constexpr v_int64 ERROR_CODE_INVALID_ESCAPED_CHAR = 1;
 
   /**
    * ERROR_CODE_INVALID_SURROGATE_PAIR
    */
-  static constexpr v_int32 ERROR_CODE_INVALID_SURROGATE_PAIR = 2;
+  static constexpr v_int64 ERROR_CODE_INVALID_SURROGATE_PAIR = 2;
 
   /**
    * '\\' - EXPECTED"
    * ERROR_CODE_PARSER_QUOTE_EXPECTED
    */
-  static constexpr v_int32 ERROR_CODE_PARSER_QUOTE_EXPECTED = 3;
+  static constexpr v_int64 ERROR_CODE_PARSER_QUOTE_EXPECTED = 3;
 
 public:
   typedef oatpp::String String;
   typedef oatpp::parser::Caret ParsingCaret;
 private:
-  static v_int32 escapeUtf8Char(p_char8 sequence, p_char8 buffer);
-  static v_int32 calcEscapedStringSize(p_char8 data, v_int32 size, v_int32& safeSize);
-  static v_int32 calcUnescapedStringSize(p_char8 data, v_int32 size, v_int32& errorCode, v_int32& errorPosition);
-  static void unescapeStringToBuffer(p_char8 data, v_int32 size, p_char8 resultData);
-  static p_char8 preparseString(ParsingCaret& caret, v_int32& size);
+  static v_int64 escapeUtf8Char(p_char8 sequence, p_char8 buffer);
+  static v_int64 calcEscapedStringSize(p_char8 data, v_int64 size, v_int64& safeSize);
+  static v_int64 calcUnescapedStringSize(p_char8 data, v_int64 size, v_int64& errorCode, v_int64& errorPosition);
+  static void unescapeStringToBuffer(p_char8 data, v_int64 size, p_char8 resultData);
+  static p_char8 preparseString(ParsingCaret& caret, v_int64& size);
 public:
 
   /**
@@ -74,7 +74,7 @@ public:
    * @param copyAsOwnData - see &id:oatpp::base::StrBuffer::StrBuffer;.
    * @return - &id:oatpp::String;.
    */
-  static String escapeString(p_char8 data, v_int32 size, bool copyAsOwnData = true);
+  static String escapeString(p_char8 data, v_int64 size, bool copyAsOwnData = true);
 
   /**
    * Unescape string as for json standard.
@@ -90,7 +90,7 @@ public:
    * @param errorPosition - out parameter. Error position in data.
    * @return - &id:oatpp::String;.
    */
-  static String unescapeString(p_char8 data, v_int32 size, v_int32& errorCode, v_int32& errorPosition);
+  static String unescapeString(p_char8 data, v_int64 size, v_int64& errorCode, v_int64& errorPosition);
 
   /**
    * Same as &l:Utils::unescapeString (); but return `std::string`.
@@ -106,7 +106,7 @@ public:
    * @param errorPosition - out parameter. Error position in data.
    * @return - &id:oatpp::String;.
    */
-  static std::string unescapeStringToStdString(p_char8 data, v_int32 size, v_int32& errorCode, v_int32& errorPosition);
+  static std::string unescapeStringToStdString(p_char8 data, v_int64 size, v_int64& errorCode, v_int64& errorPosition);
 
   /**
    * Parse string enclosed in `"<string>"`.

--- a/src/oatpp/parser/json/mapping/Deserializer.cpp
+++ b/src/oatpp/parser/json/mapping/Deserializer.cpp
@@ -32,9 +32,9 @@ namespace oatpp { namespace parser { namespace json { namespace mapping {
 void Deserializer::skipScope(oatpp::parser::Caret& caret, v_char8 charOpen, v_char8 charClose){
   
   p_char8 data = caret.getData();
-  v_int32 size = caret.getDataSize();
-  v_int32 pos = caret.getPosition();
-  v_int32 scopeCounter = 0;
+  v_int64 size = caret.getDataSize();
+  v_int64 pos = caret.getPosition();
+  v_int64 scopeCounter = 0;
   
   bool isInString = false;
   
@@ -65,9 +65,9 @@ void Deserializer::skipScope(oatpp::parser::Caret& caret, v_char8 charOpen, v_ch
   
 void Deserializer::skipString(oatpp::parser::Caret& caret){
   p_char8 data = caret.getData();
-  v_int32 size = caret.getDataSize();
-  v_int32 pos = caret.getPosition();
-  v_int32 scopeCounter = 0;
+  v_int64 size = caret.getDataSize();
+  v_int64 pos = caret.getPosition();
+  v_int64 scopeCounter = 0;
   while(pos < size){
     v_char8 a = data[pos];
     if(a == '"'){
@@ -85,8 +85,8 @@ void Deserializer::skipString(oatpp::parser::Caret& caret){
   
 void Deserializer::skipToken(oatpp::parser::Caret& caret){
   p_char8 data = caret.getData();
-  v_int32 size = caret.getDataSize();
-  v_int32 pos = caret.getPosition();
+  v_int64 size = caret.getDataSize();
+  v_int64 pos = caret.getPosition();
   while(pos < size){
     v_char8 a = data[pos];
     if(a == ' ' || a == '\t' || a == '\n' || a == '\r' || a == '\b' || a == '\f' ||

--- a/src/oatpp/parser/json/mapping/Serializer.cpp
+++ b/src/oatpp/parser/json/mapping/Serializer.cpp
@@ -28,7 +28,7 @@
 
 namespace oatpp { namespace parser { namespace json { namespace mapping {
   
-void Serializer::writeString(oatpp::data::stream::ConsistentOutputStream* stream, p_char8 data, v_int32 size) {
+void Serializer::writeString(oatpp::data::stream::ConsistentOutputStream* stream, p_char8 data, v_int64 size) {
   auto encodedValue = Utils::escapeString(data, size, false);
   stream->writeChar('\"');
   stream->write(encodedValue);
@@ -36,7 +36,7 @@ void Serializer::writeString(oatpp::data::stream::ConsistentOutputStream* stream
 }
 
 void Serializer::writeString(oatpp::data::stream::ConsistentOutputStream* stream, const char* data) {
-  writeString(stream, (p_char8)data, (v_int32)std::strlen(data));
+  writeString(stream, (p_char8)data, std::strlen(data));
 }
   
 void Serializer::writeList(oatpp::data::stream::ConsistentOutputStream* stream, const AbstractList::ObjectWrapper& list, const std::shared_ptr<Config>& config) {

--- a/src/oatpp/parser/json/mapping/Serializer.hpp
+++ b/src/oatpp/parser/json/mapping/Serializer.hpp
@@ -97,7 +97,7 @@ public:
   
 private:
   
-  static void writeString(oatpp::data::stream::ConsistentOutputStream* stream, p_char8 data, v_int32 size);
+  static void writeString(oatpp::data::stream::ConsistentOutputStream* stream, p_char8 data, v_int64 size);
   static void writeString(oatpp::data::stream::ConsistentOutputStream* stream, const char* data);
   
   template<class T>

--- a/src/oatpp/web/client/ApiClient.cpp
+++ b/src/oatpp/web/client/ApiClient.cpp
@@ -26,8 +26,8 @@
 
 namespace oatpp { namespace web { namespace client {
 
-ApiClient::PathSegment ApiClient::parsePathSegment(p_char8 data, v_int32 size, v_int32& position) {
-  for(v_int32 i = position; i < size; i++){
+ApiClient::PathSegment ApiClient::parsePathSegment(p_char8 data, v_int64 size, v_int64& position) {
+  for(v_int64 i = position; i < size; i++){
     v_char8 a = data[i];
     if(a == '{'){
       auto result = PathSegment(std::string((char*) &data[position], i - position), PathSegment::SEG_PATH);
@@ -40,8 +40,8 @@ ApiClient::PathSegment ApiClient::parsePathSegment(p_char8 data, v_int32 size, v
   return result;
 }
 
-ApiClient::PathSegment ApiClient::parseVarSegment(p_char8 data, v_int32 size, v_int32& position) {
-  for(v_int32 i = position; i < size; i++){
+ApiClient::PathSegment ApiClient::parseVarSegment(p_char8 data, v_int64 size, v_int64& position) {
+  for(v_int64 i = position; i < size; i++){
     v_char8 a = data[i];
     if(a == '}'){
       auto result = PathSegment(std::string((char*) &data[position], i - position), PathSegment::SEG_VAR);
@@ -54,8 +54,8 @@ ApiClient::PathSegment ApiClient::parseVarSegment(p_char8 data, v_int32 size, v_
   return result;
 }
   
-ApiClient::PathPattern ApiClient::parsePathPattern(p_char8 data, v_int32 size) {
-  v_int32 pos = 0;
+ApiClient::PathPattern ApiClient::parsePathPattern(p_char8 data, v_int64 size) {
+  v_int64 pos = 0;
   PathPattern result;
   while (pos < size) {
     v_char8 a = data[pos];
@@ -78,7 +78,7 @@ void ApiClient::formatPath(oatpp::data::stream::OutputStream* stream,
     if(seg.type == PathSegment::SEG_PATH) {
       stream->write(seg.text.data(), seg.text.size());
     } else {
-      auto key = oatpp::String(seg.text.data(), (v_int32) seg.text.length(), false);
+      auto key = oatpp::String(seg.text.data(), seg.text.length(), false);
       auto& param = params->get(key, oatpp::data::mapping::type::AbstractObjectWrapper::empty());
       if(!param){
         OATPP_LOGD(TAG, "Path parameter '%s' not provided in the api call", seg.text.c_str());

--- a/src/oatpp/web/client/ApiClient.hpp
+++ b/src/oatpp/web/client/ApiClient.hpp
@@ -126,15 +126,15 @@ protected:
   
   class PathSegment {
   public:
-    constexpr static const v_int32 SEG_PATH = 0;
-    constexpr static const v_int32 SEG_VAR = 1;
+    constexpr static const v_int64 SEG_PATH = 0;
+    constexpr static const v_int64 SEG_VAR = 1;
   public:
-    PathSegment(const std::string& pText, v_int32 pType)
+    PathSegment(const std::string& pText, v_int64 pType)
       : text (pText)
       , type (pType)
     {}
     const std::string text;
-    const v_int32 type;
+    const v_int64 type;
   };
   
   typedef std::list<PathSegment> PathPattern;
@@ -152,9 +152,9 @@ private:
   
 protected:
   
-  static PathSegment parsePathSegment(p_char8 data, v_int32 size, v_int32& position);
-  static PathSegment parseVarSegment(p_char8 data, v_int32 size, v_int32& position);
-  static PathPattern parsePathPattern(p_char8 data, v_int32 size);
+  static PathSegment parsePathSegment(p_char8 data, v_int64 size, v_int64& position);
+  static PathSegment parseVarSegment(p_char8 data, v_int64 size, v_int64& position);
+  static PathPattern parsePathPattern(p_char8 data, v_int64 size);
   
 protected:
   std::shared_ptr<RequestExecutor> m_requestExecutor;

--- a/src/oatpp/web/mime/multipart/Multipart.cpp
+++ b/src/oatpp/web/mime/multipart/Multipart.cpp
@@ -94,7 +94,7 @@ const std::list<std::shared_ptr<Part>>& Multipart::getAllParts() {
   return m_parts;
 }
 
-v_int32 Multipart::count() {
+v_int64 Multipart::count() {
   return m_parts.size();
 }
 

--- a/src/oatpp/web/mime/multipart/Multipart.hpp
+++ b/src/oatpp/web/mime/multipart/Multipart.hpp
@@ -101,7 +101,7 @@ public:
    * Get parts count.
    * @return - parts count.
    */
-  v_int32 count();
+  v_int64 count();
 
 };
 

--- a/src/oatpp/web/mime/multipart/StatefulParser.cpp
+++ b/src/oatpp/web/mime/multipart/StatefulParser.cpp
@@ -239,7 +239,7 @@ StatefulParser::ListenerCall StatefulParser::parseNext_Headers(data::stream::Asy
   p_char8 data = (p_char8) inlineData.currBufferPtr;
   auto size = inlineData.bytesLeft;
 
-  for(v_int32 i = 0; i < size; i ++) {
+  for(v_int64 i = 0; i < size; i ++) {
 
     m_headerSectionEndAccumulator <<= 8;
     m_headerSectionEndAccumulator |= data[i];
@@ -309,7 +309,7 @@ StatefulParser::ListenerCall StatefulParser::parseNext_Data(data::stream::AsyncI
 
 }
 
-v_int32 StatefulParser::parseNext(p_char8 data, v_int32 size) {
+v_int64 StatefulParser::parseNext(p_char8 data, v_int64 size) {
 
   data::stream::AsyncInlineWriteData inlineData(data, size);
 

--- a/src/oatpp/web/mime/multipart/StatefulParser.hpp
+++ b/src/oatpp/web/mime/multipart/StatefulParser.hpp
@@ -39,13 +39,13 @@ namespace oatpp { namespace web { namespace mime { namespace multipart {
  */
 class StatefulParser {
 private:
-  static constexpr v_int32 STATE_BOUNDARY = 0;
-  static constexpr v_int32 STATE_AFTER_BOUNDARY = 1;
-  static constexpr v_int32 STATE_HEADERS = 2;
-  static constexpr v_int32 STATE_DATA = 3;
-  static constexpr v_int32 STATE_DONE = 4;
+  static constexpr v_int64 STATE_BOUNDARY = 0;
+  static constexpr v_int64 STATE_AFTER_BOUNDARY = 1;
+  static constexpr v_int64 STATE_HEADERS = 2;
+  static constexpr v_int64 STATE_DATA = 3;
+  static constexpr v_int64 STATE_DONE = 4;
 private:
-  static constexpr v_int32 HEADERS_SECTION_END = ('\r' << 24) | ('\n' << 16) | ('\r' << 8) | ('\n');
+  static constexpr v_int64 HEADERS_SECTION_END = ('\r' << 24) | ('\n' << 16) | ('\r' << 8) | ('\n');
 private:
   /**
    * Typedef for headers map. Headers map key is case-insensitive.
@@ -131,9 +131,9 @@ private:
   class ListenerCall {
   public:
 
-    static constexpr v_int32 CALL_NONE = 0;
-    static constexpr v_int32 CALL_ON_HEADERS = 1;
-    static constexpr v_int32 CALL_ON_DATA = 2;
+    static constexpr v_int64 CALL_NONE = 0;
+    static constexpr v_int64 CALL_ON_HEADERS = 1;
+    static constexpr v_int64 CALL_ON_DATA = 2;
 
   public:
 
@@ -143,7 +143,7 @@ private:
       , size(0)
     {}
 
-    v_int32 callType;
+    v_int64 callType;
     p_char8 data;
     data::v_io_size size;
 
@@ -159,9 +159,9 @@ private:
 
 private:
 
-  v_int32 m_state;
-  v_int32 m_currPartIndex;
-  v_int32 m_currBoundaryCharIndex;
+  v_int64 m_state;
+  v_int64 m_currPartIndex;
+  v_int64 m_currBoundaryCharIndex;
   bool m_checkForBoundary;
   bool m_finishingBoundary;
   bool m_readingBody;
@@ -180,7 +180,7 @@ private:
    * Max length of all headers per one part.
    * Default value = 4096 bytes.
    */
-  v_int32 m_maxPartHeadersSize;
+  v_int64 m_maxPartHeadersSize;
 
   std::shared_ptr<Listener> m_listener;
   std::shared_ptr<AsyncListener> m_asyncListener;
@@ -215,7 +215,7 @@ public:
    * @return - exact number of parsed bytes. <br>
    * returned value may be less than size given.
    */
-  v_int32 parseNext(p_char8 data, v_int32 size);
+  v_int64 parseNext(p_char8 data, v_int64 size);
 
   /**
    * Parse next chunk of bytes in Async-Inline manner.

--- a/src/oatpp/web/protocol/http/Http.cpp
+++ b/src/oatpp/web/protocol/http/Http.cpp
@@ -258,7 +258,7 @@ oatpp::String HeaderValueData::getTitleParamValue(const data::share::StringKeyLa
 oatpp::data::share::StringKeyLabelCI_FAST Parser::parseHeaderNameLabel(const std::shared_ptr<oatpp::base::StrBuffer>& headersText,
                                                                          oatpp::parser::Caret& caret) {
   p_char8 data = caret.getData();
-  for(v_int32 i = caret.getPosition(); i < caret.getDataSize(); i++) {
+  for(v_int64 i = caret.getPosition(); i < caret.getDataSize(); i++) {
     v_char8 a = data[i];
     if(a == ':' || a == ' '){
       oatpp::data::share::StringKeyLabelCI_FAST label(headersText, &data[caret.getPosition()], i - caret.getPosition());
@@ -344,7 +344,7 @@ void Parser::parseOneHeader(Headers& headers,
       return;
     }
     caret.skipChar(' ');
-    v_int32 valuePos0 = caret.getPosition();
+    v_int64 valuePos0 = caret.getPosition();
     caret.findRN();
     headers.put(name, oatpp::data::share::StringKeyLabel(headersText, &caret.getData()[valuePos0], caret.getPosition() - valuePos0));
     caret.skipRN();

--- a/src/oatpp/web/protocol/http/incoming/RequestHeadersReader.cpp
+++ b/src/oatpp/web/protocol/http/incoming/RequestHeadersReader.cpp
@@ -35,7 +35,7 @@ data::v_io_size RequestHeadersReader::readHeadersSection(data::stream::InputStre
   data::v_io_size res;
   while (true) {
     
-    v_int32 desiredToRead = m_readChunkSize;
+    v_int64 desiredToRead = m_readChunkSize;
     if(m_bufferStream->getCurrentPosition() + desiredToRead > m_maxHeadersSize) {
       desiredToRead = m_maxHeadersSize - m_bufferStream->getCurrentPosition();
       if(desiredToRead <= 0) {
@@ -50,7 +50,7 @@ data::v_io_size RequestHeadersReader::readHeadersSection(data::stream::InputStre
 
       m_bufferStream->setCurrentPosition(m_bufferStream->getCurrentPosition() + res);
 
-      for(v_int32 i = 0; i < res; i ++) {
+      for(v_int64 i = 0; i < res; i ++) {
         accumulator <<= 8;
         accumulator |= bufferData[i];
         if(accumulator == SECTION_END) {
@@ -117,7 +117,7 @@ RequestHeadersReader::readHeadersAsync(const std::shared_ptr<data::stream::Input
     
     Action act() override {
       
-      v_int32 desiredToRead = m_this->m_readChunkSize;
+      v_int64 desiredToRead = m_this->m_readChunkSize;
       if(m_this->m_bufferStream->getCurrentPosition() + desiredToRead > m_this->m_maxHeadersSize) {
         desiredToRead = m_this->m_maxHeadersSize - m_this->m_bufferStream->getCurrentPosition();
         if(desiredToRead <= 0) {
@@ -132,7 +132,7 @@ RequestHeadersReader::readHeadersAsync(const std::shared_ptr<data::stream::Input
 
         m_this->m_bufferStream->setCurrentPosition(m_this->m_bufferStream->getCurrentPosition() + res);
         
-        for(v_int32 i = 0; i < res; i ++) {
+        for(v_int64 i = 0; i < res; i ++) {
           m_accumulator <<= 8;
           m_accumulator |= bufferData[i];
           if(m_accumulator == SECTION_END) {

--- a/src/oatpp/web/protocol/http/incoming/ResponseHeadersReader.hpp
+++ b/src/oatpp/web/protocol/http/incoming/ResponseHeadersReader.hpp
@@ -40,7 +40,7 @@ public:
    */
   typedef oatpp::async::Action Action;
 private:
-  static constexpr v_int32 SECTION_END = ('\r' << 24) | ('\n' << 16) | ('\r' << 8) | ('\n');
+  static constexpr v_int64 SECTION_END = ('\r' << 24) | ('\n' << 16) | ('\r' << 8) | ('\n');
 public:
 
   /**
@@ -60,12 +60,12 @@ public:
     /**
      * This value represents starting position in buffer used to read data from stream for the last read operation.
      */
-    v_int32 bufferPosStart;
+    v_int64 bufferPosStart;
 
     /**
      * This value represents end position in buffer used to read data from stream for the last read operation.
      */
-    v_int32 bufferPosEnd;
+    v_int64 bufferPosEnd;
   };
 
 private:
@@ -74,7 +74,7 @@ private:
                                              Result& result);
 private:
   oatpp::data::share::MemoryLabel m_buffer;
-  v_int32 m_maxHeadersSize;
+  v_int64 m_maxHeadersSize;
 public:
 
   /**
@@ -82,7 +82,7 @@ public:
    * @param buffer - buffer to use to read data from stream. &id:oatpp::data::share::MemoryLabel;.
    * @param maxHeadersSize
    */
-  ResponseHeadersReader(const oatpp::data::share::MemoryLabel& buffer, v_int32 maxHeadersSize)
+  ResponseHeadersReader(const oatpp::data::share::MemoryLabel& buffer, v_int64 maxHeadersSize)
     : m_buffer(buffer)
     , m_maxHeadersSize(maxHeadersSize)
   {}

--- a/src/oatpp/web/protocol/http/outgoing/BufferBody.cpp
+++ b/src/oatpp/web/protocol/http/outgoing/BufferBody.cpp
@@ -48,7 +48,7 @@ std::shared_ptr<BufferBody> BufferBody::createShared(const oatpp::String& buffer
 }
 
 void BufferBody::declareHeaders(Headers& headers) noexcept {
-  headers.put(oatpp::web::protocol::http::Header::CONTENT_LENGTH, oatpp::utils::conversion::int32ToStr(m_buffer->getSize()));
+  headers.put(oatpp::web::protocol::http::Header::CONTENT_LENGTH, oatpp::utils::conversion::int64ToStr(m_buffer->getSize()));
 }
 
 void BufferBody::writeToStream(OutputStream* stream) noexcept {

--- a/src/oatpp/web/url/mapping/Pattern.cpp
+++ b/src/oatpp/web/url/mapping/Pattern.cpp
@@ -32,7 +32,7 @@ const char* Pattern::Part::FUNCTION_CONST = "const";
 const char* Pattern::Part::FUNCTION_VAR = "var";
 const char* Pattern::Part::FUNCTION_ANY_END = "tail";
 
-std::shared_ptr<Pattern> Pattern::parse(p_char8 data, v_int32 size){
+std::shared_ptr<Pattern> Pattern::parse(p_char8 data, v_int64 size){
   
   if(size <= 0){
     return nullptr;
@@ -40,8 +40,8 @@ std::shared_ptr<Pattern> Pattern::parse(p_char8 data, v_int32 size){
   
   auto result = Pattern::createShared();
 
-  v_int32 lastPos = 0;
-  v_int32 i = 0;
+  v_int64 lastPos = 0;
+  v_int64 i = 0;
   
   while(i < size){
     
@@ -62,7 +62,7 @@ std::shared_ptr<Pattern> Pattern::parse(p_char8 data, v_int32 size){
         auto part = Part::createShared(Part::FUNCTION_ANY_END, oatpp::String((const char*)&data[lastPos], size - lastPos, true));
         result->m_parts->pushBack(part);
       }else{
-        auto part = Part::createShared(Part::FUNCTION_ANY_END, oatpp::String(0));
+        auto part = Part::createShared(Part::FUNCTION_ANY_END, oatpp::String((v_int64)0));
         result->m_parts->pushBack(part);
       }
       return result;
@@ -78,7 +78,7 @@ std::shared_ptr<Pattern> Pattern::parse(p_char8 data, v_int32 size){
         auto part = Part::createShared(Part::FUNCTION_VAR, oatpp::String((const char*)&data[lastPos], i - lastPos, true));
         result->m_parts->pushBack(part);
       }else{
-        auto part = Part::createShared(Part::FUNCTION_VAR, oatpp::String(0));
+        auto part = Part::createShared(Part::FUNCTION_VAR, oatpp::String((v_int64)0));
         result->m_parts->pushBack(part);
       }
       
@@ -99,7 +99,7 @@ std::shared_ptr<Pattern> Pattern::parse(p_char8 data, v_int32 size){
 }
 
 std::shared_ptr<Pattern> Pattern::parse(const char* data){
-  return parse((p_char8) data, (v_int32) std::strlen(data));
+  return parse((p_char8) data, std::strlen(data));
 }
 
 std::shared_ptr<Pattern> Pattern::parse(const oatpp::String& data){
@@ -108,7 +108,7 @@ std::shared_ptr<Pattern> Pattern::parse(const oatpp::String& data){
   
 v_char8 Pattern::findSysChar(oatpp::parser::Caret& caret) {
   auto data = caret.getData();
-  for (v_int32 i = caret.getPosition(); i < caret.getDataSize(); i++) {
+  for (v_int64 i = caret.getPosition(); i < caret.getDataSize(); i++) {
     v_char8 a = data[i];
     if(a == '/' || a == '?') {
       caret.setPosition(i);

--- a/src/oatpp/web/url/mapping/Pattern.hpp
+++ b/src/oatpp/web/url/mapping/Pattern.hpp
@@ -107,7 +107,7 @@ public:
     return std::make_shared<Pattern>();
   }
   
-  static std::shared_ptr<Pattern> parse(p_char8 data, v_int32 size);
+  static std::shared_ptr<Pattern> parse(p_char8 data, v_int64 size);
   static std::shared_ptr<Pattern> parse(const char* data);
   static std::shared_ptr<Pattern> parse(const oatpp::String& data);
   

--- a/test/oatpp/core/async/LockTest.cpp
+++ b/test/oatpp/core/async/LockTest.cpp
@@ -132,13 +132,13 @@ void testMethod(char symbol, Buff *buff, oatpp::async::Lock *lock) {
 
 }
 
-bool checkSymbol(char symbol, const char* data, v_int32 size) {
+bool checkSymbol(char symbol, const char* data, v_int64 size) {
 
-  for (v_int32 i = 0; i < size; i++) {
+  for (v_int64 i = 0; i < size; i++) {
 
     if (data[i] == symbol && size - i >= NUM_SYMBOLS) {
 
-      for (v_int32 j = 0; j < NUM_SYMBOLS; j++) {
+      for (v_int64 j = 0; j < NUM_SYMBOLS; j++) {
 
         if (data[i + j] != symbol) {
           OATPP_LOGD("aaa", "j pos=%d", j);

--- a/test/oatpp/core/data/stream/BufferStreamTest.cpp
+++ b/test/oatpp/core/data/stream/BufferStreamTest.cpp
@@ -47,7 +47,7 @@ void BufferStreamTest::onRun() {
 
     stream.setCurrentPosition(0);
     stream << (v_float32)101.1;
-    OATPP_ASSERT(stream.toString() == oatpp::utils::conversion::float32ToStr(101.1));
+    OATPP_ASSERT(stream.toString() == oatpp::utils::conversion::float32ToStr(101.1f));
 
     stream.setCurrentPosition(0);
     stream << (v_float64)101.1;
@@ -82,8 +82,8 @@ void BufferStreamTest::onRun() {
     OATPP_ASSERT(stream.toString() == oatpp::utils::conversion::int32ToStr(64));
 
     stream.setCurrentPosition(0);
-    stream << oatpp::Float32(0.32);
-    OATPP_ASSERT(stream.toString() == oatpp::utils::conversion::float32ToStr(0.32));
+    stream << oatpp::Float32(0.32f);
+    OATPP_ASSERT(stream.toString() == oatpp::utils::conversion::float32ToStr(0.32f));
 
     stream.setCurrentPosition(0);
     stream << oatpp::Float64(0.64);

--- a/test/oatpp/core/data/stream/ChunkedBufferTest.cpp
+++ b/test/oatpp/core/data/stream/ChunkedBufferTest.cpp
@@ -47,7 +47,7 @@ void ChunkedBufferTest::onRun() {
 
     stream.clear();
     stream << (v_float32)101.1;
-    OATPP_ASSERT(stream.toString() == oatpp::utils::conversion::float32ToStr(101.1));
+    OATPP_ASSERT(stream.toString() == oatpp::utils::conversion::float32ToStr(101.1f));
 
     stream.clear();
     stream << (v_float64)101.1;
@@ -82,8 +82,8 @@ void ChunkedBufferTest::onRun() {
     OATPP_ASSERT(stream.toString() == oatpp::utils::conversion::int32ToStr(64));
 
     stream.clear();
-    stream << oatpp::Float32(0.32);
-    OATPP_ASSERT(stream.toString() == oatpp::utils::conversion::float32ToStr(0.32));
+    stream << oatpp::Float32(0.32f);
+    OATPP_ASSERT(stream.toString() == oatpp::utils::conversion::float32ToStr(0.32f));
 
     stream.clear();
     stream << oatpp::Float64(0.64);

--- a/test/oatpp/encoding/UnicodeTest.cpp
+++ b/test/oatpp/encoding/UnicodeTest.cpp
@@ -61,12 +61,12 @@ void writeBinaryInt(v_int32 value){
 void UnicodeTest::onRun(){
   
   v_char8 buff[128];
-  v_int32 cnt;
+  v_int64 cnt;
 
   // 2 byte test
   
   for(v_int32 c = 128; c < 2048; c ++){
-    v_int32 size = oatpp::encoding::Unicode::decodeUtf8Char(c, buff);
+    v_int64 size = oatpp::encoding::Unicode::decodeUtf8Char(c, buff);
     OATPP_ASSERT(size == 2);
     v_int32 code = oatpp::encoding::Unicode::encodeUtf8Char(buff, cnt);
     OATPP_ASSERT(cnt == 2);
@@ -76,7 +76,7 @@ void UnicodeTest::onRun(){
   // 3 byte test
   
   for(v_int32 c = 2048; c < 65536; c ++){
-    v_int32 size = oatpp::encoding::Unicode::decodeUtf8Char(c, buff);
+    v_int64 size = oatpp::encoding::Unicode::decodeUtf8Char(c, buff);
     OATPP_ASSERT(size == 3);
     v_int32 code = oatpp::encoding::Unicode::encodeUtf8Char(buff, cnt);
     OATPP_ASSERT(cnt == 3);
@@ -86,7 +86,7 @@ void UnicodeTest::onRun(){
   // 4 byte test
   
   for(v_int32 c = 65536; c < 2097152; c ++){
-    v_int32 size = oatpp::encoding::Unicode::decodeUtf8Char(c, buff);
+    v_int64 size = oatpp::encoding::Unicode::decodeUtf8Char(c, buff);
     OATPP_ASSERT(size == 4);
     v_int32 code = oatpp::encoding::Unicode::encodeUtf8Char(buff, cnt);
     OATPP_ASSERT(cnt == 4);
@@ -96,7 +96,7 @@ void UnicodeTest::onRun(){
   // 5 byte test
   
   for(v_int32 c = 2097152; c < 67108864; c ++){
-    v_int32 size = oatpp::encoding::Unicode::decodeUtf8Char(c, buff);
+    v_int64 size = oatpp::encoding::Unicode::decodeUtf8Char(c, buff);
     OATPP_ASSERT(size == 5);
     v_int32 code = oatpp::encoding::Unicode::encodeUtf8Char(buff, cnt);
     OATPP_ASSERT(cnt == 5);
@@ -106,7 +106,7 @@ void UnicodeTest::onRun(){
   // 6 byte test
   
   for(v_int32 c = 67108864; c < 2147483647; c ++){
-    v_int32 size = oatpp::encoding::Unicode::decodeUtf8Char(c, buff);
+    v_int64 size = oatpp::encoding::Unicode::decodeUtf8Char(c, buff);
     OATPP_ASSERT(size == 6);
     v_int32 code = oatpp::encoding::Unicode::encodeUtf8Char(buff, cnt);
     OATPP_ASSERT(cnt == 6);

--- a/test/oatpp/network/virtual_/PipeTest.cpp
+++ b/test/oatpp/network/virtual_/PipeTest.cpp
@@ -45,12 +45,12 @@ namespace {
   class WriterTask : public oatpp::base::Countable {
   private:
     std::shared_ptr<Pipe> m_pipe;
-    v_int32 m_chunksToTransfer;
+    v_int64 m_chunksToTransfer;
     data::v_io_size m_position = 0;
     data::v_io_size m_transferedBytes = 0;
   public:
     
-    WriterTask(const std::shared_ptr<Pipe>& pipe, v_int32 chunksToTransfer)
+    WriterTask(const std::shared_ptr<Pipe>& pipe, v_int64 chunksToTransfer)
       : m_pipe(pipe)
       , m_chunksToTransfer(chunksToTransfer)
     {}
@@ -75,12 +75,12 @@ namespace {
   private:
     std::shared_ptr<oatpp::data::stream::ChunkedBuffer> m_buffer;
     std::shared_ptr<Pipe> m_pipe;
-    v_int32 m_chunksToTransfer;
+    v_int64 m_chunksToTransfer;
   public:
     
     ReaderTask(const std::shared_ptr<oatpp::data::stream::ChunkedBuffer> &buffer,
                const std::shared_ptr<Pipe>& pipe,
-               v_int32 chunksToTransfer)
+               v_int64 chunksToTransfer)
       : m_buffer(buffer)
       , m_pipe(pipe)
       , m_chunksToTransfer(chunksToTransfer)
@@ -99,7 +99,7 @@ namespace {
     
   };
   
-  void runTransfer(const std::shared_ptr<Pipe>& pipe, v_int32 chunksToTransfer, bool writeNonBlock, bool readerNonBlock) {
+  void runTransfer(const std::shared_ptr<Pipe>& pipe, v_int64 chunksToTransfer, bool writeNonBlock, bool readerNonBlock) {
     
     OATPP_LOGV("transfer", "writer-nb: %d, reader-nb: %d", writeNonBlock, readerNonBlock);
     
@@ -137,7 +137,7 @@ void PipeTest::onRun() {
   
   auto pipe = Pipe::createShared();
 
-  v_int32 chunkCount = oatpp::data::buffer::IOBuffer::BUFFER_SIZE * 10 / CHUNK_SIZE;
+  v_int64 chunkCount = oatpp::data::buffer::IOBuffer::BUFFER_SIZE * 10 / CHUNK_SIZE;
   
   runTransfer(pipe, chunkCount, false, false);
   runTransfer(pipe, chunkCount, true, false);

--- a/test/oatpp/parser/json/mapping/DTOMapperTest.cpp
+++ b/test/oatpp/parser/json/mapping/DTOMapperTest.cpp
@@ -95,7 +95,7 @@ void DTOMapperTest::onRun(){
   test1->field_string = "string value";
   test1->field_int32 = 32;
   test1->field_int64 = 64;
-  test1->field_float32 = 0.32;
+  test1->field_float32 = 0.32f;
   test1->field_float64 = 0.64;
   test1->field_boolean = true;
   
@@ -121,9 +121,9 @@ void DTOMapperTest::onRun(){
   test1->field_list_int64->pushBack(642);
   test1->field_list_int64->pushBack(643);
   
-  test1->field_list_float32->pushBack(0.321);
-  test1->field_list_float32->pushBack(0.322);
-  test1->field_list_float32->pushBack(0.323);
+  test1->field_list_float32->pushBack(0.321f);
+  test1->field_list_float32->pushBack(0.322f);
+  test1->field_list_float32->pushBack(0.323f);
   
   test1->field_list_float64->pushBack(0.641);
   test1->field_list_float64->pushBack(0.642);

--- a/test/oatpp/web/ClientRetryTest.cpp
+++ b/test/oatpp/web/ClientRetryTest.cpp
@@ -247,9 +247,8 @@ void ClientRetryTest::onRun() {
     auto client = app::Client::createShared(requestExecutor, objectMapper);
 
     std::list<std::thread> threads;
-    std::atomic<bool> testIsRunning(true);
 
-    std::thread clientThread([client, &testIsRunning]{
+    std::thread clientThread([client]{
 
       v_int64 counter = 0;
 

--- a/test/oatpp/web/FullTest.cpp
+++ b/test/oatpp/web/FullTest.cpp
@@ -265,7 +265,7 @@ void FullTest::onRun() {
       }
 
       { // test GET with query parameters
-        auto response = client->getWithQueriesMap("value1", 32, 0.32, connection);
+        auto response = client->getWithQueriesMap("value1", 32, 0.32f, connection);
         OATPP_ASSERT(response->getStatusCode() == 200);
         auto dto = response->readBodyToDto<app::TestDto>(objectMapper.get());
         OATPP_ASSERT(dto);
@@ -273,7 +273,7 @@ void FullTest::onRun() {
         OATPP_ASSERT(dto->testMap->count() == 3);
         OATPP_ASSERT(dto->testMap->get("key1", "") == "value1");
         OATPP_ASSERT(dto->testMap->get("key2", "") == "32");
-        OATPP_ASSERT(dto->testMap->get("key3", "") == oatpp::utils::conversion::float32ToStr(0.32));
+        OATPP_ASSERT(dto->testMap->get("key3", "") == oatpp::utils::conversion::float32ToStr(0.32f));
       }
 
       { // test GET with header parameter

--- a/test/oatpp/web/mime/multipart/StatefulParserTest.cpp
+++ b/test/oatpp/web/mime/multipart/StatefulParserTest.cpp
@@ -65,7 +65,7 @@ namespace {
 
     oatpp::data::stream::BufferInputStream stream(text.getPtr(), text->getData(), text->getSize());
     std::unique_ptr<v_char8> buffer(new v_char8[step]);
-    v_int32 size;
+    v_int64 size;
     while((size = stream.read(buffer.get(), step)) != 0) {
       parser.parseNext(buffer.get(), size);
     }
@@ -78,7 +78,7 @@ namespace {
     OATPP_ASSERT(part->getInMemoryData());
     OATPP_ASSERT(part->getInMemoryData() == value);
 
-    v_int32 bufferSize = 16;
+    v_int64 bufferSize = 16;
     std::unique_ptr<v_char8> buffer(new v_char8[bufferSize]);
 
     oatpp::data::stream::ChunkedBuffer stream;


### PR DESCRIPTION
Move String and related data types and sizes to v_int64.

Consistent size everywhere and removes tons of conversion warnings.