### PR TITLE
Builds on UWP

### DIFF
--- a/src/oatpp/encoding/Hex.cpp
+++ b/src/oatpp/encoding/Hex.cpp
@@ -25,7 +25,7 @@
 #include "Hex.hpp"
 
 #if defined(WIN32) || defined(_WIN32)
-#include <Winsock.h>
+#include <Winsock2.h>
 #else
 #include <arpa/inet.h>
 #endif

--- a/src/oatpp/encoding/Unicode.cpp
+++ b/src/oatpp/encoding/Unicode.cpp
@@ -27,7 +27,7 @@
 #include "./Hex.hpp"
 
 #if defined(WIN32) || defined(_WIN32)
-#include <Winsock.h>
+#include <Winsock2.h>
 #else
 #include <arpa/inet.h>
 #endif


### PR DESCRIPTION
Hex.cpp and Unicode.cpp were including winsock.h instead of winsock2.h which caused undefined functions for Universal Windows Platform builds.