### PR TITLE
Use stream::ChunkedBuffer instead of stream::BufferOutputStream for uploads

### DIFF
--- a/src/oatpp/core/data/mapping/ObjectMapper.cpp
+++ b/src/oatpp/core/data/mapping/ObjectMapper.cpp
@@ -24,7 +24,7 @@
 
 #include "ObjectMapper.hpp"
 
-#include "oatpp/core/data/stream/BufferStream.hpp"
+#include "oatpp/core/data/stream/ChunkedBuffer.hpp"
 
 namespace oatpp { namespace data { namespace mapping {
 
@@ -37,7 +37,7 @@ const ObjectMapper::Info& ObjectMapper::getInfo() const {
 }
 
 oatpp::String ObjectMapper::writeToString(const type::AbstractObjectWrapper& variant) const {
-  stream::BufferOutputStream stream;
+  stream::ChunkedBuffer stream;
   write(&stream, variant);
   return stream.toString();
 }

--- a/src/oatpp/parser/json/Beautifier.cpp
+++ b/src/oatpp/parser/json/Beautifier.cpp
@@ -47,7 +47,7 @@ void Beautifier::writeIndent(ConsistentOutputStream* outputStream) {
 
 v_io_size Beautifier::write(const void *data, v_buff_size count, async::Action& action) {
 
-  oatpp::data::stream::BufferOutputStream buffer;
+  oatpp::data::stream::BufferOutputStream buffer(count);
 
   for(v_buff_size i = 0; i < count; i ++) {
 

--- a/src/oatpp/web/protocol/http/incoming/BodyDecoder.cpp
+++ b/src/oatpp/web/protocol/http/incoming/BodyDecoder.cpp
@@ -37,7 +37,7 @@ BodyDecoder::decodeToStringAsync(const Headers& headers, const std::shared_ptr<d
     const BodyDecoder* m_decoder;
     Headers m_headers;
     std::shared_ptr<oatpp::data::stream::InputStream> m_bodyStream;
-    std::shared_ptr<oatpp::data::stream::BufferOutputStream> m_outputStream;
+    std::shared_ptr<oatpp::data::stream::ChunkedBuffer> m_outputStream;
   public:
 
     ToStringDecoder(const BodyDecoder* decoder,
@@ -46,7 +46,7 @@ BodyDecoder::decodeToStringAsync(const Headers& headers, const std::shared_ptr<d
       : m_decoder(decoder)
       , m_headers(headers)
       , m_bodyStream(bodyStream)
-      , m_outputStream(std::make_shared<data::stream::BufferOutputStream>())
+      , m_outputStream(std::make_shared<data::stream::ChunkedBuffer>())
     {}
 
     Action act() override {

--- a/src/oatpp/web/protocol/http/incoming/BodyDecoder.hpp
+++ b/src/oatpp/web/protocol/http/incoming/BodyDecoder.hpp
@@ -27,7 +27,7 @@
 
 #include "oatpp/web/protocol/http/Http.hpp"
 #include "oatpp/core/data/mapping/ObjectMapper.hpp"
-#include "oatpp/core/data/stream/BufferStream.hpp"
+#include "oatpp/core/data/stream/ChunkedBuffer.hpp"
 #include "oatpp/core/async/Coroutine.hpp"
 
 namespace oatpp { namespace web { namespace protocol { namespace http { namespace incoming {
@@ -48,7 +48,7 @@ private:
     Headers m_headers;
     std::shared_ptr<oatpp::data::stream::InputStream> m_bodyStream;
     std::shared_ptr<oatpp::data::mapping::ObjectMapper> m_objectMapper;
-    std::shared_ptr<oatpp::data::stream::BufferOutputStream> m_outputStream;
+    std::shared_ptr<oatpp::data::stream::ChunkedBuffer> m_outputStream;
   public:
     
     ToDtoDecoder(const BodyDecoder* decoder,
@@ -59,7 +59,7 @@ private:
       , m_headers(headers)
       , m_bodyStream(bodyStream)
       , m_objectMapper(objectMapper)
-      , m_outputStream(std::make_shared<oatpp::data::stream::BufferOutputStream>())
+      , m_outputStream(std::make_shared<oatpp::data::stream::ChunkedBuffer>())
     {}
     
     oatpp::async::Action act() override {
@@ -111,7 +111,7 @@ public:
    * @return - &oatpp::String;.
    */
   oatpp::String decodeToString(const Headers& headers, data::stream::InputStream* bodyStream) const {
-    oatpp::data::stream::BufferOutputStream stream;
+    oatpp::data::stream::ChunkedBuffer stream;
     decode(headers, bodyStream, &stream);
     return stream.toString();
   }


### PR DESCRIPTION
Use of `stream::BufferOutputStream` for uploads is inefficient due to excessive memory copy operations during buffer growth, taking too long to upload large files.

Using `stream::ChunkedBuffer` for uploads fixes this problem due to the no-copy buffer growth strategy.

Links:
- https://github.com/oatpp/oatpp/issues/198