### PR TITLE
Show http-method in logRouterMappings

### DIFF
--- a/src/oatpp/web/server/HttpRouter.cpp
+++ b/src/oatpp/web/server/HttpRouter.cpp
@@ -57,7 +57,7 @@ HttpRouter::BranchRouter::Route HttpRouter::getRoute(const StringKeyLabel& metho
 
 void HttpRouter::logRouterMappings() {
   for(auto it : m_branchMap) {
-    it.second->logRouterMappings();
+    it.second->logRouterMappings(it.first);
   }
 }
 

--- a/src/oatpp/web/url/mapping/Router.hpp
+++ b/src/oatpp/web/url/mapping/Router.hpp
@@ -131,11 +131,11 @@ public:
     return Route();
   }
   
-  void logRouterMappings() {
+  void logRouterMappings(const oatpp::data::share::StringKeyLabel &branch) {
 
     for(auto& pair : m_endpointsByPattern) {
       auto mapping = pair.first->toString();
-      OATPP_LOGD("Router", "url '%s' -> mapped", (const char*) mapping->getData());
+      OATPP_LOGD("Router", "url '%s %s' -> mapped", (const char*)branch.getData(), (const char*) mapping->getData());
     }
 
   }


### PR DESCRIPTION
`Router::logRouterMappings` never shows the http-method a URL is mapped for. So when you have multiple methods for one URL, the method will display the URL multiple times. This could confuse users why their URL is shown multiple times ("Have I added the URL twice?", "Do I call `logRouterMappings` multiple times?", etc). Its also not easily visible if all methods are mapped as designed.

This small PR adds the http-method to the output of `logRouterMappings`.