### PR TITLE
Response Description (Issue #212)

### DIFF
--- a/src/oatpp/web/server/api/Endpoint.hpp
+++ b/src/oatpp/web/server/api/Endpoint.hpp
@@ -109,11 +109,12 @@ public:
     };
 
     /**
-     * Info about content type and schema
+     * Hints about the response (content-type, schema, description, ...)
      */
-    struct ContentTypeAndSchema {
+    struct ResponseHints {
       oatpp::String contentType;
       oatpp::data::mapping::type::Type* schema;
+      oatpp::String description;
     };
     
   public:
@@ -182,7 +183,7 @@ public:
     /**
      * Consumes.
      */
-    std::list<ContentTypeAndSchema> consumes;
+    std::list<ResponseHints> consumes;
 
     /**
      * Security Requirements
@@ -208,7 +209,7 @@ public:
      *  ResponseCode to {ContentType, Type} mapping.
      *  Example responses[Status::CODE_200] = {"application/json", MyDto::ObjectWrapper::Class::getType()};
      */
-    std::unordered_map<oatpp::web::protocol::http::Status, ContentTypeAndSchema> responses;
+    std::unordered_map<oatpp::web::protocol::http::Status, ResponseHints> responses;
     
     oatpp::String toString();
 
@@ -227,10 +228,11 @@ public:
      * @tparam T
      * @param status
      * @param contentType
+     * @param responseDescription
      */
     template<class T>
-    void addResponse(const oatpp::web::protocol::http::Status& status, const oatpp::String& contentType) {
-      responses[status] = {contentType, T::Class::getType()};
+    void addResponse(const oatpp::web::protocol::http::Status& status, const oatpp::String& contentType, const oatpp::String& responseDescription = oatpp::String()) {
+      responses[status] = {contentType, T::Class::getType(), responseDescription.get() == nullptr ? status.description : responseDescription};
     }
 
     /**

--- a/test/oatpp/web/server/api/ApiControllerTest.cpp
+++ b/test/oatpp/web/server/api/ApiControllerTest.cpp
@@ -47,7 +47,7 @@ public:
 
   ENDPOINT_INFO(root) {
     info->summary = "root_summary";
-    info->addResponse<String>(Status::CODE_200, "text/plain");
+    info->addResponse<String>(Status::CODE_200, "text/plain", "test1-success");
     info->addResponse<String>(Status::CODE_404, "text/plain");
   }
   ENDPOINT("GET", "/", root) {
@@ -98,9 +98,11 @@ void ApiControllerTest::onRun() {
     auto r200 = endpoint->info()->responses[Status::CODE_200];
     OATPP_ASSERT(r200.contentType == "text/plain");
     OATPP_ASSERT(r200.schema == oatpp::String::Class::getType());
+    OATPP_ASSERT(r200.description == "test1-success");
 
     auto r404 = endpoint->info()->responses[Status::CODE_404];
     OATPP_ASSERT(r404.contentType == "text/plain");
+    OATPP_ASSERT(r404.description == "Not Found");
     OATPP_ASSERT(r404.schema == oatpp::String::Class::getType());
 
     auto response = controller.root();


### PR DESCRIPTION
This PR adds the option to provide an custom response-description in `addResponse` (needed for swagger, see issue #212)