### PR TITLE
Refactor. Remove confusing 'empty()' method of ObjectWrappers.

### DIFF
--- a/src/oatpp/core/data/mapping/type/Primitive.hpp
+++ b/src/oatpp/core/data/mapping/type/Primitive.hpp
@@ -164,6 +164,10 @@ public:
     ObjectWrapper()
       : type::ObjectWrapper<Primitive, Clazz>()
     {}
+
+    ObjectWrapper(std::nullptr_t)
+      : type::ObjectWrapper<Primitive, Clazz>()
+    {}
     
     ObjectWrapper(const std::shared_ptr<Primitive>& ptr)
       : type::ObjectWrapper<Primitive, Clazz>(ptr)
@@ -209,11 +213,6 @@ public:
     
     inline operator ValueType() const {
       return this->get()->getValue();
-    }
-    
-    static const ObjectWrapper& empty(){
-      static ObjectWrapper result;
-      return result;
     }
     
   };

--- a/src/oatpp/core/data/mapping/type/Primitive.hpp
+++ b/src/oatpp/core/data/mapping/type/Primitive.hpp
@@ -65,7 +65,9 @@ public:
 public:
   
   String() {}
-  
+
+  String(std::nullptr_t) {}
+
   String(v_buff_size size)
     : type::ObjectWrapper<oatpp::base::StrBuffer, __class::String>(oatpp::base::StrBuffer::createShared(size))
   {}
@@ -111,11 +113,6 @@ public:
   String& operator = (String&& other){
     m_ptr = std::forward<std::shared_ptr<oatpp::base::StrBuffer>>(other.m_ptr);
     return *this;
-  }
-  
-  static const String& empty(){
-    static String empty;
-    return empty;
   }
   
   bool operator==(const String &other) const {

--- a/src/oatpp/core/data/mapping/type/Type.hpp
+++ b/src/oatpp/core/data/mapping/type/Type.hpp
@@ -128,6 +128,10 @@ public:
   PolymorphicWrapper()
     : valueType(Class::getType())
   {}
+
+  PolymorphicWrapper(std::nullptr_t)
+    : valueType(Class::getType())
+  {}
   
   PolymorphicWrapper(const Type* const type)
     : valueType(type)
@@ -142,10 +146,6 @@ public:
     : m_ptr(std::move(other.m_ptr))
     , valueType(other.valueType)
   {}
-  
-  static PolymorphicWrapper empty(){
-    return PolymorphicWrapper();
-  }
   
   PolymorphicWrapper& operator=(const PolymorphicWrapper<T>& other){
     m_ptr = other.m_ptr;
@@ -233,9 +233,9 @@ public:
     : PolymorphicWrapper<T>(Class::getType())
   {}
   
-  ObjectWrapper(std::nullptr_t nullptrt)
-    : PolymorphicWrapper<T>(nullptr, Class::getType())
-  {(void)nullptrt;}
+  ObjectWrapper(std::nullptr_t)
+    : PolymorphicWrapper<T>(Class::getType())
+  {}
   
   ObjectWrapper(const std::shared_ptr<T>& ptr)
     : PolymorphicWrapper<T>(ptr, Class::getType())
@@ -248,10 +248,6 @@ public:
   ObjectWrapper(PolymorphicWrapper<T>&& other)
     : PolymorphicWrapper<T>(std::move(other.getPtr()), Class::getType())
   {}
-  
-  static ObjectWrapper empty(){
-    return ObjectWrapper();
-  }
   
   ObjectWrapper& operator=(const PolymorphicWrapper<T>& other){
     if(this->valueType != other.valueType){

--- a/src/oatpp/core/utils/ConversionUtils.cpp
+++ b/src/oatpp/core/utils/ConversionUtils.cpp
@@ -98,7 +98,7 @@ namespace oatpp { namespace utils { namespace conversion {
     if(size > 0){
       return oatpp::String((const char*)&buff[0], size, true);
     }
-    return oatpp::String::empty();
+    return nullptr;
   }
 
   oatpp::String uint32ToStr(v_uint32 value){
@@ -107,7 +107,7 @@ namespace oatpp { namespace utils { namespace conversion {
     if(size > 0){
       return oatpp::String((const char*)&buff[0], size, true);
     }
-    return oatpp::String::empty();
+    return nullptr;
   }
   
   oatpp::String int64ToStr(v_int64 value){
@@ -116,7 +116,7 @@ namespace oatpp { namespace utils { namespace conversion {
     if(size > 0){
       return oatpp::String((const char*)&buff[0], size, true);
     }
-    return oatpp::String::empty();
+    return nullptr;
   }
 
   oatpp::String uint64ToStr(v_uint64 value){
@@ -125,7 +125,7 @@ namespace oatpp { namespace utils { namespace conversion {
     if(size > 0){
       return oatpp::String((const char*)&buff[0], size, true);
     }
-    return oatpp::String::empty();
+    return nullptr;
   }
   
   std::string int32ToStdStr(v_int32 value){
@@ -202,7 +202,7 @@ v_buff_size float64ToCharSequence(v_float64 value, p_char8 data, v_buff_size n) 
     if(size > 0){
       return oatpp::String((const char*)&buff[0], size, true);
     }
-    return oatpp::String::empty();
+    return nullptr;
   }
   
   oatpp::String float64ToStr(v_float64 value){
@@ -211,7 +211,7 @@ v_buff_size float64ToCharSequence(v_float64 value, p_char8 data, v_buff_size n) 
     if(size > 0){
       return oatpp::String((const char*)&buff[0], size, true);
     }
-    return oatpp::String::empty();
+    return nullptr;
   }
   
   oatpp::String boolToStr(bool value) {

--- a/src/oatpp/core/utils/ConversionUtils.hpp
+++ b/src/oatpp/core/utils/ConversionUtils.hpp
@@ -216,7 +216,7 @@ namespace oatpp { namespace utils { namespace conversion {
     if(size > 0){
       return oatpp::String((const char*)&buff[0], size, true);
     }
-    return oatpp::String::empty();
+    return nullptr;
   }
 
   /**

--- a/src/oatpp/parser/json/mapping/Deserializer.cpp
+++ b/src/oatpp/parser/json/mapping/Deserializer.cpp
@@ -242,7 +242,7 @@ data::mapping::type::AbstractObjectWrapper Deserializer::deserializeList(Deseria
       caret.skipBlankChars();
       auto item = deserializer->deserialize(caret, itemType);
       if(caret.hasError()){
-        return AbstractObjectWrapper::empty();
+        return nullptr;
       }
 
       list->addPolymorphicItem(item);
@@ -256,13 +256,13 @@ data::mapping::type::AbstractObjectWrapper Deserializer::deserializeList(Deseria
       if(!caret.hasError()){
         caret.setError("[oatpp::parser::json::mapping::Deserializer::readList()]: Error. ']' - expected", ERROR_CODE_ARRAY_SCOPE_CLOSE);
       }
-      return AbstractObjectWrapper::empty();
+      return nullptr;
     };
 
     return AbstractObjectWrapper(list.getPtr(), list.valueType);
   } else {
     caret.setError("[oatpp::parser::json::mapping::Deserializer::readList()]: Error. '[' - expected", ERROR_CODE_ARRAY_SCOPE_OPEN);
-    return AbstractObjectWrapper::empty();
+    return nullptr;
   }
 
 }
@@ -296,13 +296,13 @@ data::mapping::type::AbstractObjectWrapper Deserializer::deserializeFieldsMap(De
       caret.skipBlankChars();
       auto key = Utils::parseString(caret);
       if(caret.hasError()){
-        return AbstractObjectWrapper::empty();
+        return nullptr;
       }
 
       caret.skipBlankChars();
       if(!caret.canContinueAtChar(':', 1)){
         caret.setError("[oatpp::parser::json::mapping::Deserializer::readListMap()]: Error. ':' - expected", ERROR_CODE_OBJECT_SCOPE_COLON_MISSING);
-        return AbstractObjectWrapper::empty();
+        return nullptr;
       }
 
       caret.skipBlankChars();
@@ -318,7 +318,7 @@ data::mapping::type::AbstractObjectWrapper Deserializer::deserializeFieldsMap(De
       if(!caret.hasError()){
         caret.setError("[oatpp::parser::json::mapping::Deserializer::readListMap()]: Error. '}' - expected", ERROR_CODE_OBJECT_SCOPE_CLOSE);
       }
-      return AbstractObjectWrapper::empty();
+      return nullptr;
     }
 
     return AbstractObjectWrapper(map.getPtr(), map.valueType);
@@ -327,7 +327,7 @@ data::mapping::type::AbstractObjectWrapper Deserializer::deserializeFieldsMap(De
     caret.setError("[oatpp::parser::json::mapping::Deserializer::readListMap()]: Error. '{' - expected", ERROR_CODE_OBJECT_SCOPE_OPEN);
   }
 
-  return AbstractObjectWrapper::empty();
+  return nullptr;
 
 }
 
@@ -352,7 +352,7 @@ data::mapping::type::AbstractObjectWrapper Deserializer::deserializeObject(Deser
       caret.skipBlankChars();
       auto key = Utils::parseStringToStdString(caret);
       if(caret.hasError()){
-        return AbstractObjectWrapper::empty();
+        return nullptr;
       }
 
       auto fieldIterator = fieldsMap.find(key);
@@ -361,7 +361,7 @@ data::mapping::type::AbstractObjectWrapper Deserializer::deserializeObject(Deser
         caret.skipBlankChars();
         if(!caret.canContinueAtChar(':', 1)){
           caret.setError("[oatpp::parser::json::mapping::Deserializer::readObject()]: Error. ':' - expected", ERROR_CODE_OBJECT_SCOPE_COLON_MISSING);
-          return AbstractObjectWrapper::empty();
+          return nullptr;
         }
 
         caret.skipBlankChars();
@@ -373,13 +373,13 @@ data::mapping::type::AbstractObjectWrapper Deserializer::deserializeObject(Deser
         caret.skipBlankChars();
         if(!caret.canContinueAtChar(':', 1)){
           caret.setError("[oatpp::parser::json::mapping::Deserializer::readObject()/if(config->allowUnknownFields){}]: Error. ':' - expected", ERROR_CODE_OBJECT_SCOPE_COLON_MISSING);
-          return AbstractObjectWrapper::empty();
+          return nullptr;
         }
         caret.skipBlankChars();
         skipValue(caret);
       } else {
         caret.setError("[oatpp::parser::json::mapping::Deserializer::readObject()]: Error. Unknown field", ERROR_CODE_OBJECT_SCOPE_UNKNOWN_FIELD);
-        return AbstractObjectWrapper::empty();
+        return nullptr;
       }
 
       caret.skipBlankChars();
@@ -391,7 +391,7 @@ data::mapping::type::AbstractObjectWrapper Deserializer::deserializeObject(Deser
       if(!caret.hasError()){
         caret.setError("[oatpp::parser::json::mapping::Deserializer::readObject()]: Error. '}' - expected", ERROR_CODE_OBJECT_SCOPE_CLOSE);
       }
-      return AbstractObjectWrapper::empty();
+      return nullptr;
     }
 
     return object;
@@ -400,7 +400,7 @@ data::mapping::type::AbstractObjectWrapper Deserializer::deserializeObject(Deser
     caret.setError("[oatpp::parser::json::mapping::Deserializer::readObject()]: Error. '{' - expected", ERROR_CODE_OBJECT_SCOPE_OPEN);
   }
 
-  return AbstractObjectWrapper::empty();
+  return nullptr;
 
 }
 

--- a/src/oatpp/web/client/ApiClient.cpp
+++ b/src/oatpp/web/client/ApiClient.cpp
@@ -81,7 +81,7 @@ void ApiClient::formatPath(oatpp::data::stream::ConsistentOutputStream* stream,
       stream->writeSimple(seg.text.data(), seg.text.size());
     } else {
       auto key = oatpp::String(seg.text.data(), seg.text.length(), false);
-      auto& param = params->get(key, oatpp::String::empty());
+      auto& param = params->get(key, nullptr);
       if(!param){
         OATPP_LOGD(TAG, "Path parameter '%s' not provided in the api call", seg.text.c_str());
         throw std::runtime_error("[oatpp::web::client::ApiClient]: Path parameter missing");


### PR DESCRIPTION
### Background

Users were confused by `oatpp::String::empty()` method which was returning just empty string instead of checking string for being empty.

---

The new `oatpp::String::empty()` method, which does the check of the string being empty 
**should NOT be introduced** in a couple of next releases - in order to NOT introduce unexpected behavior in the user's code.