### PR TITLE
types. Simplify Primitives.

### DIFF
--- a/src/oatpp/core/data/mapping/type/PairList.hpp
+++ b/src/oatpp/core/data/mapping/type/PairList.hpp
@@ -73,6 +73,12 @@ OATPP_DEFINE_OBJECT_WRAPPER_DEFAULTS(PairListObjectWrapper, TemplateObjectType, 
     this->m_ptr = std::make_shared<TemplateObjectType>(ilist);
     return *this;
   }
+
+  std::pair<Key, Value>& operator[] (v_buff_usize index) const {
+    auto it = this->m_ptr->begin();
+    std::advance(it, index);
+    return *it;
+  }
   
   Value& operator[] (const Key& key) const {
     auto& list = *(this->m_ptr.get());

--- a/src/oatpp/core/data/mapping/type/Primitive.hpp
+++ b/src/oatpp/core/data/mapping/type/Primitive.hpp
@@ -131,10 +131,10 @@ public:
   }
 
   bool operator == (const char* str) const {
-    if(!m_ptr) {
-      return str = nullptr;
-    }
-    return base::StrBuffer::equals(m_ptr.get()->getData(), str, m_ptr.get()->getSize());
+    if(!m_ptr) return str == nullptr;
+    if(str == nullptr) return false;
+    if(m_ptr->getSize() != std::strlen(str)) return false;
+    return base::StrBuffer::equals(m_ptr->getData(), str, m_ptr->getSize());
   }
 
   bool operator != (const char* str) const {

--- a/src/oatpp/core/data/mapping/type/Primitive.hpp
+++ b/src/oatpp/core/data/mapping/type/Primitive.hpp
@@ -226,20 +226,18 @@ public:
     return this->m_ptr.operator*();
   }
 
-  inline bool operator == (std::nullptr_t){
-    return m_ptr.get() == nullptr;
-  }
-
-  inline bool operator != (std::nullptr_t){
-    return m_ptr.get() != nullptr;
-  }
-
-  bool operator == (bool value) const {
+  template<typename T,
+    typename enabled = typename std::enable_if<std::is_same<T, bool>::value, void>::type
+  >
+  bool operator == (T value) const {
     if(!this->m_ptr) return false;
     return *this->m_ptr == value;
   }
 
-  bool operator != (bool value) const {
+  template<typename T,
+    typename enabled = typename std::enable_if<std::is_same<T, bool>::value, void>::type
+  >
+  bool operator != (T value) const {
     if(!this->m_ptr) return true;
     return *this->m_ptr != value;
   }

--- a/src/oatpp/core/data/mapping/type/Primitive.hpp
+++ b/src/oatpp/core/data/mapping/type/Primitive.hpp
@@ -227,6 +227,20 @@ public:
   }
 
   template<typename T,
+    typename enabled = typename std::enable_if<std::is_same<T, std::nullptr_t>::value, void>::type
+  >
+  inline bool operator == (T){
+    return m_ptr.get() == nullptr;
+  }
+
+  template<typename T,
+    typename enabled = typename std::enable_if<std::is_same<T, std::nullptr_t>::value, void>::type
+  >
+  inline bool operator != (T){
+    return m_ptr.get() != nullptr;
+  }
+
+  template<typename T,
     typename enabled = typename std::enable_if<std::is_same<T, bool>::value, void>::type
   >
   bool operator == (T value) const {

--- a/src/oatpp/core/data/mapping/type/Primitive.hpp
+++ b/src/oatpp/core/data/mapping/type/Primitive.hpp
@@ -473,6 +473,150 @@ namespace std {
     }
     
   };
+
+  template<>
+  struct hash<oatpp::data::mapping::type::Boolean> {
+
+    typedef oatpp::data::mapping::type::Boolean argument_type;
+    typedef v_uint8 result_type;
+
+    result_type operator()(argument_type const& v) const noexcept {
+      if(v.get() == nullptr) return 2;
+      return result_type(*v);
+    }
+
+  };
+
+  template<>
+  struct hash<oatpp::data::mapping::type::Int8> {
+
+    typedef oatpp::data::mapping::type::Int8 argument_type;
+    typedef v_uint8 result_type;
+
+    result_type operator()(argument_type const& v) const noexcept {
+      if(v.get() == nullptr) return 0;
+      return (result_type) *v;
+    }
+
+  };
+
+  template<>
+  struct hash<oatpp::data::mapping::type::UInt8> {
+
+    typedef oatpp::data::mapping::type::UInt8 argument_type;
+    typedef v_uint8 result_type;
+
+    result_type operator()(argument_type const& v) const noexcept {
+      if(v.get() == nullptr) return 0;
+      return (result_type) *v;
+    }
+
+  };
+
+  template<>
+  struct hash<oatpp::data::mapping::type::Int16> {
+
+    typedef oatpp::data::mapping::type::Int16 argument_type;
+    typedef v_uint16 result_type;
+
+    result_type operator()(argument_type const& v) const noexcept {
+      if(v.get() == nullptr) return 0;
+      return (result_type) *v;
+    }
+
+  };
+
+  template<>
+  struct hash<oatpp::data::mapping::type::UInt16> {
+
+    typedef oatpp::data::mapping::type::UInt16 argument_type;
+    typedef v_uint16 result_type;
+
+    result_type operator()(argument_type const& v) const noexcept {
+      if(v.get() == nullptr) return 0;
+      return (result_type) *v;
+    }
+
+  };
+
+  template<>
+  struct hash<oatpp::data::mapping::type::Int32> {
+
+    typedef oatpp::data::mapping::type::Int32 argument_type;
+    typedef v_uint32 result_type;
+
+    result_type operator()(argument_type const& v) const noexcept {
+      if(v.get() == nullptr) return 0;
+      return (result_type) *v;
+    }
+
+  };
+
+  template<>
+  struct hash<oatpp::data::mapping::type::UInt32> {
+
+    typedef oatpp::data::mapping::type::UInt32 argument_type;
+    typedef v_uint32 result_type;
+
+    result_type operator()(argument_type const& v) const noexcept {
+      if(v.get() == nullptr) return 0;
+      return (result_type) *v;
+    }
+
+  };
+
+  template<>
+  struct hash<oatpp::data::mapping::type::Int64> {
+
+    typedef oatpp::data::mapping::type::Int64 argument_type;
+    typedef v_uint64 result_type;
+
+    result_type operator()(argument_type const& v) const noexcept {
+      if(v.get() == nullptr) return 0;
+      return (result_type) *v;
+    }
+
+  };
+
+  template<>
+  struct hash<oatpp::data::mapping::type::UInt64> {
+
+    typedef oatpp::data::mapping::type::UInt64 argument_type;
+    typedef v_uint64 result_type;
+
+    result_type operator()(argument_type const& v) const noexcept {
+      if(v.get() == nullptr) return 0;
+      return (result_type) *v;
+    }
+
+  };
+
+  template<>
+  struct hash<oatpp::data::mapping::type::Float32> {
+
+    typedef oatpp::data::mapping::type::Float32 argument_type;
+    typedef v_uint32 result_type;
+
+    result_type operator()(argument_type const& v) const noexcept {
+      if(v.get() == nullptr) return 0;
+      return *((result_type*) v.get());
+    }
+
+  };
+
+  template<>
+  struct hash<oatpp::data::mapping::type::Float64> {
+
+    typedef oatpp::data::mapping::type::Float64 argument_type;
+    typedef v_uint64 result_type;
+
+    result_type operator()(argument_type const& v) const noexcept {
+      if(v.get() == nullptr) return 0;
+      return *((result_type*) v.get());
+    }
+
+  };
+
 }
 
 #endif /* oatpp_base_Countable_PrimitiveDataTypes_hpp */

--- a/src/oatpp/core/data/mapping/type/Primitive.hpp
+++ b/src/oatpp/core/data/mapping/type/Primitive.hpp
@@ -165,205 +165,100 @@ String operator + (const String& a, const String& b);
  * @tparam Clazz - Class holding static class information.
  */
 template<typename TValueType, class Clazz>
-class Primitive : public base::Countable {
-public:
-  typedef TValueType ValueType;
-public:
-  OBJECT_POOL(Primitive_Type_Pool, Primitive, 32)
-  SHARED_OBJECT_POOL(Shared_Primitive_Type_Pool, Primitive, 32)
+class Primitive : public type::ObjectWrapper<TValueType, Clazz>  {
 public:
 
-  /**
-   * ObjectWrapper template for &l:Primitive;.
-   */
-  class ObjectWrapper : public type::ObjectWrapper<Primitive, Clazz> {
-  public:
-    typedef ObjectWrapper __Wrapper;
-  public:
-    ObjectWrapper(const std::shared_ptr<Primitive>& ptr, const type::Type* const valueType)
-      : type::ObjectWrapper<Primitive, Clazz>(ptr)
-    {
-      if(Clazz::getType() != valueType){
-        throw std::runtime_error("Value type does not match");
-      }
-    }
-  public:
-    
-    ObjectWrapper()
-      : type::ObjectWrapper<Primitive, Clazz>()
-    {}
+  OATPP_DEFINE_OBJECT_WRAPPER_DEFAULTS(Primitive, TValueType, Clazz)
 
-    ObjectWrapper(std::nullptr_t)
-      : type::ObjectWrapper<Primitive, Clazz>()
-    {}
-    
-    ObjectWrapper(const std::shared_ptr<Primitive>& ptr)
-      : type::ObjectWrapper<Primitive, Clazz>(ptr)
-    {}
-    
-    ObjectWrapper(std::shared_ptr<Primitive>&& ptr)
-      : type::ObjectWrapper<Primitive, Clazz>(std::forward<std::shared_ptr<Primitive>>(ptr))
-    {}
-    
-    ObjectWrapper(const ObjectWrapper& other)
-      : type::ObjectWrapper<Primitive, Clazz>(other)
-    {}
-    
-    ObjectWrapper(ObjectWrapper&& other)
-      : type::ObjectWrapper<Primitive, Clazz>(std::forward<ObjectWrapper>(other))
-    {}
-    
-    ObjectWrapper(const ValueType& value)
-      : type::ObjectWrapper<Primitive, Clazz>(Primitive::createShared(value))
-    {}
-
-    ObjectWrapper& operator = (std::nullptr_t) {
-      this->m_ptr.reset();
-      return *this;
-    }
-
-    ObjectWrapper& operator = (const ValueType& value) {
-      if(!this->m_ptr){
-        this->m_ptr = Primitive::createShared(value);
-      } else {
-        this->m_ptr.get()->setValue(value);
-      }
-      return *this;
-    }
-    
-    ObjectWrapper& operator = (const ObjectWrapper& other) {
-      this->m_ptr = other.m_ptr;
-      return *this;
-    }
-
-    ObjectWrapper& operator = (const ObjectWrapper&& other) {
-      this->m_ptr = std::move(other.m_ptr);
-      return *this;
-    }
-    
-    bool operator == (const ObjectWrapper &other) const {
-      if(!this->m_ptr) return other.m_ptr.get() == nullptr;
-      if(!this->m_ptr || !other.m_ptr) return false;
-      return this->m_ptr->getValue() == other->getValue();
-    }
-    
-    bool operator != (const ObjectWrapper &other) const {
-      return !operator == (other);
-    }
-
-    inline operator ValueType() const {
-      if(!this->m_ptr) {
-        throw std::runtime_error("[oatpp::data::mapping::type::Primitive::ObjectWrapper::operator ValueType()]: Error. Primitive object is null.");
-      }
-      return this->get()->getValue();
-    }
-    
-  };
-  
-private:
-  
-  ValueType m_value;
-  
-public:
-  /**
-   * Constructor.
-   * @param value - initial value.
-   */
-  Primitive(const ValueType& value)
-    : m_value(value)
+  Primitive(TValueType value)
+    : type::ObjectWrapper<TValueType, Clazz>(std::make_shared<TValueType>(value))
   {}
-public:
 
-  /**
-   * Create shared primitive.
-   * @param value - initial value.
-   * @return - `std::shared_ptr` to Primitive.
-   */
-  static std::shared_ptr<Primitive> createShared(const ValueType& value){
-    return Shared_Primitive_Type_Pool::allocateShared(value);
+  Primitive& operator = (TValueType value) {
+    this->m_ptr = std::make_shared<TValueType>(value);
+    return *this;
   }
 
-  /**
-   * Create shared primitive upcasted to &id:oatpp::base::Countable;.
-   * @param value - initial value.
-   * @return - `std::shared_ptr` to primitive upcasted to &id:oatpp::base::Countable;.
-   */
-  static std::shared_ptr<Countable> createAbstract(const ValueType& value){
-    return std::static_pointer_cast<Countable>(Shared_Primitive_Type_Pool::allocateShared(value));
+  TValueType operator*() const {
+    return this->m_ptr.operator*();
   }
 
-  /**
-   * Set value.
-   * @param value.
-   */
-  void setValue(const ValueType& value) {
-    m_value = value;
+  bool operator == (TValueType value) const {
+    if(!this->m_ptr) return false;
+    return *this->m_ptr == value;
   }
 
-  /**
-   * Get value.
-   * @return - value.
-   */
-  ValueType getValue() {
-    return m_value;
+  bool operator != (TValueType value) const {
+    if(!this->m_ptr) return true;
+    return *this->m_ptr != value;
+  }
+
+  bool operator == (const Primitive &other) const {
+    if(this->m_ptr.get() == other.m_ptr.get()) return true;
+    if(!this->m_ptr || !other.m_ptr) return false;
+    return *this->m_ptr == *other.m_ptr;
+  }
+
+  bool operator != (const Primitive &other) const {
+    return !operator == (other);
   }
   
 };
 
 /**
- * Int8 is an ObjectWrapper over &l:Primitive; and __class::Int8.
+ * Int8 is an ObjectWrapper over `v_int8` and __class::Int8.
  */
-typedef Primitive<v_int8, __class::Int8>::ObjectWrapper Int8;
+typedef Primitive<v_int8, __class::Int8> Int8;
 
 /**
- * UInt8 is an ObjectWrapper over &l:Primitive; and __class::UInt8.
+ * UInt8 is an ObjectWrapper over `v_uint8` and __class::UInt8.
  */
-typedef Primitive<v_uint8, __class::UInt8>::ObjectWrapper UInt8;
+typedef Primitive<v_uint8, __class::UInt8> UInt8;
 
 /**
- * Int16 is an ObjectWrapper over &l:Primitive; and __class::Int16.
+ * Int16 is an ObjectWrapper over `v_int16` and __class::Int16.
  */
-typedef Primitive<v_int16, __class::Int16>::ObjectWrapper Int16;
+typedef Primitive<v_int16, __class::Int16> Int16;
 
 /**
- * UInt16 is an ObjectWrapper over &l:Primitive; and __class::UInt16.
+ * UInt16 is an ObjectWrapper over `v_uint16` and __class::UInt16.
  */
-typedef Primitive<v_uint16, __class::UInt16>::ObjectWrapper UInt16;
+typedef Primitive<v_uint16, __class::UInt16> UInt16;
 
 /**
- * Int32 is an ObjectWrapper over &l:Primitive; and __class::Int32.
+ * Int32 is an ObjectWrapper over `v_int32` and __class::Int32.
  */
-typedef Primitive<v_int32, __class::Int32>::ObjectWrapper Int32;
+typedef Primitive<v_int32, __class::Int32> Int32;
 
 /**
- * UInt32 is an ObjectWrapper over &l:Primitive; and __class::UInt32.
+ * UInt32 is an ObjectWrapper over `v_uint32` and __class::UInt32.
  */
-typedef Primitive<v_uint32, __class::UInt32>::ObjectWrapper UInt32;
+typedef Primitive<v_uint32, __class::UInt32> UInt32;
 
 /**
- * Int64 is an ObjectWrapper over &l:Primitive; and __class::Int64.
+ * Int64 is an ObjectWrapper over `v_int64` and __class::Int64.
  */
-typedef Primitive<v_int64, __class::Int64>::ObjectWrapper Int64;
+typedef Primitive<v_int64, __class::Int64> Int64;
 
 /**
- * UInt64 is an ObjectWrapper over &l:Primitive; and __class::UInt64.
+ * UInt64 is an ObjectWrapper over `v_uint64` and __class::UInt64.
  */
-typedef Primitive<v_uint64, __class::UInt64>::ObjectWrapper UInt64;
+typedef Primitive<v_uint64, __class::UInt64> UInt64;
 
 /**
- * Float32 is an ObjectWrapper over &l:Primitive; and __class::Float32.
+ * Float32 is an ObjectWrapper over `v_float32` and __class::Float32.
  */
-typedef Primitive<v_float32, __class::Float32>::ObjectWrapper Float32;
+typedef Primitive<v_float32, __class::Float32> Float32;
 
 /**
- * Float64 is an ObjectWrapper over &l:Primitive; and __class::Float64.
+ * Float64 is an ObjectWrapper over `v_float64` and __class::Float64.
  */
-typedef Primitive<v_float64, __class::Float64>::ObjectWrapper Float64;
+typedef Primitive<v_float64, __class::Float64> Float64;
 
 /**
- * Boolean is an ObjectWrapper over &l:Primitive; and __class::Boolean.
+ * Boolean is an ObjectWrapper over `bool` and __class::Boolean.
  */
-typedef Primitive<bool, __class::Boolean>::ObjectWrapper Boolean;
+typedef Primitive<bool, __class::Boolean> Boolean;
   
 namespace __class {
   

--- a/src/oatpp/core/data/mapping/type/Primitive.hpp
+++ b/src/oatpp/core/data/mapping/type/Primitive.hpp
@@ -206,6 +206,64 @@ public:
 };
 
 /**
+ * ObjectWrapper for Boolean.
+ */
+class Boolean : public type::ObjectWrapper<bool, __class::Boolean>  {
+public:
+
+  OATPP_DEFINE_OBJECT_WRAPPER_DEFAULTS(Boolean, bool, __class::Boolean)
+
+  Boolean(bool value)
+    : type::ObjectWrapper<bool, __class::Boolean>(std::make_shared<bool>(value))
+  {}
+
+  Boolean& operator = (bool value) {
+    this->m_ptr = std::make_shared<bool>(value);
+    return *this;
+  }
+
+  bool operator*() const {
+    return this->m_ptr.operator*();
+  }
+
+  inline bool operator == (std::nullptr_t){
+    return m_ptr.get() == nullptr;
+  }
+
+  inline bool operator != (std::nullptr_t){
+    return m_ptr.get() != nullptr;
+  }
+
+  bool operator == (bool value) const {
+    if(!this->m_ptr) return false;
+    return *this->m_ptr == value;
+  }
+
+  bool operator != (bool value) const {
+    if(!this->m_ptr) return true;
+    return *this->m_ptr != value;
+  }
+
+  bool operator == (const Boolean &other) const {
+    if(this->m_ptr.get() == other.m_ptr.get()) return true;
+    if(!this->m_ptr || !other.m_ptr) return false;
+    return *this->m_ptr == *other.m_ptr;
+  }
+
+  bool operator != (const Boolean &other) const {
+    return !operator == (other);
+  }
+
+  explicit operator bool() const {
+    if(this->m_ptr) {
+      return *(this->m_ptr);
+    }
+    return false;
+  }
+
+};
+
+/**
  * Int8 is an ObjectWrapper over `v_int8` and __class::Int8.
  */
 typedef Primitive<v_int8, __class::Int8> Int8;
@@ -254,11 +312,6 @@ typedef Primitive<v_float32, __class::Float32> Float32;
  * Float64 is an ObjectWrapper over `v_float64` and __class::Float64.
  */
 typedef Primitive<v_float64, __class::Float64> Float64;
-
-/**
- * Boolean is an ObjectWrapper over `bool` and __class::Boolean.
- */
-typedef Primitive<bool, __class::Boolean> Boolean;
   
 namespace __class {
   

--- a/src/oatpp/core/data/mapping/type/UnorderedMap.hpp
+++ b/src/oatpp/core/data/mapping/type/UnorderedMap.hpp
@@ -107,7 +107,7 @@ namespace __class {
         const auto& map = object.staticCast<type::UnorderedMap<Key, Value>>();
         const auto& k = key.staticCast<Key>();
         const auto& v = value.staticCast<Value>();
-        map->insert({k, v});
+        map[k] = v;
       }
 
     };

--- a/src/oatpp/core/data/stream/Stream.cpp
+++ b/src/oatpp/core/data/stream/Stream.cpp
@@ -438,7 +438,7 @@ ConsistentOutputStream& operator << (ConsistentOutputStream& s, const oatpp::Str
 
 ConsistentOutputStream& operator << (ConsistentOutputStream& s, const Int8& value) {
   if(value.getPtr()) {
-    return operator << (s, value->getValue());
+    return operator << (s, *value);
   }
   s.writeSimple("[<Int8(null)>]");
   return s;
@@ -446,7 +446,7 @@ ConsistentOutputStream& operator << (ConsistentOutputStream& s, const Int8& valu
 
 ConsistentOutputStream& operator << (ConsistentOutputStream& s, const UInt8& value) {
   if(value.getPtr()) {
-    return operator << (s, value->getValue());
+    return operator << (s, *value);
   }
   s.writeSimple("[<UInt8(null)>]");
   return s;
@@ -454,7 +454,7 @@ ConsistentOutputStream& operator << (ConsistentOutputStream& s, const UInt8& val
 
 ConsistentOutputStream& operator << (ConsistentOutputStream& s, const Int16& value) {
   if(value.getPtr()) {
-    return operator << (s, value->getValue());
+    return operator << (s, *value);
   }
   s.writeSimple("[<Int16(null)>]");
   return s;
@@ -462,7 +462,7 @@ ConsistentOutputStream& operator << (ConsistentOutputStream& s, const Int16& val
 
 ConsistentOutputStream& operator << (ConsistentOutputStream& s, const UInt16& value) {
   if(value.getPtr()) {
-    return operator << (s, value->getValue());
+    return operator << (s, *value);
   }
   s.writeSimple("[<UInt16(null)>]");
   return s;
@@ -470,7 +470,7 @@ ConsistentOutputStream& operator << (ConsistentOutputStream& s, const UInt16& va
 
 ConsistentOutputStream& operator << (ConsistentOutputStream& s, const Int32& value) {
   if(value.getPtr()) {
-    return operator << (s, value->getValue());
+    return operator << (s, *value);
   }
   s.writeSimple("[<Int32(null)>]");
   return s;
@@ -478,7 +478,7 @@ ConsistentOutputStream& operator << (ConsistentOutputStream& s, const Int32& val
 
 ConsistentOutputStream& operator << (ConsistentOutputStream& s, const UInt32& value) {
   if(value.getPtr()) {
-    return operator << (s, value->getValue());
+    return operator << (s, *value);
   }
   s.writeSimple("[<UInt32(null)>]");
   return s;
@@ -486,7 +486,7 @@ ConsistentOutputStream& operator << (ConsistentOutputStream& s, const UInt32& va
 
 ConsistentOutputStream& operator << (ConsistentOutputStream& s, const Int64& value) {
   if(value.getPtr()) {
-    return operator << (s, value->getValue());
+    return operator << (s, *value);
   }
   s.writeSimple("[<Int64(null)>]");
   return s;
@@ -494,7 +494,7 @@ ConsistentOutputStream& operator << (ConsistentOutputStream& s, const Int64& val
 
 ConsistentOutputStream& operator << (ConsistentOutputStream& s, const UInt64& value) {
   if(value.getPtr()) {
-    return operator << (s, value->getValue());
+    return operator << (s, *value);
   }
   s.writeSimple("[<UInt64(null)>]");
   return s;
@@ -502,7 +502,7 @@ ConsistentOutputStream& operator << (ConsistentOutputStream& s, const UInt64& va
 
 ConsistentOutputStream& operator << (ConsistentOutputStream& s, const Float32& value) {
   if(value.getPtr()) {
-    return operator << (s, value->getValue());
+    return operator << (s, *value);
   }
   s.writeSimple("[<Float32(null)>]");
   return s;
@@ -510,7 +510,7 @@ ConsistentOutputStream& operator << (ConsistentOutputStream& s, const Float32& v
 
 ConsistentOutputStream& operator << (ConsistentOutputStream& s, const Float64& value) {
   if(value.getPtr()) {
-    return operator << (s, value->getValue());
+    return operator << (s, *value);
   }
   s.writeSimple("[<Float64(null)>]");
   return s;
@@ -518,7 +518,7 @@ ConsistentOutputStream& operator << (ConsistentOutputStream& s, const Float64& v
 
 ConsistentOutputStream& operator << (ConsistentOutputStream& s, const Boolean& value) {
   if(value.getPtr()) { // use getPtr() here to avoid false to nullptr conversion
-    return operator << (s, value->getValue());
+    return operator << (s, *value);
   }
   s.writeSimple("[<Boolean(null)>]");
   return s;

--- a/src/oatpp/parser/json/mapping/Deserializer.cpp
+++ b/src/oatpp/parser/json/mapping/Deserializer.cpp
@@ -161,7 +161,7 @@ oatpp::Void Deserializer::deserializeFloat32(Deserializer* deserializer, parser:
   if(caret.isAtText("null", true)){
     return oatpp::Void(Float32::ObjectWrapper::Class::getType());
   } else {
-    return oatpp::Void(Float32::ObjectType::createAbstract(caret.parseFloat32()), Float32::ObjectWrapper::Class::getType());
+    return Float32(caret.parseFloat32());
   }
 }
 
@@ -173,7 +173,7 @@ oatpp::Void Deserializer::deserializeFloat64(Deserializer* deserializer, parser:
   if(caret.isAtText("null", true)){
     return oatpp::Void(Float64::ObjectWrapper::Class::getType());
   } else {
-    return oatpp::Void(Float64::ObjectType::createAbstract(caret.parseFloat64()), Float64::ObjectWrapper::Class::getType());
+    return Float64(caret.parseFloat64());
   }
 
 }
@@ -187,9 +187,9 @@ oatpp::Void Deserializer::deserializeBoolean(Deserializer* deserializer, parser:
     return oatpp::Void(Boolean::ObjectWrapper::Class::getType());
   } else {
     if(caret.isAtText("true", true)) {
-      return oatpp::Void(Boolean::ObjectType::createAbstract(true), Boolean::ObjectWrapper::Class::getType());
+      return Boolean(true);
     } else if(caret.isAtText("false", true)) {
-      return oatpp::Void(Boolean::ObjectType::createAbstract(false), Boolean::ObjectWrapper::Class::getType());
+      return Boolean(false);
     } else {
       caret.setError("[oatpp::parser::json::mapping::Deserializer::readBooleanValue()]: Error. 'true' or 'false' - expected.", ERROR_CODE_VALUE_BOOLEAN);
       return oatpp::Void(Boolean::ObjectWrapper::Class::getType());

--- a/src/oatpp/parser/json/mapping/Deserializer.hpp
+++ b/src/oatpp/parser/json/mapping/Deserializer.hpp
@@ -137,7 +137,7 @@ private:
     if(caret.isAtText("null", true)){
       return oatpp::Void(T::Class::getType());
     } else {
-      return oatpp::Void(T::ObjectType::createAbstract((typename T::ObjectType::ValueType) caret.parseInt()), T::ObjectWrapper::Class::getType());
+      return T(caret.parseInt());
     }
 
   }
@@ -151,7 +151,7 @@ private:
     if(caret.isAtText("null", true)){
       return oatpp::Void(T::Class::getType());
     } else {
-      return oatpp::Void(T::ObjectType::createAbstract((typename T::ObjectType::ValueType) caret.parseUnsignedInt()), T::ObjectWrapper::Class::getType());
+      return T(caret.parseUnsignedInt());
     }
 
   }

--- a/src/oatpp/parser/json/mapping/Serializer.hpp
+++ b/src/oatpp/parser/json/mapping/Serializer.hpp
@@ -115,7 +115,7 @@ private:
     (void) serializer;
 
     if(polymorph){
-      stream->writeAsString(static_cast<typename T::ObjectType*>(polymorph.get())->getValue());
+      stream->writeAsString(* static_cast<typename T::ObjectType*>(polymorph.get()));
     } else {
       stream->writeSimple("null", 4);
     }

--- a/src/oatpp/web/client/ApiClient.hpp
+++ b/src/oatpp/web/client/ApiClient.hpp
@@ -232,7 +232,7 @@ template<>
 inline oatpp::String ApiClient::convertParameterToString(const oatpp::String& typeName, const oatpp::Int8& parameter) {
   (void) typeName;
   if(parameter) {
-    return utils::conversion::int32ToStr(parameter->getValue());
+    return utils::conversion::int32ToStr(*parameter);
   }
   return "nullptr";
 }
@@ -241,7 +241,7 @@ template<>
 inline oatpp::String ApiClient::convertParameterToString(const oatpp::String& typeName, const oatpp::UInt8& parameter) {
   (void) typeName;
   if(parameter) {
-    return utils::conversion::uint32ToStr(parameter->getValue());
+    return utils::conversion::uint32ToStr(*parameter);
   }
   return "nullptr";
 }
@@ -250,7 +250,7 @@ template<>
 inline oatpp::String ApiClient::convertParameterToString(const oatpp::String& typeName, const oatpp::Int16& parameter) {
   (void) typeName;
   if(parameter) {
-    return utils::conversion::int32ToStr(parameter->getValue());
+    return utils::conversion::int32ToStr(*parameter);
   }
   return "nullptr";
 }
@@ -259,7 +259,7 @@ template<>
 inline oatpp::String ApiClient::convertParameterToString(const oatpp::String& typeName, const oatpp::UInt16& parameter) {
   (void) typeName;
   if(parameter) {
-    return utils::conversion::uint32ToStr(parameter->getValue());
+    return utils::conversion::uint32ToStr(*parameter);
   }
   return "nullptr";
 }
@@ -268,7 +268,7 @@ template<>
 inline oatpp::String ApiClient::convertParameterToString(const oatpp::String& typeName, const oatpp::Int32& parameter) {
   (void) typeName;
   if(parameter) {
-    return utils::conversion::int32ToStr(parameter->getValue());
+    return utils::conversion::int32ToStr(*parameter);
   }
   return "nullptr";
 }
@@ -277,7 +277,7 @@ template<>
 inline oatpp::String ApiClient::convertParameterToString(const oatpp::String& typeName, const oatpp::UInt32& parameter) {
   (void) typeName;
   if(parameter) {
-    return utils::conversion::uint32ToStr(parameter->getValue());
+    return utils::conversion::uint32ToStr(*parameter);
   }
   return "nullptr";
 }
@@ -286,7 +286,7 @@ template<>
 inline oatpp::String ApiClient::convertParameterToString(const oatpp::String& typeName, const oatpp::Int64& parameter) {
   (void) typeName;
   if(parameter) {
-    return utils::conversion::int64ToStr(parameter->getValue());
+    return utils::conversion::int64ToStr(*parameter);
   }
   return "nullptr";
 }
@@ -295,7 +295,7 @@ template<>
 inline oatpp::String ApiClient::convertParameterToString(const oatpp::String& typeName, const oatpp::UInt64& parameter) {
   (void) typeName;
   if(parameter) {
-    return utils::conversion::uint64ToStr(parameter->getValue());
+    return utils::conversion::uint64ToStr(*parameter);
   }
   return "nullptr";
 }
@@ -304,7 +304,7 @@ template<>
 inline oatpp::String ApiClient::convertParameterToString(const oatpp::String& typeName, const oatpp::Float32& parameter) {
   (void) typeName;
   if(parameter) {
-    return utils::conversion::float32ToStr(parameter->getValue());
+    return utils::conversion::float32ToStr(*parameter);
   }
   return "nullptr";
 }
@@ -313,7 +313,7 @@ template<>
 inline oatpp::String ApiClient::convertParameterToString(const oatpp::String& typeName, const oatpp::Float64& parameter) {
   (void) typeName;
   if(parameter) {
-    return utils::conversion::float64ToStr(parameter->getValue());
+    return utils::conversion::float64ToStr(*parameter);
   }
   return "nullptr";
 }
@@ -322,7 +322,7 @@ template<>
 inline oatpp::String ApiClient::convertParameterToString(const oatpp::String& typeName, const oatpp::Boolean& parameter) {
   (void) typeName;
   if(parameter) {
-    return utils::conversion::boolToStr(parameter->getValue());
+    return utils::conversion::boolToStr(*parameter);
   }
   return "nullptr";
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,10 +15,22 @@ add_executable(oatppAllTests
         oatpp/core/data/buffer/ProcessorTest.hpp
         oatpp/core/data/mapping/type/AnyTest.cpp
         oatpp/core/data/mapping/type/AnyTest.hpp
+        oatpp/core/data/mapping/type/ListTest.cpp
+        oatpp/core/data/mapping/type/ListTest.hpp
         oatpp/core/data/mapping/type/ObjectWrapperTest.cpp
         oatpp/core/data/mapping/type/ObjectWrapperTest.hpp
+        oatpp/core/data/mapping/type/PairListTest.cpp
+        oatpp/core/data/mapping/type/PairListTest.hpp
+        oatpp/core/data/mapping/type/PrimitiveTest.cpp
+        oatpp/core/data/mapping/type/PrimitiveTest.hpp
+        oatpp/core/data/mapping/type/StringTest.cpp
+        oatpp/core/data/mapping/type/StringTest.hpp
         oatpp/core/data/mapping/type/TypeTest.cpp
         oatpp/core/data/mapping/type/TypeTest.hpp
+        oatpp/core/data/mapping/type/UnorderedMapTest.cpp
+        oatpp/core/data/mapping/type/UnorderedMapTest.hpp
+        oatpp/core/data/mapping/type/VectorTest.cpp
+        oatpp/core/data/mapping/type/VectorTest.hpp
         oatpp/core/data/share/LazyStringMapTest.cpp
         oatpp/core/data/share/LazyStringMapTest.hpp
         oatpp/core/data/share/MemoryLabelTest.cpp

--- a/test/oatpp/AllTestsMain.cpp
+++ b/test/oatpp/AllTestsMain.cpp
@@ -38,6 +38,12 @@
 
 #include "oatpp/core/parser/CaretTest.hpp"
 
+#include "oatpp/core/data/mapping/type/UnorderedMapTest.hpp"
+#include "oatpp/core/data/mapping/type/PairListTest.hpp"
+#include "oatpp/core/data/mapping/type/VectorTest.hpp"
+#include "oatpp/core/data/mapping/type/ListTest.hpp"
+#include "oatpp/core/data/mapping/type/StringTest.hpp"
+#include "oatpp/core/data/mapping/type/PrimitiveTest.hpp"
 #include "oatpp/core/data/mapping/type/ObjectWrapperTest.hpp"
 #include "oatpp/core/data/mapping/type/TypeTest.hpp"
 #include "oatpp/core/data/mapping/type/AnyTest.hpp"
@@ -65,7 +71,9 @@ void runTests() {
 
   OATPP_LOGD("aaa", "coroutine size=%d", sizeof(oatpp::async::AbstractCoroutine));
   OATPP_LOGD("aaa", "action size=%d", sizeof(oatpp::async::Action));
-  
+
+/*
+
   OATPP_RUN_TEST(oatpp::test::base::CommandLineArgumentsTest);
 
   OATPP_RUN_TEST(oatpp::test::memory::MemoryPoolTest);
@@ -81,12 +89,18 @@ void runTests() {
 
   OATPP_RUN_TEST(oatpp::test::core::data::stream::ChunkedBufferTest);
   OATPP_RUN_TEST(oatpp::test::core::data::stream::BufferStreamTest);
-
+*/
   OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::ObjectWrapperTest);
-
   OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::TypeTest);
   OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::AnyTest);
+  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::StringTest);
+  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::PrimitiveTest);
+  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::ListTest);
+  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::VectorTest);
+  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::PairListTest);
+  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::UnorderedMapTest);
 
+/*
   OATPP_RUN_TEST(oatpp::test::async::LockTest);
 
   OATPP_RUN_TEST(oatpp::test::parser::CaretTest);
@@ -173,7 +187,7 @@ void runTests() {
     test_port.run();
 
   }
-
+*/
 }
 
 }

--- a/test/oatpp/AllTestsMain.cpp
+++ b/test/oatpp/AllTestsMain.cpp
@@ -71,7 +71,7 @@ void runTests() {
 
   OATPP_LOGD("aaa", "coroutine size=%d", sizeof(oatpp::async::AbstractCoroutine));
   OATPP_LOGD("aaa", "action size=%d", sizeof(oatpp::async::Action));
-/*
+
   OATPP_RUN_TEST(oatpp::test::base::CommandLineArgumentsTest);
 
   OATPP_RUN_TEST(oatpp::test::memory::MemoryPoolTest);
@@ -87,7 +87,7 @@ void runTests() {
 
   OATPP_RUN_TEST(oatpp::test::core::data::stream::ChunkedBufferTest);
   OATPP_RUN_TEST(oatpp::test::core::data::stream::BufferStreamTest);
-*/
+
   OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::ObjectWrapperTest);
   OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::TypeTest);
   OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::AnyTest);
@@ -97,7 +97,7 @@ void runTests() {
   OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::VectorTest);
   OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::PairListTest);
   OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::UnorderedMapTest);
-/*
+
   OATPP_RUN_TEST(oatpp::test::async::LockTest);
 
   OATPP_RUN_TEST(oatpp::test::parser::CaretTest);
@@ -184,7 +184,7 @@ void runTests() {
     test_port.run();
 
   }
-*/
+
 }
 
 }

--- a/test/oatpp/AllTestsMain.cpp
+++ b/test/oatpp/AllTestsMain.cpp
@@ -71,9 +71,7 @@ void runTests() {
 
   OATPP_LOGD("aaa", "coroutine size=%d", sizeof(oatpp::async::AbstractCoroutine));
   OATPP_LOGD("aaa", "action size=%d", sizeof(oatpp::async::Action));
-
 /*
-
   OATPP_RUN_TEST(oatpp::test::base::CommandLineArgumentsTest);
 
   OATPP_RUN_TEST(oatpp::test::memory::MemoryPoolTest);
@@ -90,16 +88,15 @@ void runTests() {
   OATPP_RUN_TEST(oatpp::test::core::data::stream::ChunkedBufferTest);
   OATPP_RUN_TEST(oatpp::test::core::data::stream::BufferStreamTest);
 */
-//  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::ObjectWrapperTest);
-//  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::TypeTest);
-//  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::AnyTest);
+  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::ObjectWrapperTest);
+  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::TypeTest);
+  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::AnyTest);
   OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::StringTest);
   OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::PrimitiveTest);
-//  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::ListTest);
-//  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::VectorTest);
-//  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::PairListTest);
-//  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::UnorderedMapTest);
-
+  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::ListTest);
+  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::VectorTest);
+  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::PairListTest);
+  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::UnorderedMapTest);
 /*
   OATPP_RUN_TEST(oatpp::test::async::LockTest);
 

--- a/test/oatpp/AllTestsMain.cpp
+++ b/test/oatpp/AllTestsMain.cpp
@@ -90,15 +90,15 @@ void runTests() {
   OATPP_RUN_TEST(oatpp::test::core::data::stream::ChunkedBufferTest);
   OATPP_RUN_TEST(oatpp::test::core::data::stream::BufferStreamTest);
 */
-  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::ObjectWrapperTest);
-  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::TypeTest);
-  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::AnyTest);
+//  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::ObjectWrapperTest);
+//  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::TypeTest);
+//  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::AnyTest);
   OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::StringTest);
   OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::PrimitiveTest);
-  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::ListTest);
-  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::VectorTest);
-  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::PairListTest);
-  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::UnorderedMapTest);
+//  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::ListTest);
+//  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::VectorTest);
+//  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::PairListTest);
+//  OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::UnorderedMapTest);
 
 /*
   OATPP_RUN_TEST(oatpp::test::async::LockTest);

--- a/test/oatpp/core/data/mapping/type/ListTest.cpp
+++ b/test/oatpp/core/data/mapping/type/ListTest.cpp
@@ -1,0 +1,160 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#include "ListTest.hpp"
+
+#include "oatpp/core/Types.hpp"
+
+namespace oatpp { namespace test { namespace core { namespace data { namespace mapping { namespace  type {
+
+void ListTest::onRun() {
+
+  {
+    OATPP_LOGI(TAG, "test default constructor...");
+    oatpp::List<oatpp::String> list;
+
+    OATPP_ASSERT(!list);
+    OATPP_ASSERT(list == nullptr);
+
+    OATPP_ASSERT(list.get() == nullptr);
+    OATPP_ASSERT(list.valueType->classId.id == oatpp::data::mapping::type::__class::AbstractList::CLASS_ID.id);
+    OATPP_ASSERT(list.valueType->params.size() == 1);
+    OATPP_ASSERT(list.valueType->params.front() == oatpp::String::Class::getType());
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test empty ilist constructor...");
+    oatpp::List<oatpp::String> list({});
+
+    OATPP_ASSERT(list);
+    OATPP_ASSERT(list != nullptr);
+    OATPP_ASSERT(list->size() == 0);
+
+    OATPP_ASSERT(list.get() != nullptr);
+    OATPP_ASSERT(list.valueType->classId.id == oatpp::data::mapping::type::__class::AbstractList::CLASS_ID.id);
+    OATPP_ASSERT(list.valueType->params.size() == 1);
+    OATPP_ASSERT(list.valueType->params.front() == oatpp::String::Class::getType());
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test createShared()...");
+    oatpp::List<oatpp::String> list = oatpp::List<oatpp::String>::createShared();
+
+    OATPP_ASSERT(list);
+    OATPP_ASSERT(list != nullptr);
+    OATPP_ASSERT(list->size() == 0);
+
+    OATPP_ASSERT(list.get() != nullptr);
+    OATPP_ASSERT(list.valueType->classId.id == oatpp::data::mapping::type::__class::AbstractList::CLASS_ID.id);
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test copy-assignment operator...");
+    oatpp::List<oatpp::String> list1({});
+    oatpp::List<oatpp::String> list2;
+
+    list2 = list1;
+
+    OATPP_ASSERT(list1);
+    OATPP_ASSERT(list2);
+
+    OATPP_ASSERT(list1->size() == 0);
+    OATPP_ASSERT(list2->size() == 0);
+
+    OATPP_ASSERT(list1.get() == list2.get());
+
+    list2->push_back("a");
+
+    OATPP_ASSERT(list1->size() == 1);
+    OATPP_ASSERT(list2->size() == 1);
+
+    list2 = {"b", "c"};
+
+    OATPP_ASSERT(list1->size() == 1);
+    OATPP_ASSERT(list2->size() == 2);
+
+    OATPP_ASSERT(list2[0] == "b");
+    OATPP_ASSERT(list2[1] == "c");
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test move-assignment operator...");
+    oatpp::List<oatpp::String> list1({});
+    oatpp::List<oatpp::String> list2;
+
+    list2 = std::move(list1);
+
+    OATPP_ASSERT(!list1);
+    OATPP_ASSERT(list2);
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test get element by index...");
+    oatpp::List<oatpp::String> list = {"a", "b", "c"};
+
+    OATPP_ASSERT(list);
+    OATPP_ASSERT(list != nullptr);
+    OATPP_ASSERT(list->size() == 3);
+
+    OATPP_ASSERT(list[0] == "a");
+    OATPP_ASSERT(list[1] == "b");
+    OATPP_ASSERT(list[2] == "c");
+
+    list[1] = "Hello!";
+
+    OATPP_ASSERT(list->size() == 3);
+
+    OATPP_ASSERT(list[0] == "a");
+    OATPP_ASSERT(list[1] == "Hello!");
+    OATPP_ASSERT(list[2] == "c");
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test polymorphicDispatcher...");
+    oatpp::List<oatpp::String> list = {"a", "b", "c"};
+
+    auto polymorphicDispatcher = static_cast<const typename oatpp::List<oatpp::String>::Class::AbstractPolymorphicDispatcher*>(
+      list.valueType->polymorphicDispatcher
+    );
+
+    polymorphicDispatcher->addPolymorphicItem(list, oatpp::String("d"));
+
+    OATPP_ASSERT(list->size() == 4);
+
+    OATPP_ASSERT(list[0] == "a");
+    OATPP_ASSERT(list[1] == "b");
+    OATPP_ASSERT(list[2] == "c");
+    OATPP_ASSERT(list[3] == "d");
+    OATPP_LOGI(TAG, "OK");
+  }
+
+}
+
+}}}}}}

--- a/test/oatpp/core/data/mapping/type/ListTest.hpp
+++ b/test/oatpp/core/data/mapping/type/ListTest.hpp
@@ -1,0 +1,42 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#ifndef oatpp_test_core_data_mapping_type_ListTest_hpp
+#define oatpp_test_core_data_mapping_type_ListTest_hpp
+
+#include "oatpp-test/UnitTest.hpp"
+
+namespace oatpp { namespace test { namespace core { namespace data { namespace mapping { namespace  type {
+
+class ListTest : public UnitTest{
+public:
+
+  ListTest():UnitTest("TEST[core::data::mapping::type::ListTest]"){}
+  void onRun() override;
+
+};
+
+}}}}}}
+
+#endif /* oatpp_test_core_data_mapping_type_ListTest_hpp */

--- a/test/oatpp/core/data/mapping/type/PairListTest.cpp
+++ b/test/oatpp/core/data/mapping/type/PairListTest.cpp
@@ -1,0 +1,164 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#include "PairListTest.hpp"
+
+#include "oatpp/core/Types.hpp"
+
+namespace oatpp { namespace test { namespace core { namespace data { namespace mapping { namespace  type {
+
+void PairListTest::onRun() {
+
+  {
+    OATPP_LOGI(TAG, "test default constructor...");
+    oatpp::Fields<String> map;
+
+    OATPP_ASSERT(!map);
+    OATPP_ASSERT(map == nullptr);
+
+    OATPP_ASSERT(map.get() == nullptr);
+    OATPP_ASSERT(map.valueType->classId.id == oatpp::data::mapping::type::__class::AbstractPairList::CLASS_ID.id);
+    OATPP_ASSERT(map.valueType->params.size() == 2);
+    auto it = map.valueType->params.begin();
+    OATPP_ASSERT(*it++ == oatpp::String::Class::getType());
+    OATPP_ASSERT(*it++ == oatpp::String::Class::getType());
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test empty ilist constructor...");
+    oatpp::Fields<String> map({});
+
+    OATPP_ASSERT(map);
+    OATPP_ASSERT(map != nullptr);
+    OATPP_ASSERT(map->size() == 0);
+
+    OATPP_ASSERT(map.get() != nullptr);
+    OATPP_ASSERT(map.valueType->classId.id == oatpp::data::mapping::type::__class::AbstractPairList::CLASS_ID.id);
+    OATPP_ASSERT(map.valueType->params.size() == 2);
+    auto it = map.valueType->params.begin();
+    OATPP_ASSERT(*it++ == oatpp::String::Class::getType());
+    OATPP_ASSERT(*it++ == oatpp::String::Class::getType());
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test createShared()...");
+    oatpp::Fields<String> map = oatpp::Fields<String>::createShared();
+
+    OATPP_ASSERT(map);
+    OATPP_ASSERT(map != nullptr);
+    OATPP_ASSERT(map->size() == 0);
+
+    OATPP_ASSERT(map.get() != nullptr);
+    OATPP_ASSERT(map.valueType->classId.id == oatpp::data::mapping::type::__class::AbstractPairList::CLASS_ID.id);
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test copy-assignment operator...");
+    oatpp::Fields<String> map1({});
+    oatpp::Fields<String> map2;
+
+    map2 = map1;
+
+    OATPP_ASSERT(map1);
+    OATPP_ASSERT(map2);
+
+    OATPP_ASSERT(map1->size() == 0);
+    OATPP_ASSERT(map2->size() == 0);
+
+    OATPP_ASSERT(map1.get() == map2.get());
+
+    map2->push_back({"key", "a"});
+
+    OATPP_ASSERT(map1->size() == 1);
+    OATPP_ASSERT(map2->size() == 1);
+
+    map2 = {{"key1", "b"}, {"key2", "c"}};
+
+    OATPP_ASSERT(map1->size() == 1);
+    OATPP_ASSERT(map2->size() == 2);
+
+    OATPP_ASSERT(map2["key1"] == "b");
+    OATPP_ASSERT(map2["key2"] == "c");
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test move-assignment operator...");
+    oatpp::Fields<String> map1({});
+    oatpp::Fields<String> map2;
+
+    map2 = std::move(map1);
+
+    OATPP_ASSERT(!map1);
+    OATPP_ASSERT(map2);
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test get element by index...");
+    oatpp::Fields<String> map = {{"key1", "a"}, {"key2", "b"}, {"key3", "c"}};
+
+    OATPP_ASSERT(map);
+    OATPP_ASSERT(map != nullptr);
+    OATPP_ASSERT(map->size() == 3);
+
+    OATPP_ASSERT(map["key1"] == "a");
+    OATPP_ASSERT(map["key2"] == "b");
+    OATPP_ASSERT(map["key3"] == "c");
+
+    map["key2"] = "Hello!";
+
+    OATPP_ASSERT(map->size() == 3);
+
+    OATPP_ASSERT(map["key1"] == "a");
+    OATPP_ASSERT(map["key2"] == "Hello!");
+    OATPP_ASSERT(map["key3"] == "c");
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test polymorphicDispatcher...");
+    oatpp::Fields<String> map = {{"key1", "a"}, {"key2", "b"}, {"key3", "c"}};
+
+    auto polymorphicDispatcher = static_cast<const typename oatpp::Fields<String>::Class::AbstractPolymorphicDispatcher*>(
+      map.valueType->polymorphicDispatcher
+    );
+
+    polymorphicDispatcher->addPolymorphicItem(map, oatpp::String("key1"), oatpp::String("d"));
+
+    OATPP_ASSERT(map->size() == 4);
+
+    OATPP_ASSERT(map[0].first == "key1" && map[0].second == "a");
+    OATPP_ASSERT(map[1].first == "key2" && map[1].second == "b");
+    OATPP_ASSERT(map[2].first == "key3" && map[2].second == "c");
+    OATPP_ASSERT(map[3].first == "key1" && map[3].second == "d");
+    OATPP_LOGI(TAG, "OK");
+  }
+
+}
+
+}}}}}}

--- a/test/oatpp/core/data/mapping/type/PairListTest.hpp
+++ b/test/oatpp/core/data/mapping/type/PairListTest.hpp
@@ -1,0 +1,42 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#ifndef oatpp_test_core_data_mapping_type_PairListTest_hpp
+#define oatpp_test_core_data_mapping_type_PairListTest_hpp
+
+#include "oatpp-test/UnitTest.hpp"
+
+namespace oatpp { namespace test { namespace core { namespace data { namespace mapping { namespace  type {
+
+class PairListTest : public UnitTest{
+public:
+
+  PairListTest():UnitTest("TEST[core::data::mapping::type::PairListTest]"){}
+  void onRun() override;
+
+};
+
+}}}}}}
+
+#endif /* oatpp_test_core_data_mapping_type_PairListTest_hpp */

--- a/test/oatpp/core/data/mapping/type/PrimitiveTest.cpp
+++ b/test/oatpp/core/data/mapping/type/PrimitiveTest.cpp
@@ -32,7 +32,8 @@ namespace {
 
   template<class T>
   void checkHash(const T& val) {
-    std::hash<T>{}(val);
+    auto h = std::hash<T>{}(val);
+    OATPP_LOGI("HASH", "type='%s', hash=%llu", val.valueType->classId.name, h);
   }
 
 }
@@ -40,8 +41,17 @@ namespace {
 void PrimitiveTest::onRun() {
 
   {
-    //checkHash(oatpp::Int8(8));
-    //checkHash(oatpp::UInt8(8));
+    checkHash(oatpp::Boolean(true));
+    checkHash(oatpp::Int8(0xFF));
+    checkHash(oatpp::UInt8(0xFF));
+    checkHash(oatpp::Int16(0xFFFF));
+    checkHash(oatpp::UInt16(0xFFFF));
+    checkHash(oatpp::Int32(0xFFFFFFFF));
+    checkHash(oatpp::UInt32(0xFFFFFFFF));
+    checkHash(oatpp::Int64(0xFFFFFFFFFFFFFFFF));
+    checkHash(oatpp::UInt64(0xFFFFFFFFFFFFFFFF));
+    checkHash(oatpp::Float32(0.2));
+    checkHash(oatpp::Float64(0.2));
   }
 
   {

--- a/test/oatpp/core/data/mapping/type/PrimitiveTest.cpp
+++ b/test/oatpp/core/data/mapping/type/PrimitiveTest.cpp
@@ -28,7 +28,193 @@
 
 namespace oatpp { namespace test { namespace core { namespace data { namespace mapping { namespace  type {
 
+namespace {
+
+  template<class T>
+  void checkHash(const T& val) {
+    std::hash<T>{}(val);
+  }
+
+}
+
 void PrimitiveTest::onRun() {
+
+  {
+    //checkHash(oatpp::Int8(8));
+    //checkHash(oatpp::UInt8(8));
+  }
+
+  {
+    OATPP_LOGI(TAG, "test default constructor");
+    oatpp::Int32 i;
+    OATPP_ASSERT(!i);
+    OATPP_ASSERT(i == nullptr);
+    OATPP_ASSERT(i.valueType == oatpp::Int32::Class::getType());
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test value constructor");
+    oatpp::Int32 i(0);
+    OATPP_ASSERT(i);
+    OATPP_ASSERT(i != nullptr);
+    OATPP_ASSERT(i == 0);
+    OATPP_ASSERT(i.valueType == oatpp::Int32::Class::getType());
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test implicit value constructor");
+    oatpp::Int32 i = 0;
+    OATPP_ASSERT(i);
+    OATPP_ASSERT(i != nullptr);
+    OATPP_ASSERT(i == 0);
+    OATPP_ASSERT(i.valueType == oatpp::Int32::Class::getType());
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test '==' and '!=' operators");
+    oatpp::Int32 i1 = 0;
+    oatpp::Int32 i2;
+
+    OATPP_ASSERT(i1);
+    OATPP_ASSERT(i1 != nullptr);
+    OATPP_ASSERT(i1 == 0);
+    OATPP_ASSERT(i1 != 1);
+
+    OATPP_ASSERT(!i2);
+    OATPP_ASSERT(i2 == nullptr)
+
+    OATPP_ASSERT(i1 != i2);
+    OATPP_ASSERT(i2 != i1);
+
+    i2 = 0;
+
+    OATPP_ASSERT(i1 == i2);
+    OATPP_ASSERT(i2 == i1);
+
+    i1 = nullptr;
+    i2 = nullptr;
+
+    OATPP_ASSERT(i1 == i2);
+
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test copy-assign operator");
+    oatpp::Int32 i1 = 0;
+    oatpp::Int32 i2;
+
+    OATPP_ASSERT(i1 != i2);
+
+    i2 = i1;
+
+    OATPP_ASSERT(i1 == i2);
+    OATPP_ASSERT(i1.get() == i2.get());
+
+    i2 = 1;
+
+    OATPP_ASSERT(i1 != i2);
+    OATPP_ASSERT(i1.get() != i2.get());
+
+    OATPP_ASSERT(i1 == 0);
+    OATPP_ASSERT(i2 == 1);
+  }
+
+  {
+    OATPP_LOGI(TAG, "test move-assign operator");
+    oatpp::Int32 i1 = 0;
+    oatpp::Int32 i2;
+
+    OATPP_ASSERT(i1 != i2);
+
+    i2 = std::move(i1);
+
+    OATPP_ASSERT(i1 == nullptr);
+    OATPP_ASSERT(i2 != nullptr);
+
+    OATPP_ASSERT(i2 == 0);
+  }
+
+  {
+    OATPP_LOGI(TAG, "Test Boolean [nullptr]");
+    oatpp::Boolean b;
+
+    OATPP_ASSERT(!b);
+    OATPP_ASSERT(b == nullptr);
+    OATPP_ASSERT(b != false);
+    OATPP_ASSERT(b != true);
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "Test Boolean [false]");
+    oatpp::Boolean b = false;
+
+    OATPP_ASSERT(!b); // <--- still !b
+    OATPP_ASSERT(b != nullptr);
+    OATPP_ASSERT(b == false);
+    OATPP_ASSERT(b != true);
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "Test Boolean [true]");
+    oatpp::Boolean b = true;
+
+    OATPP_ASSERT(b);
+    OATPP_ASSERT(b != nullptr);
+    OATPP_ASSERT(b != false);
+    OATPP_ASSERT(b == true);
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "Test Boolean copy-assign operator");
+    oatpp::Boolean b1 = true;
+    oatpp::Boolean b2;
+
+    b2 = b1;
+
+    OATPP_ASSERT(b2);
+    OATPP_ASSERT(b1);
+    OATPP_ASSERT(b1 == b2);
+    OATPP_ASSERT(b1.get() == b2.get());
+
+    b2 = false;
+
+    OATPP_ASSERT(b1.get() != b2.get());
+    OATPP_ASSERT(b1 != b2);
+    OATPP_ASSERT(b2 != b1);
+
+    b1 = false;
+    b2 = nullptr;
+
+    OATPP_ASSERT(b1 != b2);
+    OATPP_ASSERT(b2 != b1);
+
+    b1 = nullptr;
+    b2 = nullptr;
+
+    OATPP_ASSERT(b1 == b2);
+
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "Test Boolean move-assign operator");
+    oatpp::Boolean b1 = true;
+    oatpp::Boolean b2;
+
+    b2 = std::move(b1);
+
+    OATPP_ASSERT(b2 != nullptr);
+    OATPP_ASSERT(b1 == nullptr);
+
+    OATPP_LOGI(TAG, "OK");
+  }
 
 }
 

--- a/test/oatpp/core/data/mapping/type/PrimitiveTest.cpp
+++ b/test/oatpp/core/data/mapping/type/PrimitiveTest.cpp
@@ -160,6 +160,17 @@ void PrimitiveTest::onRun() {
   }
 
   {
+    OATPP_LOGI(TAG, "Test Boolean nullptr constructor");
+    oatpp::Boolean b = nullptr;
+
+    OATPP_ASSERT(!b);
+    OATPP_ASSERT(b == nullptr);
+    OATPP_ASSERT(b != false);
+    OATPP_ASSERT(b != true);
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
     OATPP_LOGI(TAG, "Test Boolean [false]");
     oatpp::Boolean b = false;
 

--- a/test/oatpp/core/data/mapping/type/PrimitiveTest.cpp
+++ b/test/oatpp/core/data/mapping/type/PrimitiveTest.cpp
@@ -1,0 +1,35 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#include "PrimitiveTest.hpp"
+
+#include "oatpp/core/Types.hpp"
+
+namespace oatpp { namespace test { namespace core { namespace data { namespace mapping { namespace  type {
+
+void PrimitiveTest::onRun() {
+
+}
+
+}}}}}}

--- a/test/oatpp/core/data/mapping/type/PrimitiveTest.hpp
+++ b/test/oatpp/core/data/mapping/type/PrimitiveTest.hpp
@@ -1,0 +1,42 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#ifndef oatpp_test_core_data_mapping_type_PrimitiveTest_hpp
+#define oatpp_test_core_data_mapping_type_PrimitiveTest_hpp
+
+#include "oatpp-test/UnitTest.hpp"
+
+namespace oatpp { namespace test { namespace core { namespace data { namespace mapping { namespace  type {
+
+class PrimitiveTest : public UnitTest{
+public:
+
+  PrimitiveTest():UnitTest("TEST[core::data::mapping::type::PrimitiveTest]"){}
+  void onRun() override;
+
+};
+
+}}}}}}
+
+#endif /* oatpp_test_core_data_mapping_type_PrimitiveTest_hpp */

--- a/test/oatpp/core/data/mapping/type/StringTest.cpp
+++ b/test/oatpp/core/data/mapping/type/StringTest.cpp
@@ -26,9 +26,113 @@
 
 #include "oatpp/core/Types.hpp"
 
+#include <functional>
+
 namespace oatpp { namespace test { namespace core { namespace data { namespace mapping { namespace  type {
 
 void StringTest::onRun() {
+
+  {
+    oatpp::String s = "hello"; // check hash function exists
+    std::hash<oatpp::String>{}(s);
+  }
+
+  {
+    OATPP_LOGI(TAG, "test default constructor");
+    oatpp::String s;
+    OATPP_ASSERT(!s);
+    OATPP_ASSERT(s == nullptr);
+    OATPP_ASSERT(s == (const char*) nullptr);
+    OATPP_ASSERT(s.valueType == oatpp::String::Class::getType());
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test const char* constructor");
+    oatpp::String s("");
+    OATPP_ASSERT(s);
+    OATPP_ASSERT(s != nullptr);
+    OATPP_ASSERT(s != (const char*) nullptr)
+    OATPP_ASSERT(s->getSize() == 0);
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test const char* implicit constructor");
+    oatpp::String s = "";
+    OATPP_ASSERT(s);
+    OATPP_ASSERT(s != nullptr);
+    OATPP_ASSERT(s != (const char*) nullptr)
+    OATPP_ASSERT(s->getSize() == 0);
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test '==', '!=' operators");
+    oatpp::String s1 = "a";
+    oatpp::String s2;
+
+    OATPP_ASSERT(s1 != s2);
+    OATPP_ASSERT(s2 != s1);
+
+    OATPP_ASSERT(s1 == "a");
+    OATPP_ASSERT(s1 != "aa");
+    OATPP_ASSERT(s1 != "");
+
+    s2 = "aa";
+
+    OATPP_ASSERT(s1 != s2);
+    OATPP_ASSERT(s2 != s1);
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test copy-asssign operator");
+    oatpp::String s1 = "s1";
+    oatpp::String s2;
+
+    s2 = s1;
+
+    OATPP_ASSERT(s1 == s2);
+    OATPP_ASSERT(s1.get() == s2.get());
+
+    s1 = "s2";
+
+    OATPP_ASSERT(s1 != s2);
+    OATPP_ASSERT(s2 != s1);
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test const char* assign operator");
+    oatpp::String s1 = "s1";
+    oatpp::String s2(s1);
+
+    OATPP_ASSERT(s1 == s2);
+    OATPP_ASSERT(s1.get() == s2.get());
+
+    s1 = "s2";
+
+    OATPP_ASSERT(s1 != s2);
+    OATPP_ASSERT(s2 != s1);
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test move assign operator");
+    oatpp::String s1 = "s1";
+    oatpp::String s2;
+
+    s2 = std::move(s1);
+
+    OATPP_ASSERT(s1 == nullptr);
+    OATPP_ASSERT(s2 != nullptr);
+    OATPP_ASSERT(s2 == "s1");
+
+    OATPP_ASSERT(s1 != s2);
+    OATPP_ASSERT(s1.get() != s2.get());
+    OATPP_LOGI(TAG, "OK");
+  }
 
 }
 

--- a/test/oatpp/core/data/mapping/type/StringTest.cpp
+++ b/test/oatpp/core/data/mapping/type/StringTest.cpp
@@ -1,0 +1,35 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#include "StringTest.hpp"
+
+#include "oatpp/core/Types.hpp"
+
+namespace oatpp { namespace test { namespace core { namespace data { namespace mapping { namespace  type {
+
+void StringTest::onRun() {
+
+}
+
+}}}}}}

--- a/test/oatpp/core/data/mapping/type/StringTest.hpp
+++ b/test/oatpp/core/data/mapping/type/StringTest.hpp
@@ -1,0 +1,42 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#ifndef oatpp_test_core_data_mapping_type_StringTest_hpp
+#define oatpp_test_core_data_mapping_type_StringTest_hpp
+
+#include "oatpp-test/UnitTest.hpp"
+
+namespace oatpp { namespace test { namespace core { namespace data { namespace mapping { namespace  type {
+
+class StringTest : public UnitTest{
+public:
+
+  StringTest():UnitTest("TEST[core::data::mapping::type::StringTest]"){}
+  void onRun() override;
+
+};
+
+}}}}}}
+
+#endif /* oatpp_test_core_data_mapping_type_StringTest_hpp */

--- a/test/oatpp/core/data/mapping/type/UnorderedMapTest.cpp
+++ b/test/oatpp/core/data/mapping/type/UnorderedMapTest.cpp
@@ -1,0 +1,163 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#include "UnorderedMapTest.hpp"
+
+#include "oatpp/core/Types.hpp"
+
+namespace oatpp { namespace test { namespace core { namespace data { namespace mapping { namespace  type {
+
+void UnorderedMapTest::onRun() {
+
+  {
+    OATPP_LOGI(TAG, "test default constructor...");
+    oatpp::UnorderedFields<String> map;
+
+    OATPP_ASSERT(!map);
+    OATPP_ASSERT(map == nullptr);
+
+    OATPP_ASSERT(map.get() == nullptr);
+    OATPP_ASSERT(map.valueType->classId.id == oatpp::data::mapping::type::__class::AbstractUnorderedMap::CLASS_ID.id);
+    OATPP_ASSERT(map.valueType->params.size() == 2);
+    auto it = map.valueType->params.begin();
+    OATPP_ASSERT(*it++ == oatpp::String::Class::getType());
+    OATPP_ASSERT(*it++ == oatpp::String::Class::getType());
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test empty ilist constructor...");
+    oatpp::UnorderedFields<String> map({});
+
+    OATPP_ASSERT(map);
+    OATPP_ASSERT(map != nullptr);
+    OATPP_ASSERT(map->size() == 0);
+
+    OATPP_ASSERT(map.get() != nullptr);
+    OATPP_ASSERT(map.valueType->classId.id == oatpp::data::mapping::type::__class::AbstractUnorderedMap::CLASS_ID.id);
+    OATPP_ASSERT(map.valueType->params.size() == 2);
+    auto it = map.valueType->params.begin();
+    OATPP_ASSERT(*it++ == oatpp::String::Class::getType());
+    OATPP_ASSERT(*it++ == oatpp::String::Class::getType());
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test createShared()...");
+    oatpp::UnorderedFields<String> map = oatpp::UnorderedFields<String>::createShared();
+
+    OATPP_ASSERT(map);
+    OATPP_ASSERT(map != nullptr);
+    OATPP_ASSERT(map->size() == 0);
+
+    OATPP_ASSERT(map.get() != nullptr);
+    OATPP_ASSERT(map.valueType->classId.id == oatpp::data::mapping::type::__class::AbstractUnorderedMap::CLASS_ID.id);
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test copy-assignment operator...");
+    oatpp::UnorderedFields<String> map1({});
+    oatpp::UnorderedFields<String> map2;
+
+    map2 = map1;
+
+    OATPP_ASSERT(map1);
+    OATPP_ASSERT(map2);
+
+    OATPP_ASSERT(map1->size() == 0);
+    OATPP_ASSERT(map2->size() == 0);
+
+    OATPP_ASSERT(map1.get() == map2.get());
+
+    map2->insert({"key", "a"});
+
+    OATPP_ASSERT(map1->size() == 1);
+    OATPP_ASSERT(map2->size() == 1);
+
+    map2 = {{"key1", "b"}, {"key2", "c"}};
+
+    OATPP_ASSERT(map1->size() == 1);
+    OATPP_ASSERT(map2->size() == 2);
+
+    OATPP_ASSERT(map2["key1"] == "b");
+    OATPP_ASSERT(map2["key2"] == "c");
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test move-assignment operator...");
+    oatpp::UnorderedFields<String> map1({});
+    oatpp::UnorderedFields<String> map2;
+
+    map2 = std::move(map1);
+
+    OATPP_ASSERT(!map1);
+    OATPP_ASSERT(map2);
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test get element by index...");
+    oatpp::UnorderedFields<String> map = {{"key1", "a"}, {"key2", "b"}, {"key3", "c"}};
+
+    OATPP_ASSERT(map);
+    OATPP_ASSERT(map != nullptr);
+    OATPP_ASSERT(map->size() == 3);
+
+    OATPP_ASSERT(map["key1"] == "a");
+    OATPP_ASSERT(map["key2"] == "b");
+    OATPP_ASSERT(map["key3"] == "c");
+
+    map["key2"] = "Hello!";
+
+    OATPP_ASSERT(map->size() == 3);
+
+    OATPP_ASSERT(map["key1"] == "a");
+    OATPP_ASSERT(map["key2"] == "Hello!");
+    OATPP_ASSERT(map["key3"] == "c");
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test polymorphicDispatcher...");
+    oatpp::UnorderedFields<String> map = {{"key1", "a"}, {"key2", "b"}, {"key3", "c"}};
+
+    auto polymorphicDispatcher = static_cast<const typename oatpp::UnorderedFields<String>::Class::AbstractPolymorphicDispatcher*>(
+      map.valueType->polymorphicDispatcher
+    );
+
+    polymorphicDispatcher->addPolymorphicItem(map, oatpp::String("key1"), oatpp::String("d"));
+
+    OATPP_ASSERT(map->size() == 3);
+
+    OATPP_ASSERT(map["key1"] == "d");
+    OATPP_ASSERT(map["key2"] == "b");
+    OATPP_ASSERT(map["key3"] == "c");
+    OATPP_LOGI(TAG, "OK");
+  }
+
+}
+
+}}}}}}

--- a/test/oatpp/core/data/mapping/type/UnorderedMapTest.hpp
+++ b/test/oatpp/core/data/mapping/type/UnorderedMapTest.hpp
@@ -1,0 +1,42 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#ifndef oatpp_test_core_data_mapping_type_UnorderedMapTest_hpp
+#define oatpp_test_core_data_mapping_type_UnorderedMapTest_hpp
+
+#include "oatpp-test/UnitTest.hpp"
+
+namespace oatpp { namespace test { namespace core { namespace data { namespace mapping { namespace  type {
+
+class UnorderedMapTest : public UnitTest{
+public:
+
+  UnorderedMapTest():UnitTest("TEST[core::data::mapping::type::UnorderedMapTest]"){}
+  void onRun() override;
+
+};
+
+}}}}}}
+
+#endif /* oatpp_test_core_data_mapping_type_UnorderedMapTest_hpp */

--- a/test/oatpp/core/data/mapping/type/VectorTest.cpp
+++ b/test/oatpp/core/data/mapping/type/VectorTest.cpp
@@ -1,0 +1,160 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#include "VectorTest.hpp"
+
+#include "oatpp/core/Types.hpp"
+
+namespace oatpp { namespace test { namespace core { namespace data { namespace mapping { namespace  type {
+
+void VectorTest::onRun() {
+
+  {
+    OATPP_LOGI(TAG, "test default constructor...");
+    oatpp::Vector<oatpp::String> vector;
+
+    OATPP_ASSERT(!vector);
+    OATPP_ASSERT(vector == nullptr);
+
+    OATPP_ASSERT(vector.get() == nullptr);
+    OATPP_ASSERT(vector.valueType->classId.id == oatpp::data::mapping::type::__class::AbstractVector::CLASS_ID.id);
+    OATPP_ASSERT(vector.valueType->params.size() == 1);
+    OATPP_ASSERT(vector.valueType->params.front() == oatpp::String::Class::getType());
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test empty ilist constructor...");
+    oatpp::Vector<oatpp::String> vector({});
+
+    OATPP_ASSERT(vector);
+    OATPP_ASSERT(vector != nullptr);
+    OATPP_ASSERT(vector->size() == 0);
+
+    OATPP_ASSERT(vector.get() != nullptr);
+    OATPP_ASSERT(vector.valueType->classId.id == oatpp::data::mapping::type::__class::AbstractVector::CLASS_ID.id);
+    OATPP_ASSERT(vector.valueType->params.size() == 1);
+    OATPP_ASSERT(vector.valueType->params.front() == oatpp::String::Class::getType());
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test createShared()...");
+    oatpp::Vector<oatpp::String> vector = oatpp::Vector<oatpp::String>::createShared();
+
+    OATPP_ASSERT(vector);
+    OATPP_ASSERT(vector != nullptr);
+    OATPP_ASSERT(vector->size() == 0);
+
+    OATPP_ASSERT(vector.get() != nullptr);
+    OATPP_ASSERT(vector.valueType->classId.id == oatpp::data::mapping::type::__class::AbstractVector::CLASS_ID.id);
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test copy-assignment operator...");
+    oatpp::Vector<oatpp::String> vector1({});
+    oatpp::Vector<oatpp::String> vector2;
+
+    vector2 = vector1;
+
+    OATPP_ASSERT(vector1);
+    OATPP_ASSERT(vector2);
+
+    OATPP_ASSERT(vector1->size() == 0);
+    OATPP_ASSERT(vector2->size() == 0);
+
+    OATPP_ASSERT(vector1.get() == vector2.get());
+
+    vector2->push_back("a");
+
+    OATPP_ASSERT(vector1->size() == 1);
+    OATPP_ASSERT(vector2->size() == 1);
+
+    vector2 = {"b", "c"};
+
+    OATPP_ASSERT(vector1->size() == 1);
+    OATPP_ASSERT(vector2->size() == 2);
+
+    OATPP_ASSERT(vector2[0] == "b");
+    OATPP_ASSERT(vector2[1] == "c");
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test move-assignment operator...");
+    oatpp::Vector<oatpp::String> vector1({});
+    oatpp::Vector<oatpp::String> vector2;
+
+    vector2 = std::move(vector1);
+
+    OATPP_ASSERT(!vector1);
+    OATPP_ASSERT(vector2);
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test get element by index...");
+    oatpp::Vector<oatpp::String> vector = {"a", "b", "c"};
+
+    OATPP_ASSERT(vector);
+    OATPP_ASSERT(vector != nullptr);
+    OATPP_ASSERT(vector->size() == 3);
+
+    OATPP_ASSERT(vector[0] == "a");
+    OATPP_ASSERT(vector[1] == "b");
+    OATPP_ASSERT(vector[2] == "c");
+
+    vector[1] = "Hello!";
+
+    OATPP_ASSERT(vector->size() == 3);
+
+    OATPP_ASSERT(vector[0] == "a");
+    OATPP_ASSERT(vector[1] == "Hello!");
+    OATPP_ASSERT(vector[2] == "c");
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "test polymorphicDispatcher...");
+    oatpp::Vector<oatpp::String> vector = {"a", "b", "c"};
+
+    auto polymorphicDispatcher = static_cast<const typename oatpp::Vector<oatpp::String>::Class::AbstractPolymorphicDispatcher*>(
+      vector.valueType->polymorphicDispatcher
+    );
+
+    polymorphicDispatcher->addPolymorphicItem(vector, oatpp::String("d"));
+
+    OATPP_ASSERT(vector->size() == 4);
+
+    OATPP_ASSERT(vector[0] == "a");
+    OATPP_ASSERT(vector[1] == "b");
+    OATPP_ASSERT(vector[2] == "c");
+    OATPP_ASSERT(vector[3] == "d");
+    OATPP_LOGI(TAG, "OK");
+  }
+
+}
+
+}}}}}}

--- a/test/oatpp/core/data/mapping/type/VectorTest.hpp
+++ b/test/oatpp/core/data/mapping/type/VectorTest.hpp
@@ -1,0 +1,42 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#ifndef oatpp_test_core_data_mapping_type_VectorTest_hpp
+#define oatpp_test_core_data_mapping_type_VectorTest_hpp
+
+#include "oatpp-test/UnitTest.hpp"
+
+namespace oatpp { namespace test { namespace core { namespace data { namespace mapping { namespace  type {
+
+class VectorTest : public UnitTest{
+public:
+
+  VectorTest():UnitTest("TEST[core::data::mapping::type::VectorTest]"){}
+  void onRun() override;
+
+};
+
+}}}}}}
+
+#endif /* oatpp_test_core_data_mapping_type_VectorTest_hpp */

--- a/test/oatpp/parser/json/mapping/DTOMapperTest.cpp
+++ b/test/oatpp/parser/json/mapping/DTOMapperTest.cpp
@@ -226,19 +226,19 @@ void DTOMapperTest::onRun(){
   OATPP_ASSERT(obj->field_string == test1->field_string);
   
   OATPP_ASSERT(obj->field_int32);
-  OATPP_ASSERT(obj->field_int32->getValue() == test1->field_int32->getValue());
+  OATPP_ASSERT(obj->field_int32 == test1->field_int32);
   
   OATPP_ASSERT(obj->field_int64);
-  OATPP_ASSERT(obj->field_int64->getValue() == test1->field_int64->getValue());
+  OATPP_ASSERT(obj->field_int64 == test1->field_int64);
   
   OATPP_ASSERT(obj->field_float32);
-  OATPP_ASSERT(obj->field_float32->getValue() == test1->field_float32->getValue());
+  OATPP_ASSERT(obj->field_float32 == test1->field_float32);
   
   OATPP_ASSERT(obj->field_float64);
-  OATPP_ASSERT(obj->field_float64->getValue() == test1->field_float64->getValue());
+  OATPP_ASSERT(obj->field_float64 == test1->field_float64);
   
   OATPP_ASSERT(obj->field_boolean);
-  OATPP_ASSERT(obj->field_boolean->getValue() == test1->field_boolean->getValue());
+  OATPP_ASSERT(obj->field_boolean == test1->field_boolean);
 
   {
     auto c = obj->field_vector;

--- a/test/oatpp/parser/json/mapping/DeserializerTest.cpp
+++ b/test/oatpp/parser/json/mapping/DeserializerTest.cpp
@@ -111,12 +111,12 @@ void DeserializerTest::onRun(){
   obj2 = mapper->readFromString<Test2>("{\"int32F\": 32}");
   
   OATPP_ASSERT(obj2);
-  OATPP_ASSERT(obj2->int32F->getValue() == 32);
+  OATPP_ASSERT(obj2->int32F == 32);
   
   obj2 = mapper->readFromString<Test2>("{\"int32F\":    -32}");
   
   OATPP_ASSERT(obj2);
-  OATPP_ASSERT(obj2->int32F->getValue() == -32);
+  OATPP_ASSERT(obj2->int32F == -32);
   
   auto obj3 = mapper->readFromString<Test3>("{\"float32F\": null}");
   
@@ -126,7 +126,7 @@ void DeserializerTest::onRun(){
   obj3 = mapper->readFromString<Test3>("{\"float32F\": 32}");
   
   OATPP_ASSERT(obj3);
-  OATPP_ASSERT(obj3->float32F->getValue() == 32);
+  OATPP_ASSERT(obj3->float32F == 32);
   
   obj3 = mapper->readFromString<Test3>("{\"float32F\": 1.32e1}");
   
@@ -156,9 +156,9 @@ void DeserializerTest::onRun(){
   auto list = mapper->readFromString<Test1::List<Test1::Int32>>("[1, 2, 3]");
   OATPP_ASSERT(list);
   OATPP_ASSERT(list->size() == 3);
-  OATPP_ASSERT(list[0]->getValue() == 1);
-  OATPP_ASSERT(list[1]->getValue() == 2);
-  OATPP_ASSERT(list[2]->getValue() == 3);
+  OATPP_ASSERT(list[0] == 1);
+  OATPP_ASSERT(list[1] == 2);
+  OATPP_ASSERT(list[2] == 3);
 
   // Empty test
 

--- a/test/oatpp/web/FullTest.cpp
+++ b/test/oatpp/web/FullTest.cpp
@@ -299,7 +299,7 @@ void FullTest::onRun() {
         OATPP_ASSERT(response->getStatusCode() == 200);
         auto dtoOut = response->readBodyToDto<app::TestDto>(objectMapper.get());
         OATPP_ASSERT(dtoOut);
-        OATPP_ASSERT(dtoOut->testValueInt->getValue() == i);
+        OATPP_ASSERT(dtoOut->testValueInt == i);
       }
 
       { // test Big Echo with body

--- a/test/oatpp/web/app/Controller.hpp
+++ b/test/oatpp/web/app/Controller.hpp
@@ -109,7 +109,7 @@ public:
   ENDPOINT("GET", "queries", getWithQueries,
            QUERY(String, name), QUERY(Int32, age)) {
     auto dto = TestDto::createShared();
-    dto->testValue = "name=" + name + "&age=" + oatpp::utils::conversion::int32ToStr(age->getValue());
+    dto->testValue = "name=" + name + "&age=" + oatpp::utils::conversion::int32ToStr(*age);
     return createDtoResponse(Status::CODE_200, dto);
   }
 
@@ -216,7 +216,7 @@ public:
            REQUEST(std::shared_ptr<IncomingRequest>, request))
   {
     auto body = std::make_shared<oatpp::web::protocol::http::outgoing::StreamingBody>
-      (std::make_shared<ReadCallback>(text, numIterations->getValue()));
+      (std::make_shared<ReadCallback>(text, *numIterations));
     return OutgoingResponse::createShared(Status::CODE_200, body);
   }
 


### PR DESCRIPTION
# Summary

No more `<primitive>->getValue()`.

```cpp
oatpp::Int32 objV = 32;
v_int32 v = *objV;

bool eq = v == objV;
```