### PR TITLE
add check for gcc version less than 5 due to missing std::put_time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ test/build/
 
 Dockerfile
 
+# VS
+.vs/
+out/
+CMakeSettings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,10 @@ if(OATPP_DISABLE_LOGE)
     add_definitions(-DOATPP_DISABLE_LOGE)
 endif()
 
+if(CMAKE_COMPILER_IS_GNUCXX AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 5.0)
+    add_definitions(-DOATPP_DISABLE_STD_PUT_TIME)
+endif()
+
 message("\n############################################################################\n")
 
 ###################################################################################################

--- a/src/oatpp/core/base/Environment.cpp
+++ b/src/oatpp/core/base/Environment.cpp
@@ -90,10 +90,16 @@ void DefaultLogger::log(v_int32 priority, const std::string& tag, const std::str
   }
 
   if(m_config.timeFormat) {
-    time_t seconds = std::chrono::duration_cast<std::chrono::seconds>(time).count();
+	time_t seconds = std::chrono::duration_cast<std::chrono::seconds>(time).count();
     struct tm now;
     localtime_r(&seconds, &now);
-    std::cout << std::put_time(&now, m_config.timeFormat);
+#ifdef OATPP_DISABLE_STD_PUT_TIME
+	  char timeBuffer[50];
+      strftime(timeBuffer, sizeof(timeBuffer), m_config.timeFormat, &now);
+      std::cout << timeBuffer;
+#else
+      std::cout << std::put_time(&now, m_config.timeFormat);
+#endif
     indent = true;
   }
 


### PR DESCRIPTION
Hello,

I created this PR because I'm having an issue about GCC version less than 5. The problem is due to std::put_time (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54354#c9). I added also in the .gitignore some generated folders and file of Visual Studio.