### PR TITLE
IODefinitions. Move #include <WinSock2.h> back to .cpp file.

### DIFF
--- a/src/oatpp/core/IODefinitions.cpp
+++ b/src/oatpp/core/IODefinitions.cpp
@@ -24,6 +24,10 @@
 
 #include "IODefinitions.hpp"
 
+#if defined(WIN32) || defined(_WIN32)
+  #include <WinSock2.h>
+#endif
+
 namespace oatpp {
 
 bool isValidIOHandle(v_io_handle handle) {

--- a/src/oatpp/core/IODefinitions.hpp
+++ b/src/oatpp/core/IODefinitions.hpp
@@ -28,22 +28,18 @@
 #include "oatpp/core/async/Error.hpp"
 #include "oatpp/core/Types.hpp"
 
-#if defined(WIN32) || defined(_WIN32)
-#include <WinSock2.h>
-#endif // defined(WIN32) || defined(_WIN32)
-
 namespace oatpp {
 
 /**
  * Represents I/O handle (ex.: file descriptor).
  */
 #if defined(WIN32) || defined(_WIN32)
-	#if defined(_WIN64)
-	  typedef unsigned long long v_io_handle;
-	#else
-	  typedef unsigned long v_io_handle;
-	#endif
-    constexpr const v_io_handle INVALID_IO_HANDLE = v_io_handle(INVALID_SOCKET);
+  #if defined(_WIN64)
+    typedef unsigned long long v_io_handle;
+  #else
+    typedef unsigned long v_io_handle;
+  #endif
+    constexpr const v_io_handle INVALID_IO_HANDLE = v_io_handle (-1);
 #else
   typedef int v_io_handle;
   constexpr const v_io_handle INVALID_IO_HANDLE = v_io_handle (-1);


### PR DESCRIPTION
The `#include <WinSock2.h>` introduces `min` and `max` macros that clush with c++ `numeric_limits::min/max`.
To fix that I'm moving `WinSock2.h` include back to .cpp file. 
And the `INVALID_IO_HANDLE ` constant is now just manually defined as -1 which is rounded to max int32/int64.