### PR TITLE
virtual_::Interface.hpp. No need to #undef interface.

### DIFF
--- a/src/oatpp/network/virtual_/Interface.hpp
+++ b/src/oatpp/network/virtual_/Interface.hpp
@@ -31,8 +31,6 @@
 
 #include <unordered_map>
 
-#undef interface
-
 namespace oatpp { namespace network { namespace virtual_ {
 
 /**


### PR DESCRIPTION
Since we've moved windows include from `UIDefinitions.hpp` there is no need to undefine the `interface` .