### PR TITLE
Proposal for #261: Fine grained configurable Loglevel

### DIFF
--- a/src/oatpp/core/base/Environment.cpp
+++ b/src/oatpp/core/base/Environment.cpp
@@ -113,10 +113,15 @@ void DefaultLogger::log(v_uint32 priority, const std::string& tag, const std::st
     indent = true;
   }
 
-  if(indent) {
+  if (indent) {
     std::cout << "|";
   }
-  std::cout << " " << tag << ":" << message << std::endl;
+
+  if (message.empty()) {
+    std::cout << " " << tag << std::endl;
+  } else {
+    std::cout << " " << tag << ":" << message << std::endl;
+  }
 
 }
 
@@ -295,7 +300,7 @@ void Environment::logFormatted(v_int32 priority, const std::string& tag, const c
   }
   // if we dont need to format anything, just print the message
   if(message == nullptr) {
-    log(priority, tag, "[null]");
+    log(priority, tag, std::string());
     return;
   }
   // check how big our buffer has to be

--- a/src/oatpp/core/base/Environment.cpp
+++ b/src/oatpp/core/base/Environment.cpp
@@ -7,6 +7,7 @@
  *
  *
  * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *                         Benedikt-Alexander Mokroß <oatpp@bamkrs.de>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +58,11 @@ DefaultLogger::DefaultLogger(const Config& config)
   : m_config(config)
 {}
 
-void DefaultLogger::log(v_int32 priority, const std::string& tag, const std::string& message) {
+void DefaultLogger::log(v_uint32 priority, const std::string& tag, const std::string& message) {
+
+  if (!(m_config.logMask & priority)) {
+    return;
+  }
 
   bool indent = false;
   auto time = std::chrono::system_clock::now().time_since_epoch();
@@ -89,7 +94,7 @@ void DefaultLogger::log(v_int32 priority, const std::string& tag, const std::str
       std::cout << " " << priority << " |";
   }
 
-  if(m_config.timeFormat) {
+  if (m_config.timeFormat) {
 	time_t seconds = std::chrono::duration_cast<std::chrono::seconds>(time).count();
     struct tm now;
     localtime_r(&seconds, &now);
@@ -103,7 +108,7 @@ void DefaultLogger::log(v_int32 priority, const std::string& tag, const std::str
     indent = true;
   }
 
-  if(m_config.printTicks) {
+  if (m_config.printTicks) {
     auto ticks = std::chrono::duration_cast<std::chrono::microseconds>(time).count();
     if(indent) {
       std::cout << " ";
@@ -117,6 +122,14 @@ void DefaultLogger::log(v_int32 priority, const std::string& tag, const std::str
   }
   std::cout << " " << tag << ":" << message << std::endl;
 
+}
+
+void DefaultLogger::enablePriority(v_uint32 priorities) {
+  m_config.logMask |= priorities;
+}
+
+void DefaultLogger::disablePriority(v_uint32 priorities) {
+  m_config.logMask &= ~priorities;
 }
 
 
@@ -237,6 +250,10 @@ v_counter Environment::getThreadLocalObjectsCreated(){
 
 void Environment::setLogger(const std::shared_ptr<Logger>& logger){
   m_logger = logger;
+}
+
+std::shared_ptr<Logger> Environment::getLogger() {
+  return m_logger;
 }
 
 void Environment::printCompilationConfig() {

--- a/src/oatpp/core/base/Environment.cpp
+++ b/src/oatpp/core/base/Environment.cpp
@@ -312,16 +312,15 @@ void Environment::logFormatted(v_int32 priority, const std::string& tag, const c
   if (allocsize > m_logger->getMaxFormattingBufferSize()) {
     allocsize = m_logger->getMaxFormattingBufferSize();
   }
-  char* buffer = new char[allocsize];
-  memset(buffer, 0, allocsize);
+  auto buffer = std::unique_ptr<char[]>(new char[allocsize]);
+  memset(buffer.get(), 0, allocsize);
   // actually format
   va_start(args, message);
-  vsnprintf(buffer, allocsize, message, args);
+  vsnprintf(buffer.get(), allocsize, message, args);
   // call (user) providen log function
-  log(priority, tag, buffer);
+  log(priority, tag, buffer.get());
   // cleanup
   va_end(args);
-  delete[] buffer;
 }
 
 void Environment::registerComponent(const std::string& typeName, const std::string& componentName, void* component) {

--- a/src/oatpp/core/base/Environment.hpp
+++ b/src/oatpp/core/base/Environment.hpp
@@ -93,27 +93,27 @@ public:
   /**
    * Log priority V-verbouse.
    */
-  static constexpr v_uint32 PRIORITY_V = (1 << 0);
+  static constexpr v_uint32 PRIORITY_V = 0;
 
   /**
    * Log priority D-debug.
    */
-  static constexpr v_uint32 PRIORITY_D = (1 << 1);
+  static constexpr v_uint32 PRIORITY_D = 1;
 
   /**
    * Log priority I-Info.
    */
-  static constexpr v_uint32 PRIORITY_I = (1 << 2);
+  static constexpr v_uint32 PRIORITY_I = 2;
 
   /**
    * Log priority W-Warning.
    */
-  static constexpr v_uint32 PRIORITY_W = (1 << 3);
+  static constexpr v_uint32 PRIORITY_W = 3;
 
   /**
    * Log priority E-error.
    */
-  static constexpr v_uint32 PRIORITY_E = (1 << 4);
+  static constexpr v_uint32 PRIORITY_E = 4;
 public:
   /**
    * Virtual Destructor.
@@ -127,6 +127,23 @@ public:
    * @param message - message.
    */
   virtual void log(v_uint32 priority, const std::string& tag, const std::string& message) = 0;
+
+  /**
+   * Returns wether or not a priority should be logged/printed
+   * @param priority
+   * @return - true if given priority should be logged
+   */
+  virtual bool isLogPriorityEnabled(v_uint32 priority) {
+    return true;
+  }
+
+  /**
+   * Should return the maximum amount of bytes that should be allocated for a single log message
+   * @return - maximum buffer size
+   */
+  virtual v_buff_size getMaxFormattingBufferSize() {
+    return 4096;
+  }
 };
 
 /**
@@ -178,7 +195,7 @@ public:
   DefaultLogger(const Config& config = Config(
           "%Y-%m-%d %H:%M:%S",
           true,
-          PRIORITY_V | PRIORITY_D | PRIORITY_I | PRIORITY_W | PRIORITY_E
+          (1 << PRIORITY_V) | (1 << PRIORITY_D) | (1 << PRIORITY_I) | (1 << PRIORITY_W) | (1 << PRIORITY_E)
           ));
 
   /**
@@ -190,16 +207,23 @@ public:
   void log(v_uint32 priority, const std::string& tag, const std::string& message) override;
 
   /**
-   * Enables logging of one or multiple priorities for this instance
-   * @param priorities - the priority levels to enable
+   * Enables logging of a priorities for this instance
+   * @param priority - the priority level to enable
    */
-  void enablePriority(v_uint32 priorities);
+  void enablePriority(v_uint32 priority);
 
   /**
-   * Disables logging of one or multiple priorities for this instance
-   * @param priorities - the priority levels to disable
+   * Disables logging of a priority for this instance
+   * @param priority - the priority level to disable
    */
-  void disablePriority(v_uint32 priorities);
+  void disablePriority(v_uint32 priority);
+
+  /**
+   * Returns wether or not a priority should be logged/printed
+   * @param priority
+   * @return - true if given priority should be logged
+   */
+  bool isLogPriorityEnabled(v_uint32 priority) override;
 };
 
 /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,8 @@ add_executable(oatppAllTests
         oatpp/core/async/LockTest.hpp
         oatpp/core/base/CommandLineArgumentsTest.cpp
         oatpp/core/base/CommandLineArgumentsTest.hpp
+        oatpp/core/base/LoggerTest.cpp
+        oatpp/core/base/LoggerTest.hpp
         oatpp/core/base/collection/LinkedListTest.cpp
         oatpp/core/base/collection/LinkedListTest.hpp
         oatpp/core/base/memory/MemoryPoolTest.cpp
@@ -96,8 +98,7 @@ add_executable(oatppAllTests
         oatpp/web/app/ControllerAsync.hpp
         oatpp/web/app/DTOs.hpp
         oatpp/web/app/ControllerWithInterceptors.hpp
-        oatpp/web/app/ControllerWithInterceptorsAsync.hpp
-)
+        oatpp/web/app/ControllerWithInterceptorsAsync.hpp)
 
 target_link_libraries(oatppAllTests PRIVATE oatpp PRIVATE oatpp-test)
 

--- a/test/oatpp/AllTestsMain.cpp
+++ b/test/oatpp/AllTestsMain.cpp
@@ -57,6 +57,7 @@
 #include "oatpp/core/base/memory/MemoryPoolTest.hpp"
 #include "oatpp/core/base/memory/PerfTest.hpp"
 #include "oatpp/core/base/CommandLineArgumentsTest.hpp"
+#include "oatpp/core/base/LoggerTest.hpp"
 
 #include "oatpp/core/async/Coroutine.hpp"
 #include "oatpp/core/Types.hpp"
@@ -77,6 +78,7 @@ void runTests() {
   OATPP_LOGD("aaa", "action size=%d", sizeof(oatpp::async::Action));
 
   OATPP_RUN_TEST(oatpp::test::base::CommandLineArgumentsTest);
+  OATPP_RUN_TEST(oatpp::test::base::LoggerTest);
 
   OATPP_RUN_TEST(oatpp::test::memory::MemoryPoolTest);
   OATPP_RUN_TEST(oatpp::test::memory::PerfTest);

--- a/test/oatpp/core/base/LoggerTest.cpp
+++ b/test/oatpp/core/base/LoggerTest.cpp
@@ -37,8 +37,8 @@ void LoggerTest::onRun() {
   OATPP_LOGW("LoggerTest", "Warning Log");
   OATPP_LOGE("LoggerTest", "Error Log");
 
-  OATPP_LOGV("LoggerTest", "Disabling Debug and Info Log");
-  logger->disablePriority(oatpp::base::DefaultLogger::PRIORITY_D | oatpp::base::DefaultLogger::PRIORITY_I);
+  OATPP_LOGV("LoggerTest", "Disabling Debug Log");
+  logger->disablePriority(oatpp::base::DefaultLogger::PRIORITY_D);
 
   OATPP_LOGV("LoggerTest", "Verbose Log");
   OATPP_LOGD("LoggerTest", "Debug Log");
@@ -46,8 +46,8 @@ void LoggerTest::onRun() {
   OATPP_LOGW("LoggerTest", "Warning Log");
   OATPP_LOGE("LoggerTest", "Error Log");
 
-  OATPP_LOGV("LoggerTest", "Enabling Debug and Info Log again");
-  logger->enablePriority(oatpp::base::DefaultLogger::PRIORITY_D | oatpp::base::DefaultLogger::PRIORITY_I);
+  OATPP_LOGV("LoggerTest", "Enabling Debug Log again");
+  logger->enablePriority(oatpp::base::DefaultLogger::PRIORITY_D);
 
   OATPP_LOGV("LoggerTest", "Verbose Log");
   OATPP_LOGD("LoggerTest", "Debug Log");

--- a/test/oatpp/core/base/LoggerTest.cpp
+++ b/test/oatpp/core/base/LoggerTest.cpp
@@ -1,0 +1,60 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *                         Benedikt-Alexander Mokroß <oatpp@bamkrs.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#include "LoggerTest.hpp"
+
+namespace oatpp { namespace test { namespace base {
+
+void LoggerTest::onRun() {
+
+  auto logger = std::static_pointer_cast<oatpp::base::DefaultLogger>(oatpp::base::Environment::getLogger());
+
+  OATPP_LOGV("LoggerTest", "Verbose Log");
+  OATPP_LOGD("LoggerTest", "Debug Log");
+  OATPP_LOGI("LoggerTest", "Info Log");
+  OATPP_LOGW("LoggerTest", "Warning Log");
+  OATPP_LOGE("LoggerTest", "Error Log");
+
+  OATPP_LOGV("LoggerTest", "Disabling Debug and Info Log");
+  logger->disablePriority(oatpp::base::DefaultLogger::PRIORITY_D | oatpp::base::DefaultLogger::PRIORITY_I);
+
+  OATPP_LOGV("LoggerTest", "Verbose Log");
+  OATPP_LOGD("LoggerTest", "Debug Log");
+  OATPP_LOGI("LoggerTest", "Info Log");
+  OATPP_LOGW("LoggerTest", "Warning Log");
+  OATPP_LOGE("LoggerTest", "Error Log");
+
+  OATPP_LOGV("LoggerTest", "Enabling Debug and Info Log again");
+  logger->enablePriority(oatpp::base::DefaultLogger::PRIORITY_D | oatpp::base::DefaultLogger::PRIORITY_I);
+
+  OATPP_LOGV("LoggerTest", "Verbose Log");
+  OATPP_LOGD("LoggerTest", "Debug Log");
+  OATPP_LOGI("LoggerTest", "Info Log");
+  OATPP_LOGW("LoggerTest", "Warning Log");
+  OATPP_LOGE("LoggerTest", "Error Log");
+
+}
+
+}}}

--- a/test/oatpp/core/base/LoggerTest.hpp
+++ b/test/oatpp/core/base/LoggerTest.hpp
@@ -1,0 +1,43 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *                         Benedikt-Alexander Mokroß <oatpp@bamkrs.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#ifndef oatpp_test_base_LoggerTest_hpp
+#define oatpp_test_base_LoggerTest_hpp
+
+#include "oatpp-test/UnitTest.hpp"
+
+namespace oatpp { namespace test { namespace base {
+
+class LoggerTest : public UnitTest{
+ public:
+
+  LoggerTest():UnitTest("TEST[base::LoggerTest]"){}
+  void onRun() override;
+
+};
+
+}}}
+
+#endif /* oatpp_test_base_LoggerTest_hpp */


### PR DESCRIPTION
We received several wishes to implement a runtime configuration of enabled log-level (the latest one being #261).
In this PR, the individual loglevels are converted to a bitmask rather than an ongoing number. Thus we can enable and disable single log levels without side-affects for the other levels.

However, to keep the `Logger` interface as generic as possible, this is only implemented for the `DefaultLogger`, not the interface. The new function `oatpp::base::Environment::getLogger()` is generic as well and only returns `std::shared_ptr<Logger>`. Therefore, the user has to use a pointer cast to `std::shared_ptr<DefaultLogger>` to be able to call the `disablePriority()` and `enablePriority()` functions. This is a design limitation to keep everything generic and extensible. 

```c++
auto logger = std::static_pointer_cast<oatpp::base::DefaultLogger>(oatpp::base::Environment::getLogger());
logger->disablePriority(oatpp::base::DefaultLogger::PRIORITY_D | oatpp::base::DefaultLogger::PRIORITY_I);
logger->enablePriority(oatpp::base::DefaultLogger::PRIORITY_D | oatpp::base::DefaultLogger::PRIORITY_I);
```

Multiple priorities can be or'd at once. 