### PR TITLE
Initial implementation of defaults for swagger

### DIFF
--- a/src/oatpp/core/data/mapping/type/Type.hpp
+++ b/src/oatpp/core/data/mapping/type/Type.hpp
@@ -280,7 +280,7 @@ public:
        * Description.
        */
       std::string description = "";
-      std::string default_value = "";
+      std::string defaultValue = "";
     };
 
   private:

--- a/src/oatpp/core/data/mapping/type/Type.hpp
+++ b/src/oatpp/core/data/mapping/type/Type.hpp
@@ -280,6 +280,7 @@ public:
        * Description.
        */
       std::string description = "";
+      std::string default_value = "";
     };
 
   private:

--- a/test/oatpp/core/data/mapping/type/ObjectTest.cpp
+++ b/test/oatpp/core/data/mapping/type/ObjectTest.cpp
@@ -47,6 +47,7 @@ class DtoA : public oatpp::DTO {
 
   DTO_FIELD_INFO(id) {
     info->description = "identifier";
+    info->default_value = "Some default id";
   }
   DTO_FIELD(String, id) = "Some default id";
 
@@ -66,6 +67,7 @@ class DtoB : public DtoA {
 
   DTO_FIELD_INFO(a) {
     info->description = "some field with a qualified name";
+    info->default_value = "default-value";
   }
   DTO_FIELD(String, a, "field-a") = "default-value";
 
@@ -129,6 +131,7 @@ void ObjectTest::onRun() {
     auto it = propsMap.find("id");
     OATPP_ASSERT(it != propsMap.end());
     OATPP_ASSERT(it->second->info.description == "identifier");
+    OATPP_ASSERT(it->second->info.default_value == "Some default id");
 
     OATPP_LOGI(TAG, "OK");
   }
@@ -145,12 +148,14 @@ void ObjectTest::onRun() {
       auto it = propsMap.find("id");
       OATPP_ASSERT("id" && it != propsMap.end());
       OATPP_ASSERT(it->second->info.description == "identifier");
+      OATPP_ASSERT(it->second->info.default_value == "Some default id");
     }
 
     {
       auto it = propsMap.find("field-a");
       OATPP_ASSERT("field-a" && it != propsMap.end());
       OATPP_ASSERT(it->second->info.description == "some field with a qualified name");
+      OATPP_ASSERT(it->second->info.default_value == "default-value");
     }
 
     OATPP_LOGI(TAG, "OK");

--- a/test/oatpp/core/data/mapping/type/ObjectTest.cpp
+++ b/test/oatpp/core/data/mapping/type/ObjectTest.cpp
@@ -47,7 +47,7 @@ class DtoA : public oatpp::DTO {
 
   DTO_FIELD_INFO(id) {
     info->description = "identifier";
-    info->default_value = "Some default id";
+    info->defaultValue = "Some default id";
   }
   DTO_FIELD(String, id) = "Some default id";
 
@@ -67,7 +67,7 @@ class DtoB : public DtoA {
 
   DTO_FIELD_INFO(a) {
     info->description = "some field with a qualified name";
-    info->default_value = "default-value";
+    info->defaultValue = "default-value";
   }
   DTO_FIELD(String, a, "field-a") = "default-value";
 
@@ -131,7 +131,7 @@ void ObjectTest::onRun() {
     auto it = propsMap.find("id");
     OATPP_ASSERT(it != propsMap.end());
     OATPP_ASSERT(it->second->info.description == "identifier");
-    OATPP_ASSERT(it->second->info.default_value == "Some default id");
+    OATPP_ASSERT(it->second->info.defaultValue == "Some default id");
 
     OATPP_LOGI(TAG, "OK");
   }
@@ -148,14 +148,14 @@ void ObjectTest::onRun() {
       auto it = propsMap.find("id");
       OATPP_ASSERT("id" && it != propsMap.end());
       OATPP_ASSERT(it->second->info.description == "identifier");
-      OATPP_ASSERT(it->second->info.default_value == "Some default id");
+      OATPP_ASSERT(it->second->info.defaultValue == "Some default id");
     }
 
     {
       auto it = propsMap.find("field-a");
       OATPP_ASSERT("field-a" && it != propsMap.end());
       OATPP_ASSERT(it->second->info.description == "some field with a qualified name");
-      OATPP_ASSERT(it->second->info.default_value == "default-value");
+      OATPP_ASSERT(it->second->info.defaultValue == "default-value");
     }
 
     OATPP_LOGI(TAG, "OK");


### PR DESCRIPTION
Following the issue https://github.com/oatpp/oatpp-swagger/issues/23
I don't think this serves as a complete solution for the defaults in swagger, as it should match the type of the field and I implemented it as a string in all cases. The word `default` is quite tricky as well so I went with `default_value`, if anything it makes it more explicit.
I'm open to all suggestions.