### PR TITLE
oatpp::data::stream::BufferOutputStream. Optimize growth.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,6 +118,8 @@ add_library(oatpp
         oatpp/core/parser/Caret.hpp
         oatpp/core/parser/ParsingError.cpp
         oatpp/core/parser/ParsingError.hpp
+        oatpp/core/utils/Binary.cpp
+        oatpp/core/utils/Binary.hpp
         oatpp/core/utils/ConversionUtils.cpp
         oatpp/core/utils/ConversionUtils.hpp
         oatpp/core/utils/Random.cpp

--- a/src/oatpp/core/data/stream/BufferStream.hpp
+++ b/src/oatpp/core/data/stream/BufferStream.hpp
@@ -39,7 +39,7 @@ private:
   p_char8 m_data;
   v_buff_size m_capacity;
   v_buff_size m_position;
-  v_buff_size m_growBytes;
+  v_buff_size m_maxCapacity;
   IOMode m_ioMode;
 public:
 
@@ -47,7 +47,7 @@ public:
    * Constructor.
    * @param growBytes
    */
-  BufferOutputStream(v_buff_size initialCapacity = 2048, v_buff_size growBytes = 2048);
+  BufferOutputStream(v_buff_size initialCapacity = 2048);
 
   /**
    * Virtual destructor.

--- a/src/oatpp/core/utils/Binary.cpp
+++ b/src/oatpp/core/utils/Binary.cpp
@@ -1,0 +1,41 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#include "Binary.hpp"
+
+namespace oatpp { namespace utils {
+
+v_int64 Binary::nextP2(v_int64 v) {
+  v--;
+  v |= v >> 1;
+  v |= v >> 2;
+  v |= v >> 4;
+  v |= v >> 8;
+  v |= v >> 16;
+  v |= v >> 32;
+  v++;
+  return v;
+}
+
+}}

--- a/src/oatpp/core/utils/Binary.hpp
+++ b/src/oatpp/core/utils/Binary.hpp
@@ -1,0 +1,50 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#ifndef oatpp_utils_Binary_hpp
+#define oatpp_utils_Binary_hpp
+
+#include "oatpp/core/base/Environment.hpp"
+
+namespace oatpp { namespace utils {
+
+/**
+ * Collection of methods for binary operations and arithmetics.
+ */
+class Binary {
+public:
+
+  /**
+   * Calculate the next power of 2. <br>
+   * Example: <br>
+   * `nextP2(127) = 128`, `nextP2(1025) = 2048`.
+   * @return
+   */
+  static v_int64 nextP2(v_int64 v);
+
+};
+
+}}
+
+#endif // oatpp_utils_Binary_hpp

--- a/src/oatpp/web/protocol/http/encoding/Chunked.cpp
+++ b/src/oatpp/web/protocol/http/encoding/Chunked.cpp
@@ -60,7 +60,7 @@ v_int32 EncoderChunked::iterate(data::buffer::InlineReadData& dataIn, data::buff
     if(m_writeChunkHeader) {
 
       async::Action action;
-      data::stream::BufferOutputStream stream(16, 16);
+      data::stream::BufferOutputStream stream(16);
       if(!m_firstChunk) {
         stream.write("\r\n", 2, action);
       }
@@ -88,7 +88,7 @@ v_int32 EncoderChunked::iterate(data::buffer::InlineReadData& dataIn, data::buff
   if(m_writeChunkHeader){
 
     async::Action action;
-    data::stream::BufferOutputStream stream(16, 16);
+    data::stream::BufferOutputStream stream(16);
     if(!m_firstChunk) {
       stream.write("\r\n", 2, action);
     }
@@ -115,7 +115,7 @@ v_int32 EncoderChunked::iterate(data::buffer::InlineReadData& dataIn, data::buff
 // DecoderChunked
 
 DecoderChunked::DecoderChunked()
-  : m_chunkHeaderBuffer(16, 16)
+  : m_chunkHeaderBuffer(16)
   , m_currentChunkSize(-1)
   , m_firstChunk(true)
   , m_finished(false)

--- a/src/oatpp/web/protocol/http/outgoing/Request.cpp
+++ b/src/oatpp/web/protocol/http/outgoing/Request.cpp
@@ -92,7 +92,7 @@ void Request::send(data::stream::OutputStream* stream){
     m_headers.put_LockFree(Header::CONTENT_LENGTH, "0");
   }
 
-  oatpp::data::stream::BufferOutputStream buffer(2048, 2048);
+  oatpp::data::stream::BufferOutputStream buffer(2048);
 
   buffer.writeSimple(m_method.getData(), m_method.getSize());
   buffer.writeSimple(" /", 2);

--- a/src/oatpp/web/server/HttpProcessor.cpp
+++ b/src/oatpp/web/server/HttpProcessor.cpp
@@ -70,8 +70,8 @@ HttpProcessor::ProcessingResources::ProcessingResources(const std::shared_ptr<Co
                                                         const std::shared_ptr<oatpp::data::stream::IOStream>& pConnection)
   : components(pComponents)
   , connection(pConnection)
-  , headersInBuffer(components->config->headersInBufferInitial, components->config->headersInBufferGrow)
-  , headersOutBuffer(components->config->headersOutBufferInitial, components->config->headersOutBufferGrow)
+  , headersInBuffer(components->config->headersInBufferInitial)
+  , headersOutBuffer(components->config->headersOutBufferInitial)
   , headersReader(&headersInBuffer, components->config->headersReaderChunkSize, components->config->headersReaderMaxSize)
   , inStream(data::stream::InputStreamBufferedProxy::createShared(connection, base::StrBuffer::createShared(data::buffer::IOBuffer::BUFFER_SIZE)))
 {}
@@ -210,9 +210,9 @@ HttpProcessor::Coroutine::Coroutine(const std::shared_ptr<Components>& component
                                     const std::shared_ptr<oatpp::data::stream::IOStream>& connection)
   : m_components(components)
   , m_connection(connection)
-  , m_headersInBuffer(components->config->headersInBufferInitial, components->config->headersInBufferGrow)
+  , m_headersInBuffer(components->config->headersInBufferInitial)
   , m_headersReader(&m_headersInBuffer, components->config->headersReaderChunkSize, components->config->headersReaderMaxSize)
-  , m_headersOutBuffer(std::make_shared<oatpp::data::stream::BufferOutputStream>(components->config->headersOutBufferInitial, components->config->headersOutBufferGrow))
+  , m_headersOutBuffer(std::make_shared<oatpp::data::stream::BufferOutputStream>(components->config->headersOutBufferInitial))
   , m_inStream(data::stream::InputStreamBufferedProxy::createShared(m_connection, base::StrBuffer::createShared(data::buffer::IOBuffer::BUFFER_SIZE)))
   , m_connectionState(oatpp::web::protocol::http::utils::CommunicationUtils::CONNECTION_STATE_KEEP_ALIVE)
 {}

--- a/src/oatpp/web/server/HttpProcessor.hpp
+++ b/src/oatpp/web/server/HttpProcessor.hpp
@@ -63,19 +63,9 @@ public:
     v_buff_size headersInBufferInitial = 2048;
 
     /**
-     * Buffer used to read headers in request. Size of the chunk to grow.
-     */
-    v_buff_size headersInBufferGrow = 2048;
-
-    /**
      * Buffer used to write headers in response. Initial size of the buffer.
      */
     v_buff_size headersOutBufferInitial = 2048;
-
-    /**
-     * Buffer used to write headers in response. Size of the chunk to grow.
-     */
-    v_buff_size headersOutBufferGrow = 2048;
 
     /**
      * Size of the chunk used for iterative-read of headers.

--- a/test/oatpp/AllTestsMain.cpp
+++ b/test/oatpp/AllTestsMain.cpp
@@ -70,6 +70,18 @@
 
 namespace {
 
+v_int64 calcNextP2(v_int64 v) {
+  v--;
+  v |= v >> 1;
+  v |= v >> 2;
+  v |= v >> 4;
+  v |= v >> 8;
+  v |= v >> 16;
+  v |= v >> 32;
+  v++;
+  return v;
+}
+
 void runTests() {
 
   oatpp::base::Environment::printCompilationConfig();

--- a/test/oatpp/core/data/stream/BufferStreamTest.cpp
+++ b/test/oatpp/core/data/stream/BufferStreamTest.cpp
@@ -26,6 +26,7 @@
 
 #include "oatpp/core/data/stream/BufferStream.hpp"
 #include "oatpp/core/utils/ConversionUtils.hpp"
+#include "oatpp/core/utils/Binary.hpp"
 
 namespace oatpp { namespace test { namespace core { namespace data { namespace stream {
 
@@ -128,22 +129,18 @@ void BufferStreamTest::onRun() {
       text = text + sample;
     }
 
-    for(v_int32 incStep = 1; incStep <= 1024; incStep ++) {
+    BufferOutputStream stream(0);
 
-      BufferOutputStream stream(0, incStep);
+    for(v_int32 i = 0; i < 1024; i++ ) {
+      stream << sample;
 
-      for(v_int32 i = 0; i < 1024; i++ ) {
-        stream << sample;
-
-        OATPP_ASSERT(stream.getCapacity() >= stream.getCurrentPosition());
-
-      }
-
-      OATPP_ASSERT(text == stream.toString());
-
-      OATPP_ASSERT(stream.getCapacity() < 1024 * (10 + 1));
+      OATPP_ASSERT(stream.getCapacity() >= stream.getCurrentPosition());
 
     }
+
+    OATPP_ASSERT(text == stream.toString());
+
+    OATPP_ASSERT(stream.getCapacity() == oatpp::utils::Binary::nextP2(1024 * (10)));
 
   }
 


### PR DESCRIPTION
Make the `oatpp::data::stream::BufferOutputStream` to grow by a factor of 2.
The [m_maxCapacity](https://github.com/oatpp/oatpp/compare/optimize_buffer_output_stream?expand=1#diff-f48230c096b596650980d36d03f1a28dR40) parameter will be configurable later - in order to avoid silent bugs.