### PR TITLE
Adds pattern to the info, to be used in swagger

### DIFF
--- a/src/oatpp/core/data/mapping/type/Type.hpp
+++ b/src/oatpp/core/data/mapping/type/Type.hpp
@@ -280,6 +280,7 @@ public:
        * Description.
        */
       std::string description = "";
+      std::string pattern = "";
     };
 
   private:

--- a/test/oatpp/core/data/mapping/type/ObjectTest.cpp
+++ b/test/oatpp/core/data/mapping/type/ObjectTest.cpp
@@ -47,6 +47,7 @@ class DtoA : public oatpp::DTO {
 
   DTO_FIELD_INFO(id) {
     info->description = "identifier";
+    info->pattern = "^[a-z0-9]+$";
   }
   DTO_FIELD(String, id) = "Some default id";
 
@@ -129,6 +130,7 @@ void ObjectTest::onRun() {
     auto it = propsMap.find("id");
     OATPP_ASSERT(it != propsMap.end());
     OATPP_ASSERT(it->second->info.description == "identifier");
+    OATPP_ASSERT(it->second->info.pattern == "^[a-z0-9]+$");
 
     OATPP_LOGI(TAG, "OK");
   }


### PR DESCRIPTION
Just the first step to have something like the following working:
```cpp
DTO_FIELD_INFO(start_date) {
    info->description = "Your start date";
    info->pattern = "^\d{4}-\d{2}-\d{2}$";
}
DTO_FIELD(String, start_date);
```
So in `oatpp-swagger` we can just pass it through and make the OAS like:
```json
"start-date": {
    "type": "string",
    "pattern": "^\d{4}-\d{2}-\d{2}$" // <- some swagger clients may now validate the string date with this
},
```