### PR TITLE
Throw HTTP/400 instead of HTTP/500 for invalid body-dto's (Closes #301)

### DIFF
--- a/src/oatpp/codegen/api_controller/base_define.hpp
+++ b/src/oatpp/codegen/api_controller/base_define.hpp
@@ -214,12 +214,22 @@ info->body.type = oatpp::data::mapping::type::__class::String::getType();
 // BODY_DTO MACRO // ------------------------------------------------------
 
 #define OATPP_MACRO_API_CONTROLLER_BODY_DTO(TYPE, PARAM_LIST) \
-const auto& OATPP_MACRO_FIRSTARG PARAM_LIST = \
-__request->readBodyToDto<TYPE>(getDefaultObjectMapper().get()); \
-if(!OATPP_MACRO_FIRSTARG PARAM_LIST) { \
-  return ApiController::handleError(Status::CODE_400, "Missing valid body parameter '" OATPP_MACRO_FIRSTARG_STR PARAM_LIST "'"); \
+TYPE OATPP_MACRO_FIRSTARG PARAM_LIST; \
+try { \
+  OATPP_MACRO_FIRSTARG PARAM_LIST = __request->readBodyToDto<TYPE>(getDefaultObjectMapper().get()); \
+  if(!OATPP_MACRO_FIRSTARG PARAM_LIST) { \
+    return ApiController::handleError(Status::CODE_400, "Missing valid body parameter '" OATPP_MACRO_FIRSTARG_STR PARAM_LIST "'"); \
+  } \
+} catch (const oatpp::parser::ParsingError &pe) {             \
+  oatpp::data::stream::BufferOutputStream buffer(pe.getMessage()->getSize() + 20); \
+  buffer.writeSimple(pe.getMessage()); \
+  buffer.writeSimple(" (Position: "); \
+  buffer.writeAsString(pe.getPosition()); \
+  buffer.writeSimple(")"); \
+  return ApiController::handleError(Status::CODE_400, buffer.toString()); \
+} catch (const std::runtime_error &re) {                     \
+  return ApiController::handleError(Status::CODE_400, re.what()); \
 }
-
 // __INFO
 
 #define OATPP_MACRO_API_CONTROLLER_BODY_DTO_INFO(TYPE, PARAM_LIST) \

--- a/test/oatpp/web/FullTest.cpp
+++ b/test/oatpp/web/FullTest.cpp
@@ -302,6 +302,13 @@ void FullTest::onRun() {
         OATPP_ASSERT(dtoOut->testValueInt == i);
       }
 
+      { // test POST with invalid dto body
+        auto dtoIn = app::AnotherTestDto::createShared();
+        dtoIn->testValue = i;
+        auto response = client->postInvalidBodyDto(dtoIn, connection);
+        OATPP_ASSERT(response->getStatusCode() == 400);
+      }
+
       { // test Enum as String
 
         OATPP_ASSERT(oatpp::Enum<app::AllowedPathParams>::getEntries().size() == 2);

--- a/test/oatpp/web/app/Client.hpp
+++ b/test/oatpp/web/app/Client.hpp
@@ -56,6 +56,7 @@ public:
   API_CALL("GET", "headers", getWithHeaders, HEADER(String, param, "X-TEST-HEADER"))
   API_CALL("POST", "body", postBody, BODY_STRING(String, body))
   API_CALL("POST", "body-dto", postBodyDto, BODY_DTO(Object<TestDto>, body))
+  API_CALL("POST", "body-dto", postInvalidBodyDto, BODY_DTO(Object<AnotherTestDto>, body))
 
   API_CALL("GET", "enum/as-string", getHeaderEnumAsString, HEADER(Enum<AllowedPathParams>::AsString, enumValue, "enum"))
   API_CALL("GET", "enum/as-number", getHeaderEnumAsNumber, HEADER(Enum<AllowedPathParams>::AsNumber, enumValue, "enum"))

--- a/test/oatpp/web/app/DTOs.hpp
+++ b/test/oatpp/web/app/DTOs.hpp
@@ -42,6 +42,14 @@ class TestDto : public oatpp::DTO {
   
 };
 
+class AnotherTestDto : public oatpp::DTO {
+    DTO_INIT(AnotherTestDto, DTO);
+
+    DTO_FIELD(Int32, testValue);
+    DTO_FIELD(String, testValueStr);
+    DTO_FIELD(Fields<Int32>, testMap);
+};
+
 ENUM(AllowedPathParams, v_int32,
   VALUE(HELLO, 100, "hello"),
   VALUE(WORLD, 200, "world")


### PR DESCRIPTION
Instead of throwing an HTTP/500 (internal server error) Oat++ can now detect invalid body-dto's and throws an HTTP/400 (bad request) if the body-dto isn't parsable or the wrong body-dto.

There is however, a bug in the tests: After running the 400-Test (test/oatpp/web/FullTest.cpp#305) the following echo-test fails. Does the connection get closed because of a "failed" request?