### PR TITLE
web::server::interceptor: introduce AllowCorsGlobal and AllowOptionsG…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -263,6 +263,8 @@ add_library(oatpp
         oatpp/web/server/handler/AuthorizationHandler.hpp
         oatpp/web/server/handler/ErrorHandler.cpp
         oatpp/web/server/handler/ErrorHandler.hpp
+        oatpp/web/server/interceptor/AllowCorsGlobal.cpp
+        oatpp/web/server/interceptor/AllowCorsGlobal.hpp
         oatpp/web/server/interceptor/RequestInterceptor.hpp
         oatpp/web/server/interceptor/ResponseInterceptor.hpp
         oatpp/web/url/mapping/Pattern.cpp

--- a/src/oatpp/web/server/HttpProcessor.cpp
+++ b/src/oatpp/web/server/HttpProcessor.cpp
@@ -112,18 +112,19 @@ bool HttpProcessor::processNextRequest(ProcessingResources& resources) {
       }
     }
 
-    auto route = resources.components->router->getRoute(headersReadResult.startingLine.method, headersReadResult.startingLine.path);
-
-    if(!route) {
-      response = resources.components->errorHandler->handleError(protocol::http::Status::CODE_404, "Current url has no mapping");
-      response->send(resources.connection.get(), &resources.headersOutBuffer, nullptr);
-      return false;
-    }
-
-    request->setPathVariables(route.getMatchMap());
-
     if(!response) {
+
+      auto route = resources.components->router->getRoute(headersReadResult.startingLine.method, headersReadResult.startingLine.path);
+
+      if(!route) {
+        response = resources.components->errorHandler->handleError(protocol::http::Status::CODE_404, "Current url has no mapping");
+        response->send(resources.connection.get(), &resources.headersOutBuffer, nullptr);
+        return false;
+      }
+
+      request->setPathVariables(route.getMatchMap());
       response = route.getEndpoint()->handle(request);
+
     }
 
     for(auto interceptor : resources.components->responseInterceptors) {

--- a/src/oatpp/web/server/interceptor/AllowCorsGlobal.cpp
+++ b/src/oatpp/web/server/interceptor/AllowCorsGlobal.cpp
@@ -1,0 +1,59 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#include "AllowCorsGlobal.hpp"
+
+namespace oatpp { namespace web { namespace server { namespace interceptor {
+
+std::shared_ptr<protocol::http::outgoing::Response> AllowOptionsGlobal::intercept(std::shared_ptr<IncomingRequest> &request) {
+
+  const auto &line = request->getStartingLine();
+
+  if (line.method == "OPTIONS") {
+    return OutgoingResponse::createShared(protocol::http::Status::CODE_204, nullptr);
+  }
+
+  return nullptr;
+
+}
+
+AllowCorsGlobal::AllowCorsGlobal(const oatpp::String &origin,
+                                 const oatpp::String &methods,
+                                 const oatpp::String &headers,
+                                 const oatpp::String &maxAge)
+  : m_origin(origin)
+  , m_methods(methods)
+  , m_headers(headers)
+  , m_maxAge(maxAge)
+{}
+
+std::shared_ptr<protocol::http::outgoing::Response> AllowCorsGlobal::intercept(std::shared_ptr<OutgoingResponse> &response) {
+  response->putHeaderIfNotExists(protocol::http::Header::CORS_ORIGIN, m_origin);
+  response->putHeaderIfNotExists(protocol::http::Header::CORS_METHODS, m_methods);
+  response->putHeaderIfNotExists(protocol::http::Header::CORS_HEADERS, m_headers);
+  response->putHeaderIfNotExists(protocol::http::Header::CORS_MAX_AGE, m_maxAge);
+  return response;
+}
+
+}}}}

--- a/src/oatpp/web/server/interceptor/AllowCorsGlobal.hpp
+++ b/src/oatpp/web/server/interceptor/AllowCorsGlobal.hpp
@@ -1,0 +1,57 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#ifndef oatpp_web_server_interceptor_AllowCorsGlobal_hpp
+#define oatpp_web_server_interceptor_AllowCorsGlobal_hpp
+
+#include "oatpp/web/server/interceptor/ResponseInterceptor.hpp"
+#include "oatpp/web/server/interceptor/RequestInterceptor.hpp"
+
+namespace oatpp { namespace web { namespace server { namespace interceptor {
+
+class AllowOptionsGlobal : public RequestInterceptor {
+public:
+  std::shared_ptr<OutgoingResponse> intercept(std::shared_ptr<IncomingRequest> &request) override;
+};
+
+class AllowCorsGlobal : public ResponseInterceptor {
+private:
+  oatpp::String m_origin;
+  oatpp::String m_methods;
+  oatpp::String m_headers;
+  oatpp::String m_maxAge;
+public:
+
+  AllowCorsGlobal(const oatpp::String &origin = "*",
+                  const oatpp::String &methods = "GET, POST, OPTIONS",
+                  const oatpp::String &headers = "DNT, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Range, Authorization",
+                  const oatpp::String &maxAge = "1728000");
+
+  std::shared_ptr<OutgoingResponse> intercept(std::shared_ptr<OutgoingResponse> &request) override;
+
+};
+
+}}}}
+
+#endif // oatpp_web_server_interceptor_AllowCorsGlobal_hpp


### PR DESCRIPTION
## Summary

Allow CORS for all endpoints:

```cpp
  OATPP_CREATE_COMPONENT(std::shared_ptr<oatpp::network::ConnectionHandler>, serverConnectionHandler)([] {

    OATPP_COMPONENT(std::shared_ptr<oatpp::web::server::HttpRouter>, router); 

    auto connectionHandler = oatpp::web::server::HttpConnectionHandler::createShared(router);

    /* Add CORS request and response interceptors */
    connectionHandler->addRequestInterceptor(std::make_shared<oatpp::web::server::interceptor::AllowOptionsGlobal>());
    connectionHandler->addResponseInterceptor(std::make_shared<oatpp::web::server::interceptor::AllowCorsGlobal>());

    return connectionHandler;

  }());
```

## Links
- #350
