### PR TITLE
WIP/Discussion: Let server check an (optional) stopping condition by itself

### DIFF
--- a/src/oatpp-test/UnitTest.hpp
+++ b/src/oatpp-test/UnitTest.hpp
@@ -25,6 +25,7 @@
 #ifndef oatpp_test_UnitTest_hpp
 #define oatpp_test_UnitTest_hpp
 
+#include <functional>
 #include "oatpp/core/base/Environment.hpp"
 
 namespace oatpp { namespace test {

--- a/src/oatpp-test/web/ClientServerTestRunner.hpp
+++ b/src/oatpp-test/web/ClientServerTestRunner.hpp
@@ -89,21 +89,25 @@ public:
     std::atomic<bool> running(true);
     std::mutex timeoutMutex;
     std::condition_variable timeoutCondition;
+    bool runConditionForLambda = true;
 
     m_server = std::make_shared<oatpp::network::Server>(m_connectionProvider, m_connectionHandler);
     OATPP_LOGD("\033[1;34mClientServerTestRunner\033[0m", "\033[1;34mRunning server on port %s. Timeout %lld(micro)\033[0m",
                m_connectionProvider->getProperty("port").toString()->c_str(),
                timeout.count());
 
-    std::thread serverThread([this]{
-      m_server->run();
-    });
+    std::function<bool()> condition = [runConditionForLambda](){
+        return runConditionForLambda;
+    };
 
-    std::thread clientThread([this, &lambda]{
+    m_server->run(true, condition);
+
+    std::thread clientThread([&runConditionForLambda, this, &lambda]{
 
       lambda();
 
-      m_server->stop();
+//      m_server->stop();
+      runConditionForLambda = false;
       m_connectionHandler->stop();
       m_connectionProvider->stop();
 
@@ -120,7 +124,6 @@ public:
 
     });
 
-    serverThread.join();
     clientThread.join();
 
     auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - startTime);

--- a/src/oatpp-test/web/ClientServerTestRunner.hpp
+++ b/src/oatpp-test/web/ClientServerTestRunner.hpp
@@ -96,7 +96,7 @@ public:
                m_connectionProvider->getProperty("port").toString()->c_str(),
                timeout.count());
 
-    std::function<bool()> condition = [runConditionForLambda](){
+    std::function<bool()> condition = [&runConditionForLambda](){
         return runConditionForLambda;
     };
 

--- a/src/oatpp/network/Server.cpp
+++ b/src/oatpp/network/Server.cpp
@@ -106,7 +106,7 @@ void Server::run(std::function<bool()> conditional) {
   m_condition = std::move(conditional);
 
   ul.unlock(); // early unlock
-  mainLoop(this);
+  conditionalMainLoop();
 }
 
 void Server::run(bool startAsNewThread) {

--- a/src/oatpp/network/Server.hpp
+++ b/src/oatpp/network/Server.hpp
@@ -35,6 +35,7 @@
 
 #include <atomic>
 #include <thread>
+#include <functional>
 
 namespace oatpp { namespace network {
 
@@ -46,13 +47,14 @@ class Server : public base::Countable {
 private:
 
   static void mainLoop(Server *instance);
-  
+
   bool setStatus(v_int32 expectedStatus, v_int32 newStatus);
   void setStatus(v_int32 status);
 
 private:
 
   std::atomic<v_int32> m_status;
+  std::function<bool()> m_condition;
   std::thread m_thread;
   std::mutex m_mutex;
 
@@ -116,7 +118,8 @@ public:
    * to &id:oatpp::network::ConnectionHandler;.
    * @param startAsNewThread - Start the server blocking (thread of callee) or non-blocking (own thread)
    */
-  void run(bool startAsNewThread = false);
+  void run(bool startAsNewThread, std::function<bool()> conditional = nullptr);
+
 
   /**
    * Break server loop.

--- a/test/oatpp/web/PipelineTest.cpp
+++ b/test/oatpp/web/PipelineTest.cpp
@@ -176,7 +176,7 @@ void PipelineTest::onRun() {
     pipeOutThread.join();
     pipeInThread.join();
 
-  }, std::chrono::minutes(10));
+  }, std::chrono::minutes(1));
 
   std::this_thread::sleep_for(std::chrono::seconds(1));
 


### PR DESCRIPTION
Instead of an external invocation of `stop()` to stop a running server, one could pass an lambda that returns true when the server should continue to run or false if it should stop.
Ideally this function should return as fast as possible and only do minimal amount of work. Like an interrupt function in µC.
This would ease the implementation of simple stopping mechanism that do not require external threads or other management.
For more complex functions, the minimal `bool()` function can be bound with `std::bind` to pass parameters etc.

In src/oatpp-test/web/ClientServerTestRunner.hpp a quick and dirty example is shown how a lambda is passed to `run()` which does nothing but return an bool that is modified somewhere other. This part isn't meant to be merged just as a dirty example.

Consider the following pseudo-code:

```c++
void RunApp() {
/* [...] */
  SomeLogicClass slc(); // does some logic, maybe reads some other sockets or whatever in its own thread etc

  std::function<bool()> condition = [&slc]() {
    return slc.HasError() == false;
  };

  /* Create server which takes provided TCP connections and passes them to HTTP connection handler */
  oatpp::network::Server server(connectionProvider, connectionHandler);
  
  server.run(false /* run in this thread */, condition);
}
```

In this example, the condition-lambda checks if an other part of our application logic has an error. If not, the lambda returns true and the server continues to run. If an error occurs, the lambda returns false and the server stops.

There are other ways to archive this behaviour. One could pass an `shared_ptr` to the `SomeLogicClass` which then calls `server.stop()` in its error handler. However, this may not be possible because the `SomeLogicClass` is an blackbox-library. 
Another option would be to have an entire thread just checking the error-status of `SomeLogicClass` and then calls `server.stop()` which might be to big of an overhead. 


