### PR TITLE
EndpointInfo: Add example field for parameters.

### DIFF
--- a/src/oatpp/codegen/api_controller/base_define.hpp
+++ b/src/oatpp/codegen/api_controller/base_define.hpp
@@ -209,11 +209,18 @@ const auto& OATPP_MACRO_FIRSTARG PARAM_LIST = __request->readBodyToString();
 
 #define OATPP_MACRO_API_CONTROLLER_BODY_STRING_INFO(TYPE, PARAM_LIST) \
 info->body.name = OATPP_MACRO_FIRSTARG_STR PARAM_LIST; \
-info->body.type = oatpp::data::mapping::type::__class::String::getType();
+info->body.required = true; \
+info->body.type = oatpp::data::mapping::type::__class::String::getType(); \
+if(getDefaultObjectMapper()) { \
+  info->bodyContentType = getDefaultObjectMapper()->getInfo().http_content_type; \
+}
 
 // BODY_DTO MACRO // ------------------------------------------------------
 
 #define OATPP_MACRO_API_CONTROLLER_BODY_DTO(TYPE, PARAM_LIST) \
+if(!getDefaultObjectMapper()) { \
+  return ApiController::handleError(Status::CODE_500, "ObjectMapper was NOT set. Can't deserialize the request body."); \
+} \
 const auto& OATPP_MACRO_FIRSTARG PARAM_LIST = \
 __request->readBodyToDto<TYPE>(getDefaultObjectMapper().get()); \
 if(!OATPP_MACRO_FIRSTARG PARAM_LIST) { \
@@ -224,7 +231,11 @@ if(!OATPP_MACRO_FIRSTARG PARAM_LIST) { \
 
 #define OATPP_MACRO_API_CONTROLLER_BODY_DTO_INFO(TYPE, PARAM_LIST) \
 info->body.name = OATPP_MACRO_FIRSTARG_STR PARAM_LIST; \
-info->body.type = TYPE::Class::getType();
+info->body.required = true; \
+info->body.type = TYPE::Class::getType(); \
+if(getDefaultObjectMapper()) { \
+  info->bodyContentType = getDefaultObjectMapper()->getInfo().http_content_type; \
+}
 
 // FOR EACH // ------------------------------------------------------
 

--- a/src/oatpp/web/server/api/Endpoint.hpp
+++ b/src/oatpp/web/server/api/Endpoint.hpp
@@ -67,7 +67,8 @@ public:
       oatpp::Boolean required = true;
       oatpp::Boolean deprecated = false;
       oatpp::Boolean allowEmptyValue;
-      
+      oatpp::Any example;
+
     };
 
     /**
@@ -111,10 +112,11 @@ public:
     /**
      * Hints about the response (content-type, schema, description, ...)
      */
-    struct ResponseHints {
+    struct ContentHints {
       oatpp::String contentType;
       oatpp::data::mapping::type::Type* schema;
       oatpp::String description;
+      oatpp::Any example;
     };
     
   public:
@@ -183,7 +185,7 @@ public:
     /**
      * Consumes.
      */
-    std::list<ResponseHints> consumes;
+    std::list<ContentHints> consumes;
 
     /**
      * Security Requirements
@@ -209,7 +211,7 @@ public:
      *  ResponseCode to {ContentType, Type} mapping.
      *  Example responses[Status::CODE_200] = {"application/json", MyDto::ObjectWrapper::Class::getType()};
      */
-    std::unordered_map<oatpp::web::protocol::http::Status, ResponseHints> responses;
+    std::unordered_map<oatpp::web::protocol::http::Status, ContentHints> responses;
     
     oatpp::String toString();
 
@@ -219,8 +221,9 @@ public:
      * @param contentType
      */
     template<class Wrapper>
-    void addConsumes(const oatpp::String& contentType, const oatpp::String& description = oatpp::String()) {
+    ContentHints& addConsumes(const oatpp::String& contentType, const oatpp::String& description = oatpp::String()) {
       consumes.push_back({contentType, Wrapper::Class::getType(), description});
+      return consumes.back();
     }
 
     /**
@@ -231,8 +234,12 @@ public:
      * @param responseDescription
      */
     template<class Wrapper>
-    void addResponse(const oatpp::web::protocol::http::Status& status, const oatpp::String& contentType, const oatpp::String& responseDescription = oatpp::String()) {
-      responses[status] = {contentType, Wrapper::Class::getType(), responseDescription.get() == nullptr ? status.description : responseDescription};
+    ContentHints& addResponse(const oatpp::web::protocol::http::Status& status, const oatpp::String& contentType, const oatpp::String& responseDescription = oatpp::String()) {
+      auto& hint = responses[status];
+      hint.contentType = contentType;
+      hint.description = responseDescription.get() == nullptr ? status.description : responseDescription;
+      hint.schema = Wrapper::Class::getType();
+      return hint;
     }
 
     /**


### PR DESCRIPTION
- Add example field to EndpointInfo::Param
- Better API for `EndpointInfo::addConsumes`, `EndpointInfo::addResponse`
- Set Endpoint `info->bodyContentType` according to controller's default object mapper.
- Return error if endpoint consumes `BODY_DTO` but no default object mapper was set for controller
- Set Endpoint `info->body.required = true;` if `BODY` or `BODY_DTO` parameter is present in `ENDPOINT`.

Links:
- https://github.com/oatpp/oatpp-swagger/issues/33
- https://github.com/oatpp/oatpp/issues/368