### PR TITLE
Fix wrong calling of conditional loop if condition is null (Closes #372)

### DIFF
--- a/src/oatpp/network/Server.cpp
+++ b/src/oatpp/network/Server.cpp
@@ -103,10 +103,14 @@ void Server::run(std::function<bool()> conditional) {
   m_threaded = false;
   setStatus(STATUS_CREATED, STATUS_STARTING);
 
-  m_condition = std::move(conditional);
-
-  ul.unlock(); // early unlock
-  conditionalMainLoop();
+  if (conditional) {
+    m_condition = std::move(conditional);
+    ul.unlock(); // early unlock
+    conditionalMainLoop();
+  } else {
+    ul.unlock();
+    mainLoop(this);
+  }
 }
 
 void Server::run(bool startAsNewThread) {


### PR DESCRIPTION
If `server->run()` is called (no argument given, thus `conditional` is `nullptr`) the `conditionalMainLoop` was called instead of the normal `mainLoop`.
First reported in Issue #372.

Now the correct normal `mainLoop` is called when no conditional function was given. 