### PR TITLE
Add optional default-value for QUERY parameters to ease the implementation of optional QUERY parameters

### DIFF
--- a/src/oatpp/codegen/api_controller/base_define.hpp
+++ b/src/oatpp/codegen/api_controller/base_define.hpp
@@ -186,6 +186,17 @@ if(!__param_validation_check_##NAME){ \
                                     "'. Expected type is '" #TYPE "'"); \
 }
 
+#define OATPP_MACRO_API_CONTROLLER_QUERY_3(TYPE, NAME, QUALIFIER, DEFAULT) \
+const auto& __param_str_val_##NAME = __request->getQueryParameter(QUALIFIER, DEFAULT); \
+bool __param_validation_check_##NAME; \
+const auto& NAME = ApiController::TypeInterpretation<TYPE>::fromString(#TYPE, __param_str_val_##NAME, __param_validation_check_##NAME); \
+if(!__param_validation_check_##NAME){ \
+  return ApiController::handleError(Status::CODE_400, \
+                                    oatpp::String("Invalid QUERY parameter '") + \
+                                    QUALIFIER + \
+                                    "'. Expected type is '" #TYPE "'"); \
+}
+
 #define OATPP_MACRO_API_CONTROLLER_QUERY(TYPE, PARAM_LIST) \
 OATPP_MACRO_API_CONTROLLER_MACRO_SELECTOR(OATPP_MACRO_API_CONTROLLER_QUERY_, TYPE, OATPP_MACRO_UNFOLD_VA_ARGS PARAM_LIST)
 
@@ -195,6 +206,9 @@ OATPP_MACRO_API_CONTROLLER_MACRO_SELECTOR(OATPP_MACRO_API_CONTROLLER_QUERY_, TYP
 info->queryParams.add(#NAME, TYPE::Class::getType());
 
 #define OATPP_MACRO_API_CONTROLLER_QUERY_INFO_2(TYPE, NAME, QUALIFIER) \
+info->queryParams.add(QUALIFIER, TYPE::Class::getType());
+
+#define OATPP_MACRO_API_CONTROLLER_QUERY_INFO_3(TYPE, NAME, QUALIFIER, DEFAULT) \
 info->queryParams.add(QUALIFIER, TYPE::Class::getType());
 
 #define OATPP_MACRO_API_CONTROLLER_QUERY_INFO(TYPE, PARAM_LIST) \

--- a/test/oatpp/web/FullTest.cpp
+++ b/test/oatpp/web/FullTest.cpp
@@ -264,6 +264,14 @@ void FullTest::onRun() {
         OATPP_ASSERT(dto->testValue == "name=oatpp&age=1");
       }
 
+      { // test GET with optional query parameters
+        auto response = client->getWithOptQueries("oatpp", connection);
+        OATPP_ASSERT(response->getStatusCode() == 200);
+        auto dto = response->readBodyToDto<oatpp::Object<app::TestDto>>(objectMapper.get());
+        OATPP_ASSERT(dto);
+        OATPP_ASSERT(dto->testValue == "name=oatpp&age=101");
+      }
+
       { // test GET with query parameters
         auto response = client->getWithQueriesMap("value1", 32, 0.32f, connection);
         OATPP_ASSERT(response->getStatusCode() == 200);

--- a/test/oatpp/web/app/Client.hpp
+++ b/test/oatpp/web/app/Client.hpp
@@ -52,6 +52,7 @@ public:
   API_CALL("GET", "/cors-origin-methods-headers", getCorsOriginMethodsHeader)
   API_CALL("GET", "params/{param}", getWithParams, PATH(String, param))
   API_CALL("GET", "queries", getWithQueries, QUERY(String, name), QUERY(Int32, age))
+  API_CALL("GET", "queries/optional", getWithOptQueries, QUERY(String, name))
   API_CALL("GET", "queries/map", getWithQueriesMap, QUERY(String, key1), QUERY(Int32, key2), QUERY(Float32, key3))
   API_CALL("GET", "headers", getWithHeaders, HEADER(String, param, "X-TEST-HEADER"))
   API_CALL("POST", "body", postBody, BODY_STRING(String, body))

--- a/test/oatpp/web/app/Controller.hpp
+++ b/test/oatpp/web/app/Controller.hpp
@@ -117,6 +117,13 @@ public:
     return createDtoResponse(Status::CODE_200, dto);
   }
 
+  ENDPOINT("GET", "queries/optional", getWithOptQueries,
+           QUERY(String, name, "name", "Default"), QUERY(Int32, age, "age", "101")) {
+    auto dto = TestDto::createShared();
+    dto->testValue = "name=" + name + "&age=" + oatpp::utils::conversion::int32ToStr(*age);
+    return createDtoResponse(Status::CODE_200, dto);
+  }
+
   ENDPOINT("GET", "queries/map", getWithQueriesMap,
            QUERIES(QueryParams, queries)) {
     auto dto = TestDto::createShared();


### PR DESCRIPTION
This PR adds a fourth parameter to QUERY() where the string-representation of an default-value can be set. Thus allowing for optional QUERY parameters. 