### PR TITLE
json::mapping::Serializer::Config: Introduce escapeFlags (#381)

### DIFF
--- a/src/oatpp/parser/json/Utils.cpp
+++ b/src/oatpp/parser/json/Utils.cpp
@@ -29,7 +29,7 @@
 
 namespace oatpp { namespace parser { namespace json{
 
-v_buff_size Utils::calcEscapedStringSize(p_char8 data, v_buff_size size, v_buff_size& safeSize) {
+v_buff_size Utils::calcEscapedStringSize(p_char8 data, v_buff_size size, v_buff_size& safeSize, v_uint32 flags) {
   v_buff_size result = 0;
   v_buff_size i = 0;
   safeSize = size;
@@ -37,18 +37,39 @@ v_buff_size Utils::calcEscapedStringSize(p_char8 data, v_buff_size size, v_buff_
     v_char8 a = data[i];
     if(a < 32) {
       i ++;
-      if(a == '\b' || a == '\f' || a == '\n' || a == '\r' || a == '\t'){
-        result += 2; // '\n'
-      } else {
-        result += 6; // '\uFFFF' - 6 chars
+
+      switch (a) {
+
+        case '\b':
+        case '\f':
+        case '\n':
+        case '\r':
+        case '\t': result += 2; break; // '\n'
+
+        default:
+          result += 6; // '\uFFFF' - 6 chars
+          break;
+
       }
+
     } else if(a < 128){
       i ++;
-      if(a == '\"' || a == '\\' || a == '/'){
-        result += 2; // '\/'
-      } else {
-        result ++;
+
+      switch (a) {
+        case '\"':
+        case '\\': result += 2; break; // '\/'
+
+        case '/':
+          result ++;
+          if((flags & FLAG_ESCAPE_SOLIDUS) > 0) result ++;
+          break;
+
+        default:
+          result ++;
+          break;
+
       }
+
     } else {
       v_buff_size charSize = oatpp::encoding::Unicode::getUtf8CharSequenceLength(a);
       if(charSize != 0) {
@@ -196,9 +217,9 @@ v_buff_size Utils::escapeUtf8Char(p_char8 sequence, p_char8 buffer){
   }
 }
   
-oatpp::String Utils::escapeString(p_char8 data, v_buff_size size, bool copyAsOwnData) {
+oatpp::String Utils::escapeString(p_char8 data, v_buff_size size, bool copyAsOwnData, v_uint32 flags) {
   v_buff_size safeSize;
-  v_buff_size escapedSize = calcEscapedStringSize(data, size, safeSize);
+  v_buff_size escapedSize = calcEscapedStringSize(data, size, safeSize, flags);
   if(escapedSize == size) {
     return String((const char*)data, size, copyAsOwnData);
   }
@@ -211,43 +232,51 @@ oatpp::String Utils::escapeString(p_char8 data, v_buff_size size, bool copyAsOwn
     while (i < safeSize) {
       v_char8 a = data[i];
       if (a < 32) {
-        if (a == '\b') {
-          resultData[pos] = '\\'; resultData[pos + 1] = 'b'; pos += 2;
+
+        switch (a) {
+
+          case '\b': resultData[pos] = '\\'; resultData[pos + 1] = 'b'; pos += 2; break;
+          case '\f': resultData[pos] = '\\'; resultData[pos + 1] = 'f'; pos += 2; break;
+          case '\n': resultData[pos] = '\\'; resultData[pos + 1] = 'n'; pos += 2; break;
+          case '\r': resultData[pos] = '\\'; resultData[pos + 1] = 'r'; pos += 2; break;
+          case '\t': resultData[pos] = '\\'; resultData[pos + 1] = 't'; pos += 2; break;
+
+          default:
+            resultData[pos] = '\\';
+            resultData[pos + 1] = 'u';
+            oatpp::encoding::Hex::writeUInt16(a, &resultData[pos + 2]);
+            pos += 6;
+            break;
+
         }
-        else if (a == '\f') {
-          resultData[pos] = '\\'; resultData[pos + 1] = 'f'; pos += 2;
-        }
-        else if (a == '\n') {
-          resultData[pos] = '\\'; resultData[pos + 1] = 'n'; pos += 2;
-        }
-        else if (a == '\r') {
-          resultData[pos] = '\\'; resultData[pos + 1] = 'r'; pos += 2;
-        }
-        else if (a == '\t') {
-          resultData[pos] = '\\'; resultData[pos + 1] = 't'; pos += 2;
-        }
-        else {
-          resultData[pos] = '\\';
-          resultData[pos + 1] = 'u';
-          oatpp::encoding::Hex::writeUInt16(a, &resultData[pos + 2]);
-          pos += 6;
-        }
+
         i++;
+
       }
       else if (a < 128) {
-        if (a == '\"') {
-          resultData[pos] = '\\'; resultData[pos + 1] = '"'; pos += 2;
+
+        switch (a) {
+          case '\"': resultData[pos] = '\\'; resultData[pos + 1] = '"'; pos += 2; break;
+          case '\\': resultData[pos] = '\\'; resultData[pos + 1] = '\\'; pos += 2; break;
+
+          case '/':
+            if((flags & FLAG_ESCAPE_SOLIDUS) > 0) {
+              resultData[pos] = '\\';
+              resultData[pos + 1] = '/';
+              pos += 2;
+            } else {
+              resultData[pos] = data[i];
+              pos++;
+            }
+            break;
+
+          default:
+            resultData[pos] = data[i];
+            pos++;
+            break;
+
         }
-        else if (a == '\\') {
-          resultData[pos] = '\\'; resultData[pos + 1] = '\\'; pos += 2;
-        }
-        else if (a == '/') {
-          resultData[pos] = '\\'; resultData[pos + 1] = '/'; pos += 2;
-        }
-        else {
-          resultData[pos] = data[i];
-          pos++;
-        }
+
         i++;
       }
       else {

--- a/src/oatpp/parser/json/Utils.hpp
+++ b/src/oatpp/parser/json/Utils.hpp
@@ -39,6 +39,12 @@ namespace oatpp { namespace parser { namespace json {
 class Utils {
 public:
 
+  static constexpr v_uint32 FLAG_ESCAPE_SOLIDUS = 1;
+
+  static constexpr v_uint32 FLAG_ESCAPE_ALL = FLAG_ESCAPE_SOLIDUS;
+
+public:
+
   /**
    * ERROR_CODE_INVALID_ESCAPED_CHAR
    */
@@ -60,7 +66,7 @@ public:
   typedef oatpp::parser::Caret ParsingCaret;
 private:
   static v_buff_size escapeUtf8Char(p_char8 sequence, p_char8 buffer);
-  static v_buff_size calcEscapedStringSize(p_char8 data, v_buff_size size, v_buff_size& safeSize);
+  static v_buff_size calcEscapedStringSize(p_char8 data, v_buff_size size, v_buff_size& safeSize, v_uint32 flags);
   static v_buff_size calcUnescapedStringSize(p_char8 data, v_buff_size size, v_int64& errorCode, v_buff_size& errorPosition);
   static void unescapeStringToBuffer(p_char8 data, v_buff_size size, p_char8 resultData);
   static p_char8 preparseString(ParsingCaret& caret, v_buff_size& size);
@@ -72,9 +78,10 @@ public:
    * @param data - pointer to string to escape.
    * @param size - data size.
    * @param copyAsOwnData - see &id:oatpp::base::StrBuffer::StrBuffer;.
+   * @param flags - escape flags.
    * @return - &id:oatpp::String;.
    */
-  static String escapeString(p_char8 data, v_buff_size size, bool copyAsOwnData = true);
+  static String escapeString(p_char8 data, v_buff_size size, bool copyAsOwnData = true, v_uint32 flags = FLAG_ESCAPE_ALL);
 
   /**
    * Unescape string as for json standard.

--- a/src/oatpp/parser/json/mapping/Serializer.hpp
+++ b/src/oatpp/parser/json/mapping/Serializer.hpp
@@ -25,6 +25,7 @@
 #ifndef oatpp_parser_json_mapping_Serializer_hpp
 #define oatpp_parser_json_mapping_Serializer_hpp
 
+#include "oatpp/parser/json/Utils.hpp"
 #include "oatpp/parser/json/Beautifier.hpp"
 #include "oatpp/core/Types.hpp"
 #include <vector>
@@ -96,6 +97,11 @@ public:
      */
     std::vector<std::string> enabledInterpretations = {};
 
+    /**
+     * Escape flags.
+     */
+    v_uint32 escapeFlags = json::Utils::FLAG_ESCAPE_ALL;
+
   };
 public:
   typedef void (*SerializerMethod)(Serializer*,
@@ -155,10 +161,10 @@ private:
 
     for(auto& pair : *map) {
       const auto& value = pair.second;
-      if(value || serializer->getConfig()->includeNullFields) {
+      if(value || serializer->m_config->includeNullFields) {
         (first) ? first = false : stream->writeSimple(",", 1);
         const auto& key = pair.first;
-        serializeString(stream, key->getData(), key->getSize());
+        serializeString(stream, key->getData(), key->getSize(), serializer->m_config->escapeFlags);
         stream->writeSimple(":", 1);
         serializer->serialize(stream, value);
       }
@@ -168,7 +174,11 @@ private:
 
   }
 
-  static void serializeString(oatpp::data::stream::ConsistentOutputStream* stream, p_char8 data, v_buff_size size);
+  static void serializeString(oatpp::data::stream::ConsistentOutputStream* stream,
+                              p_char8 data,
+                              v_buff_size size,
+                              v_uint32 escapeFlags);
+
   static void serializeString(Serializer* serializer,
                               data::stream::ConsistentOutputStream* stream,
                               const oatpp::Void& polymorph);


### PR DESCRIPTION
Now user can disable `'/'` escaping. 
String `"https://oatpp.io/"` will be serialized as `"https://oatpp.io/` instead of `"https:\/\/oatpp.io\/"`

```cpp
objectMapper->getSerializer()->getConfig()->escapeFlags &= !oatpp::parser::json::Utils::FLAG_ESCAPE_SOLIDUS;
```

Links:
- #381 