### PR TITLE
Fix a 64bit function that was also being called when the environment …

### DIFF
--- a/src/oatpp/core/base/Environment.cpp
+++ b/src/oatpp/core/base/Environment.cpp
@@ -33,10 +33,17 @@
 #include <cstdarg>
 
 #if defined(WIN32) || defined(_WIN32)
-#include <WinSock2.h>
+	#include <WinSock2.h>
+#endif
 
+#if (defined(WIN32) || defined(_WIN32)) && defined(_WIN64)
 struct tm* localtime_r(time_t *_clock, struct tm *_result) {
     _localtime64_s(_result, _clock);
+    return _result;
+}
+#elif (defined(WIN32) || defined(_WIN32)) && not defined(_WIN64)
+struct tm* localtime_r(time_t *_clock, struct tm *_result) {
+    _localtime32_s(_result, _clock);
     return _result;
 }
 #endif


### PR DESCRIPTION
…is 32btis.

The function _localtime64 was being called inside a ifdef WIN32 which
makes it try to compile even when it's in a 32bti environment.
Now if it calls _localtime32 in that case.
Tested on Windows using Msys+mingw 32bit shell.

Signed-off-by: Samega 7Cattac <7Cattac@gmail.com>