### PR TITLE
Let the ConnectionHandlers count how many threads they spawn.

### DIFF
--- a/src/oatpp/web/server/AsyncHttpConnectionHandler.cpp
+++ b/src/oatpp/web/server/AsyncHttpConnectionHandler.cpp
@@ -30,6 +30,7 @@ AsyncHttpConnectionHandler::AsyncHttpConnectionHandler(const std::shared_ptr<Htt
                                                        v_int32 threadCount)
   : m_executor(std::make_shared<oatpp::async::Executor>(threadCount))
   , m_components(components)
+  , m_spawns(std::make_shared<std::atomic_ulong>(0))
 {
   m_executor->detach();
 }
@@ -38,6 +39,7 @@ AsyncHttpConnectionHandler::AsyncHttpConnectionHandler(const std::shared_ptr<Htt
                                                        const std::shared_ptr<oatpp::async::Executor>& executor)
   : m_executor(executor)
   , m_components(components)
+  , m_spawns(std::make_shared<std::atomic_ulong>(0))
 {}
 
 std::shared_ptr<AsyncHttpConnectionHandler> AsyncHttpConnectionHandler::createShared(const std::shared_ptr<HttpRouter>& router, v_int32 threadCount){
@@ -72,12 +74,26 @@ void AsyncHttpConnectionHandler::handleConnection(const std::shared_ptr<IOStream
   connection->setOutputStreamIOMode(oatpp::data::stream::IOMode::ASYNCHRONOUS);
   connection->setInputStreamIOMode(oatpp::data::stream::IOMode::ASYNCHRONOUS);
 
-  m_executor->execute<HttpProcessor::Coroutine>(m_components, connection);
+  m_executor->execute<HttpProcessor::Coroutine>(m_components, connection, m_spawns);
   
 }
 
 void AsyncHttpConnectionHandler::stop() {
-  // DO NOTHING
+  /* Wait until all connection-threads are done but no longer than 1min */
+  auto startTime = std::chrono::system_clock::now();
+  auto timeout = std::chrono::minutes(1);
+
+  while(m_spawns->load() != 0) {
+    auto elapsed = std::chrono::system_clock::now() - startTime;
+    if(elapsed < timeout) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    } else {
+      if (m_spawns->load() > 0) {
+        OATPP_LOGW("[oatpp::web::server::AsyncHttpConnectionHandler::stop()]", "Timeout while waiting 1 minute for all connections to close. There are %ul connections still alive.", m_spawns->load());
+      }
+      break;
+    }
+  }
 }
   
 }}}

--- a/src/oatpp/web/server/AsyncHttpConnectionHandler.hpp
+++ b/src/oatpp/web/server/AsyncHttpConnectionHandler.hpp
@@ -38,7 +38,8 @@ class AsyncHttpConnectionHandler : public base::Countable, public network::Conne
 private:
   std::shared_ptr<oatpp::async::Executor> m_executor;
   std::shared_ptr<HttpProcessor::Components> m_components;
-  std::shared_ptr<std::atomic_ulong> m_spawns;
+  std::atomic_long m_spawns;
+  std::atomic_bool m_continue;
 public:
 
   /**

--- a/src/oatpp/web/server/AsyncHttpConnectionHandler.hpp
+++ b/src/oatpp/web/server/AsyncHttpConnectionHandler.hpp
@@ -37,8 +37,8 @@ namespace oatpp { namespace web { namespace server {
 class AsyncHttpConnectionHandler : public base::Countable, public network::ConnectionHandler {
 private:
   std::shared_ptr<oatpp::async::Executor> m_executor;
-private:
   std::shared_ptr<HttpProcessor::Components> m_components;
+  std::shared_ptr<std::atomic_ulong> m_spawns;
 public:
 
   /**

--- a/src/oatpp/web/server/HttpConnectionHandler.cpp
+++ b/src/oatpp/web/server/HttpConnectionHandler.cpp
@@ -74,7 +74,7 @@ void HttpConnectionHandler::handleConnection(const std::shared_ptr<oatpp::data::
     connection->setInputStreamIOMode(oatpp::data::stream::IOMode::BLOCKING);
 
     /* Create working thread */
-    std::thread thread(&HttpProcessor::Task::run, HttpProcessor::Task(m_components, connection, &m_spawns));
+    std::thread thread(&HttpProcessor::Task::run, std::move(HttpProcessor::Task(m_components, connection, &m_spawns)));
 
     /* Get hardware concurrency -1 in order to have 1cpu free of workers. */
     v_int32 concurrency = oatpp::concurrency::getHardwareConcurrency();

--- a/src/oatpp/web/server/HttpConnectionHandler.hpp
+++ b/src/oatpp/web/server/HttpConnectionHandler.hpp
@@ -37,6 +37,7 @@ namespace oatpp { namespace web { namespace server {
 class HttpConnectionHandler : public base::Countable, public network::ConnectionHandler {
 private:
   std::shared_ptr<HttpProcessor::Components> m_components;
+  std::shared_ptr<std::atomic_ulong> m_spawns;
 public:
 
   /**

--- a/src/oatpp/web/server/HttpConnectionHandler.hpp
+++ b/src/oatpp/web/server/HttpConnectionHandler.hpp
@@ -37,7 +37,8 @@ namespace oatpp { namespace web { namespace server {
 class HttpConnectionHandler : public base::Countable, public network::ConnectionHandler {
 private:
   std::shared_ptr<HttpProcessor::Components> m_components;
-  std::shared_ptr<std::atomic_ulong> m_spawns;
+  std::atomic_long m_spawns;
+  std::atomic_bool m_continue;
 public:
 
   /**

--- a/src/oatpp/web/server/HttpProcessor.cpp
+++ b/src/oatpp/web/server/HttpProcessor.cpp
@@ -244,6 +244,24 @@ HttpProcessor::Task::Task(HttpProcessor::Task &&move)
   move.m_counter = nullptr;
 }
 
+HttpProcessor::Task &HttpProcessor::Task::operator=(const HttpProcessor::Task &t) {
+  if (this != &t) {
+    m_components = t.m_components;
+    m_connection = t.m_connection;
+    m_counter = t.m_counter;
+    (*m_counter)++;
+  }
+  return *this;
+}
+
+HttpProcessor::Task &HttpProcessor::Task::operator=(HttpProcessor::Task &&t) {
+  m_components = std::move(t.m_components);
+  m_connection = std::move(t.m_connection);
+  m_counter = t.m_counter;
+  t.m_counter = nullptr;
+  return *this;
+}
+
 void HttpProcessor::Task::run(){
 
   m_connection->initContexts();

--- a/src/oatpp/web/server/HttpProcessor.cpp
+++ b/src/oatpp/web/server/HttpProcessor.cpp
@@ -220,7 +220,7 @@ HttpProcessor::ConnectionState HttpProcessor::processNextRequest(ProcessingResou
 
 HttpProcessor::Task::Task(const std::shared_ptr<Components>& components,
                           const std::shared_ptr<oatpp::data::stream::IOStream>& connection,
-                          const std::shared_ptr<std::atomic_ulong>& taskCounter)
+                          std::atomic_long *taskCounter)
   : m_components(components)
   , m_connection(connection)
   , m_counter(taskCounter)
@@ -257,7 +257,7 @@ void HttpProcessor::Task::run(){
 
 HttpProcessor::Coroutine::Coroutine(const std::shared_ptr<Components>& components,
                                     const std::shared_ptr<oatpp::data::stream::IOStream>& connection,
-                                    const std::shared_ptr<std::atomic_ulong>& taskCounter)
+                                    std::atomic_long *taskCounter)
   : m_components(components)
   , m_connection(connection)
   , m_headersInBuffer(components->config->headersInBufferInitial)

--- a/src/oatpp/web/server/HttpProcessor.cpp
+++ b/src/oatpp/web/server/HttpProcessor.cpp
@@ -236,6 +236,14 @@ HttpProcessor::Task::Task(const HttpProcessor::Task &copy)
   (*m_counter)++;
 }
 
+HttpProcessor::Task::Task(HttpProcessor::Task &&move)
+  : m_components(std::move(move.m_components))
+  , m_connection(std::move(move.m_connection))
+  , m_counter(move.m_counter)
+{
+  move.m_counter = nullptr;
+}
+
 void HttpProcessor::Task::run(){
 
   m_connection->initContexts();
@@ -258,7 +266,9 @@ void HttpProcessor::Task::run(){
 
 }
 HttpProcessor::Task::~Task() {
-  (*m_counter)--;
+  if (m_counter != nullptr) {
+    (*m_counter)--;
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/oatpp/web/server/HttpProcessor.cpp
+++ b/src/oatpp/web/server/HttpProcessor.cpp
@@ -224,11 +224,19 @@ HttpProcessor::Task::Task(const std::shared_ptr<Components>& components,
   : m_components(components)
   , m_connection(connection)
   , m_counter(taskCounter)
-{}
+{
+  (*m_counter)++;
+}
+
+HttpProcessor::Task::Task(const HttpProcessor::Task &copy)
+  : m_components(copy.m_components)
+  , m_connection(copy.m_connection)
+  , m_counter(copy.m_counter)
+{
+  (*m_counter)++;
+}
 
 void HttpProcessor::Task::run(){
-
-  (*m_counter)++;
 
   m_connection->initContexts();
 
@@ -248,8 +256,9 @@ void HttpProcessor::Task::run(){
     // DO NOTHING
   }
 
+}
+HttpProcessor::Task::~Task() {
   (*m_counter)--;
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/oatpp/web/server/HttpProcessor.hpp
+++ b/src/oatpp/web/server/HttpProcessor.hpp
@@ -190,7 +190,7 @@ public:
   private:
     std::shared_ptr<Components> m_components;
     std::shared_ptr<oatpp::data::stream::IOStream> m_connection;
-    std::shared_ptr<std::atomic_ulong> m_counter;
+    std::atomic_long *m_counter;
   public:
 
     /**
@@ -200,12 +200,12 @@ public:
      */
     Task(const std::shared_ptr<Components>& components,
          const std::shared_ptr<oatpp::data::stream::IOStream>& connection,
-         const std::shared_ptr<std::atomic_ulong>& taskCounter);
+         std::atomic_long *taskCounter);
 
     /**
      * Destructor, needed for counting.
      */
-    ~Task();
+    ~Task() override;
 
   public:
 
@@ -234,7 +234,7 @@ public:
     oatpp::web::server::HttpRouter::BranchRouter::Route m_currentRoute;
     std::shared_ptr<protocol::http::incoming::Request> m_currentRequest;
     std::shared_ptr<protocol::http::outgoing::Response> m_currentResponse;
-    std::shared_ptr<std::atomic_ulong> m_counter;
+    std::atomic_long *m_counter;
   public:
 
 
@@ -245,8 +245,8 @@ public:
      */
     Coroutine(const std::shared_ptr<Components>& components,
               const std::shared_ptr<oatpp::data::stream::IOStream>& connection,
-              const std::shared_ptr<std::atomic_ulong>& taskCounter);
-    
+              std::atomic_long *taskCounter);
+
     Action act() override;
 
     Action parseHeaders();
@@ -260,7 +260,7 @@ public:
     
     Action handleError(Error* error) override;
 
-    ~Coroutine();
+    ~Coroutine() override;
     
   };
   

--- a/src/oatpp/web/server/HttpProcessor.hpp
+++ b/src/oatpp/web/server/HttpProcessor.hpp
@@ -203,6 +203,11 @@ public:
          std::atomic_long *taskCounter);
 
     /**
+     * Copy-Constructor to correctly count tasks.
+     */
+    Task(const Task &copy);
+
+    /**
      * Destructor, needed for counting.
      */
     ~Task() override;

--- a/src/oatpp/web/server/HttpProcessor.hpp
+++ b/src/oatpp/web/server/HttpProcessor.hpp
@@ -208,9 +208,23 @@ public:
     Task(const Task &copy);
 
     /**
+     * Copy-Assignment to correctly count tasks.
+     * @param t - Task to copy
+     * @return
+     */
+    Task &operator=(const Task &t);
+
+    /**
      * Move-Constructor to correclty count tasks;
      */
      Task(Task &&move);
+
+     /**
+      * Move-Assignment to correctly count tasks.
+      * @param t
+      * @return
+      */
+    Task &operator=(Task &&t);
 
     /**
      * Destructor, needed for counting.

--- a/src/oatpp/web/server/HttpProcessor.hpp
+++ b/src/oatpp/web/server/HttpProcessor.hpp
@@ -190,6 +190,7 @@ public:
   private:
     std::shared_ptr<Components> m_components;
     std::shared_ptr<oatpp::data::stream::IOStream> m_connection;
+    std::shared_ptr<std::atomic_ulong> m_counter;
   public:
 
     /**
@@ -198,7 +199,14 @@ public:
      * @param connection - &id:oatpp::data::stream::IOStream;.
      */
     Task(const std::shared_ptr<Components>& components,
-         const std::shared_ptr<oatpp::data::stream::IOStream>& connection);
+         const std::shared_ptr<oatpp::data::stream::IOStream>& connection,
+         const std::shared_ptr<std::atomic_ulong>& taskCounter);
+
+    /**
+     * Destructor, needed for counting.
+     */
+    ~Task();
+
   public:
 
     /**
@@ -226,6 +234,7 @@ public:
     oatpp::web::server::HttpRouter::BranchRouter::Route m_currentRoute;
     std::shared_ptr<protocol::http::incoming::Request> m_currentRequest;
     std::shared_ptr<protocol::http::outgoing::Response> m_currentResponse;
+    std::shared_ptr<std::atomic_ulong> m_counter;
   public:
 
 
@@ -235,7 +244,8 @@ public:
      * @param connection - &id:oatpp::data::stream::IOStream;.
      */
     Coroutine(const std::shared_ptr<Components>& components,
-              const std::shared_ptr<oatpp::data::stream::IOStream>& connection);
+              const std::shared_ptr<oatpp::data::stream::IOStream>& connection,
+              const std::shared_ptr<std::atomic_ulong>& taskCounter);
     
     Action act() override;
 
@@ -249,6 +259,8 @@ public:
     Action onRequestDone();
     
     Action handleError(Error* error) override;
+
+    ~Coroutine();
     
   };
   

--- a/src/oatpp/web/server/HttpProcessor.hpp
+++ b/src/oatpp/web/server/HttpProcessor.hpp
@@ -208,6 +208,11 @@ public:
     Task(const Task &copy);
 
     /**
+     * Move-Constructor to correclty count tasks;
+     */
+     Task(Task &&move);
+
+    /**
      * Destructor, needed for counting.
      */
     ~Task() override;


### PR DESCRIPTION
To reliable stop a ConnectionHandler it needs to count its spawned threads and wait for all threads to be done before stopping.
Because we can have multiple ConnectionHandlers, this counting can not be done via the `Components` since they *could* be shared between multiple ConnectionHandlers.
Thus we have to pass the counter separately.
While the counting can easily be done in the constructor and destructor of the Async-Api's `Coroutine` since it's threadpool cleanly allocs and deallocs the `Coroutine` the Simple-Api needs to be counted in the `Task::run()` method. It seems that `std::thread` does not deallocates the passed `HttpProcessor::Task` as expected (e.g. when the thread is done).