### PR TITLE
Fix #324

### DIFF
--- a/src/oatpp/network/tcp/server/ConnectionProvider.cpp
+++ b/src/oatpp/network/tcp/server/ConnectionProvider.cpp
@@ -43,6 +43,29 @@
   #endif
 #endif
 
+#if _WIN32_WINNT < 0x0600
+  const char * inet_ntop (int af, const void *src, char *dst, socklen_t cnt) {
+    if (af == AF_INET) {
+      struct sockaddr_in in;
+
+      memset (&in, 0, sizeof(in));
+      in.sin_family = AF_INET;
+      memcpy (&in.sin_addr, src, sizeof(struct in_addr));
+      getnameinfo ((struct sockaddr *)&in, sizeof (struct sockaddr_in), dst, cnt, NULL, 0, NI_NUMERICHOST);
+      return dst;
+    } else if (af == AF_INET6) {
+      struct sockaddr_in6 in;
+      memset (&in, 0, sizeof(in));
+      in.sin6_family = AF_INET6;
+      memcpy (&in.sin6_addr, src, sizeof(struct in_addr6));
+      getnameinfo ((struct sockaddr *)&in, sizeof (struct sockaddr_in6), dst, cnt, NULL, 0, NI_NUMERICHOST);
+      return dst;
+    }
+
+      return NULL;
+  }
+#endif
+
 namespace oatpp { namespace network { namespace tcp { namespace server {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/oatpp/network/tcp/server/ConnectionProvider.cpp
+++ b/src/oatpp/network/tcp/server/ConnectionProvider.cpp
@@ -43,7 +43,9 @@
   #endif
 #endif
 
-#if _WIN32_WINNT < 0x0600
+
+// Workaround for MinGW from: https://www.mail-archive.com/users@ipv6.org/msg02107.html
+#if defined(__MINGW32__) && _WIN32_WINNT < 0x0600
   const char * inet_ntop (int af, const void *src, char *dst, socklen_t cnt) {
     if (af == AF_INET) {
       struct sockaddr_in in;
@@ -62,7 +64,7 @@
       return dst;
     }
 
-      return NULL;
+    return NULL;
   }
 #endif
 


### PR DESCRIPTION
https://github.com/oatpp/oatpp/issues/324#issuecomment-711065560 describes how MinGW is failing to build due to its Windows XP support and this PR implements the failing function based on the code from https://www.mail-archive.com/users@ipv6.org/msg02107.html.