### PR TITLE
Add hints and advice to the threading-examples in `Server.hpp`

### DIFF
--- a/src/oatpp/network/Server.cpp
+++ b/src/oatpp/network/Server.cpp
@@ -115,7 +115,7 @@ void Server::run(std::function<bool()> conditional) {
 
 void Server::run(bool startAsNewThread) {
   std::unique_lock<std::mutex> ul(m_mutex);
-  OATPP_LOGW("[oatpp::network::server::run(bool)]", "Using oatpp::network::server::run(bool) is deprecated and will be removed in the next release. Please implement your own threading.")
+  OATPP_LOGW("[oatpp::network::server::run(bool)]", "Using oatpp::network::server::run(bool) is deprecated and will be removed in the next release. Please implement your own threading (See https://github.com/oatpp/oatpp-threaded-starter).")
   switch (getStatus()) {
     case STATUS_STARTING:
       throw std::runtime_error("[oatpp::network::server::run()] Error. Server already starting");

--- a/src/oatpp/network/Server.hpp
+++ b/src/oatpp/network/Server.hpp
@@ -127,6 +127,13 @@ public:
    * to &id:oatpp::network::ConnectionHandler;.
    * @param startAsNewThread - Start the server blocking (thread of callee) or non-blocking (own thread)
    * @deprecated Deprecated since 1.3.0, will be removed in the next release.
+   * The new repository https://github.com/oatpp/oatpp-threaded-starter shows many configurations how to run Oat++ in its own thread.
+   * From simple No-Stop to Stop-Simple and ending in Oat++ completely isolated in its own thread-scope.
+   * We recommend the Stop-Simple for most applications! You can find it here: https://github.com/oatpp/oatpp-threaded-starter/blob/master/src/App_StopSimple.cpp
+   * The other examples are non trivial and highly specialized on specific environments or requirements.
+   * Please read the comments carefully and think about the consequences twice.
+   * If someone wants to use them please get back to us in an issue in the new repository and we can assist you with them.
+   * Again: These examples introduce special conditions and requirements for your code!
    */
   void run(bool startAsNewThread);
 


### PR DESCRIPTION
This PR adds some advice and hints to the threading-examples how to implement own threading when the deprecated threaded `run(true)` is removed. 