### PR TITLE
First step implementing silent connection drops. (#403)

### DIFF
--- a/src/oatpp/web/server/HttpProcessor.cpp
+++ b/src/oatpp/web/server/HttpProcessor.cpp
@@ -155,6 +155,11 @@ HttpProcessor::ConnectionState HttpProcessor::processNextRequest(ProcessingResou
 
     response = processNextRequest(resources, request, connectionState);
 
+    // Silently close connection when endpoint returned a nullptr.
+    if (!response) {
+      return ConnectionState::CLOSING;
+    }
+
     try {
 
       for (auto& interceptor : resources.components->responseInterceptors) {
@@ -357,6 +362,10 @@ HttpProcessor::Coroutine::Action HttpProcessor::Coroutine::onRequestFormed() {
 }
 
 HttpProcessor::Coroutine::Action HttpProcessor::Coroutine::onResponse(const std::shared_ptr<protocol::http::outgoing::Response>& response) {
+  // Silently close connection when endpoint returned a nullptr.
+  if (!response) {
+    return finish();
+  }
   m_currentResponse = response;
   return yieldTo(&HttpProcessor::Coroutine::onResponseFormed);
 }

--- a/test/oatpp/web/FullAsyncTest.cpp
+++ b/test/oatpp/web/FullAsyncTest.cpp
@@ -187,6 +187,11 @@ void FullAsyncTest::onRun() {
         OATPP_ASSERT(dto);
         OATPP_ASSERT(dto->testValue == "my_test_header-Async");
       }
+
+      // { // test silent connection close
+      //   auto response = client->silentClose();
+      //   OATPP_ASSERT(response == nullptr);
+      // }
       
       { // test POST with body
         auto response = client->postBody("my_test_body-Async", connection);

--- a/test/oatpp/web/FullTest.cpp
+++ b/test/oatpp/web/FullTest.cpp
@@ -292,6 +292,11 @@ void FullTest::onRun() {
         OATPP_ASSERT(dto->testValue == "my_test_header");
       }
 
+      // { // test silent close
+      //   auto response = client->silentClose();
+      //   OATPP_ASSERT(response == nullptr);
+      // }
+
       { // test POST with body
         auto response = client->postBody("my_test_body", connection);
         OATPP_ASSERT(response->getStatusCode() == 200);

--- a/test/oatpp/web/app/Client.hpp
+++ b/test/oatpp/web/app/Client.hpp
@@ -55,6 +55,7 @@ public:
   API_CALL("GET", "queries/optional", getWithOptQueries, QUERY(String, name))
   API_CALL("GET", "queries/map", getWithQueriesMap, QUERY(String, key1), QUERY(Int32, key2), QUERY(Float32, key3))
   API_CALL("GET", "headers", getWithHeaders, HEADER(String, param, "X-TEST-HEADER"))
+  API_CALL("GET", "close", silentClose)
   API_CALL("POST", "body", postBody, BODY_STRING(String, body))
   API_CALL("POST", "body-dto", postBodyDto, BODY_DTO(Object<TestDto>, body))
 
@@ -92,6 +93,7 @@ public:
   API_CALL_ASYNC("GET", "queries", getWithQueriesAsync, QUERY(String, name), QUERY(Int32, age))
   API_CALL_ASYNC("GET", "queries/map", getWithQueriesMapAsync, QUERY(String, key1), QUERY(Int32, key2), QUERY(Float32, key3))
   API_CALL_ASYNC("GET", "headers", getWithHeadersAsync, HEADER(String, param, "X-TEST-HEADER"))
+  API_CALL_ASYNC("GET", "close", silentCloseAsync)
   API_CALL_ASYNC("POST", "body", postBodyAsync, BODY_STRING(String, body))
   API_CALL_ASYNC("POST", "echo", echoBodyAsync, BODY_STRING(String, body))
 

--- a/test/oatpp/web/app/Controller.hpp
+++ b/test/oatpp/web/app/Controller.hpp
@@ -141,7 +141,11 @@ public:
     dto->testValue = param;
     return createDtoResponse(Status::CODE_200, dto);
   }
-  
+
+  ENDPOINT("GET", "close", silentClose) {
+    return nullptr;
+  }
+
   ENDPOINT("POST", "body", postBody,
            BODY_STRING(String, body)) {
     //OATPP_LOGV(TAG, "POST body %s", body->c_str());

--- a/test/oatpp/web/app/ControllerAsync.hpp
+++ b/test/oatpp/web/app/ControllerAsync.hpp
@@ -90,7 +90,7 @@ public:
 
   ENDPOINT_ASYNC("GET", "headers", GetWithHeaders) {
 
-    ENDPOINT_ASYNC_INIT(GetWithHeaders)
+   ENDPOINT_ASYNC_INIT(GetWithHeaders)
 
     Action act() {
       auto param = request->getHeader("X-TEST-HEADER");
@@ -98,6 +98,16 @@ public:
       auto dto = TestDto::createShared();
       dto->testValue = param;
       return _return(controller->createDtoResponse(Status::CODE_200, dto));
+    }
+
+  };
+
+  ENDPOINT_ASYNC("GET", "close", SilentClose) {
+
+   ENDPOINT_ASYNC_INIT(SilentClose)
+
+    Action act() {
+      return _return(nullptr);
     }
 
   };


### PR DESCRIPTION
Server can now silently drop/close connections when an endpoint returns nullptr instead of an response. Tests are prepared but Oat++-client is not able to cope with it currently.
So still in need of improvements on the client side.