### PR TITLE
Fixed memory leak in move assignement operators

### DIFF
--- a/src/oatpp/core/async/Coroutine.cpp
+++ b/src/oatpp/core/async/Coroutine.cpp
@@ -168,23 +168,16 @@ CoroutineStarter::CoroutineStarter(CoroutineStarter&& other)
 }
 
 CoroutineStarter::~CoroutineStarter() {
-  if(m_first != nullptr) {
-    auto curr = m_first;
-    while(curr != nullptr) {
-      AbstractCoroutine* next = nullptr;
-      if(curr->m_parentReturnAction.m_type == Action::TYPE_COROUTINE) {
-        next = curr->m_parentReturnAction.m_data.coroutine;
-      }
-      delete curr;
-      curr = next;
-    }
-  }
+  freeCoroutines();
 }
 
 /*
  * Move assignment operator.
  */
 CoroutineStarter& CoroutineStarter::operator=(CoroutineStarter&& other) {
+  if (this == std::addressof(other)) return *this;
+
+  freeCoroutines();
   m_first = other.m_first;
   m_last = other.m_last;
   other.m_first = nullptr;
@@ -214,6 +207,21 @@ CoroutineStarter& CoroutineStarter::next(CoroutineStarter&& starter) {
   starter.m_first = nullptr;
   starter.m_last = nullptr;
   return *this;
+}
+
+void CoroutineStarter::freeCoroutines()
+{
+  if (m_first != nullptr) {
+    auto curr = m_first;
+    while (curr != nullptr) {
+      AbstractCoroutine* next = nullptr;
+      if (curr->m_parentReturnAction.m_type == Action::TYPE_COROUTINE) {
+        next = curr->m_parentReturnAction.m_data.coroutine;
+      }
+      delete curr;
+      curr = next;
+    }
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/oatpp/core/async/Coroutine.hpp
+++ b/src/oatpp/core/async/Coroutine.hpp
@@ -341,6 +341,11 @@ class CoroutineStarter {
 private:
   AbstractCoroutine* m_first;
   AbstractCoroutine* m_last;
+
+private:
+
+  void freeCoroutines();
+
 public:
 
   /**
@@ -686,6 +691,9 @@ public:
      * Move assignment operator.
      */
     StarterForResult& operator=(StarterForResult&& other) {
+      if (this == std::addressof(other)) return *this;
+        
+      delete m_coroutine;
       m_coroutine = other.m_coroutine;
       other.m_coroutine = nullptr;
       return *this;


### PR DESCRIPTION
Since the destructors call the delete operator, it should also be called in the move assignement operators.