### PR TITLE
Fixed compiler warnings

### DIFF
--- a/src/oatpp/core/data/mapping/type/Enum.hpp
+++ b/src/oatpp/core/data/mapping/type/Enum.hpp
@@ -497,7 +497,7 @@ Void EnumInterpreterAsString<T, notnull>::fromInterpretation(const Void& interVa
   try {
     const auto &entry = EnumOW::getEntryByName(interValue.staticCast<String>());
     return EnumOW(entry.value);
-  } catch (const std::runtime_error& e) { // TODO - add a specific error for this.
+  } catch (const std::runtime_error&) { // TODO - add a specific error for this.
     error = EnumInterpreterError::ENTRY_NOT_FOUND;
   }
   return Void(nullptr, EnumOW::Class::getType());
@@ -558,7 +558,7 @@ Void EnumInterpreterAsNumber<T, notnull>::fromInterpretation(const Void& interVa
       interValue.staticCast<OW>()
     );
     return EnumOW(entry.value);
-  } catch (const std::runtime_error& e) { // TODO - add a specific error for this.
+  } catch (const std::runtime_error&) { // TODO - add a specific error for this.
     error = EnumInterpreterError::ENTRY_NOT_FOUND;
   }
   return Void(nullptr, EnumOW::Class::getType());

--- a/test/oatpp/core/data/mapping/TypeResolverTest.cpp
+++ b/test/oatpp/core/data/mapping/TypeResolverTest.cpp
@@ -95,7 +95,7 @@ void TypeResolverTest::onRun() {
   dto1->f_int64 = 64;
   dto1->f_uint64 = 6464;
 
-  dto1->f_float32 = 0.32;
+  dto1->f_float32 = 0.32f;
   dto1->f_float64 = 0.64;
 
   dto1->f_bool = true;

--- a/test/oatpp/core/data/mapping/type/AnyTest.cpp
+++ b/test/oatpp/core/data/mapping/type/AnyTest.cpp
@@ -116,7 +116,7 @@ void AnyTest::onRun() {
 
     try {
       auto obj = any.retrieve<oatpp::Object<Dto2>>(); // wrong object
-    } catch (std::runtime_error& e) {
+    } catch (std::runtime_error&) {
       wasError = true;
     }
 

--- a/test/oatpp/core/data/mapping/type/PrimitiveTest.cpp
+++ b/test/oatpp/core/data/mapping/type/PrimitiveTest.cpp
@@ -42,15 +42,15 @@ void PrimitiveTest::onRun() {
 
   {
     checkHash(oatpp::Boolean(true));
-    checkHash(oatpp::Int8(0xFF));
+    checkHash(oatpp::Int8(0x7F));
     checkHash(oatpp::UInt8(0xFF));
-    checkHash(oatpp::Int16(0xFFFF));
+    checkHash(oatpp::Int16(0x7FFF));
     checkHash(oatpp::UInt16(0xFFFF));
-    checkHash(oatpp::Int32(0xFFFFFFFF));
+    checkHash(oatpp::Int32(0x7FFFFFFF));
     checkHash(oatpp::UInt32(0xFFFFFFFF));
-    checkHash(oatpp::Int64(0xFFFFFFFFFFFFFFFF));
+    checkHash(oatpp::Int64(0x7FFFFFFFFFFFFFFF));
     checkHash(oatpp::UInt64(0xFFFFFFFFFFFFFFFF));
-    checkHash(oatpp::Float32(0.2));
+    checkHash(oatpp::Float32(0.2f));
     checkHash(oatpp::Float64(0.2));
   }
 


### PR DESCRIPTION
When comiling the project with MSVC I got a few warnings for truncations and unreferenced variables.
Clang/GCC also produce the truncation warnings if the -Wconversion flag is set.