### PR TITLE
Migrating fuzzers from oss-fuzz.

### DIFF
--- a/test/fuzzers/json-fuzz.cpp
+++ b/test/fuzzers/json-fuzz.cpp
@@ -1,0 +1,27 @@
+#include "oatpp/parser/json/mapping/ObjectMapper.hpp"
+#include "oatpp/core/macro/codegen.hpp"
+
+typedef oatpp::parser::Caret ParsingCaret;
+typedef oatpp::parser::json::mapping::Serializer Serializer;
+typedef oatpp::parser::json::mapping::Deserializer Deserializer;
+
+#include OATPP_CODEGEN_BEGIN(DTO)
+
+class EmptyDto : public oatpp::DTO {
+  DTO_INIT(EmptyDto, DTO)
+};
+
+class Test1 : public oatpp::DTO {
+  DTO_INIT(Test1, DTO)
+  DTO_FIELD(String, strF);
+};
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  oatpp::String input(reinterpret_cast<const char*>(data), size, true);
+  oatpp::parser::json::mapping::ObjectMapper mapper;
+  try {
+    mapper.readFromString<oatpp::Object<Test1>>(input);
+  } catch(...) {}
+
+  return 0;
+}


### PR DESCRIPTION
It would be great to migrate the fuzzing infrastructure from oss-fuzz into the upstream repository, so this is an effort to start this. To start with it would be nice to move the fuzzer from this PR https://github.com/google/oss-fuzz/pull/5689 onto an upstream location. Later it would be nice to have further fuzzers implemented as well as integrate it into the build infrastructure. 