### PR TITLE
Android API 19 does not support the epoll_create1

### DIFF
--- a/src/oatpp/core/async/worker/IOEventWorker_epoll.cpp
+++ b/src/oatpp/core/async/worker/IOEventWorker_epoll.cpp
@@ -39,7 +39,11 @@ namespace oatpp { namespace async { namespace worker {
 
 void IOEventWorker::initEventQueue() {
 
+#if !defined __ANDROID_API__ || __ANDROID_API__ >= 21
   m_eventQueueHandle = ::epoll_create1(0);
+#else
+  m_eventQueueHandle = ::epoll_create(0);
+#endif
 
   if(m_eventQueueHandle == -1) {
     OATPP_LOGE("[oatpp::async::worker::IOEventWorker::initEventQueue()]", "Error. Call to ::epoll_create1() failed. errno=%d", errno);


### PR DESCRIPTION
I've branched from 1.2.5 and implemented a fix for Android API 19, as it does not support the epoll_create1 interface and should instead use the older epoll_create.

See https://github.com/android/ndk/issues/394 for more information.