### PR TITLE
Serialization should respect the 'includeNullFields' configuration

### DIFF
--- a/src/oatpp/parser/json/mapping/Serializer.cpp
+++ b/src/oatpp/parser/json/mapping/Serializer.cpp
@@ -90,7 +90,9 @@ void Serializer::serializeString(Serializer* serializer,
   (void) serializer;
 
   if(!polymorph) {
-    stream->writeSimple("null", 4);
+    if(serializer->getConfig()->includeNullFields) {
+      stream->writeSimple("null", 4);
+    }
     return;
   }
 
@@ -106,7 +108,9 @@ void Serializer::serializeAny(Serializer* serializer,
 {
 
   if(!polymorph) {
-    stream->writeSimple("null", 4);
+    if(serializer->getConfig()->includeNullFields) {
+      stream->writeSimple("null", 4);
+    }
     return;
   }
 
@@ -145,7 +149,9 @@ void Serializer::serializeObject(Serializer* serializer,
 {
 
   if(!polymorph) {
-    stream->writeSimple("null", 4);
+    if(serializer->getConfig()->includeNullFields) {
+      stream->writeSimple("null", 4);
+    }
     return;
   }
 

--- a/src/oatpp/parser/json/mapping/Serializer.hpp
+++ b/src/oatpp/parser/json/mapping/Serializer.hpp
@@ -112,7 +112,9 @@ private:
     if(polymorph){
       stream->writeAsString(* static_cast<typename T::ObjectType*>(polymorph.get()));
     } else {
-      stream->writeSimple("null", 4);
+      if(serializer->getConfig()->includeNullFields) {
+        stream->writeSimple("null", 4);
+      }
     }
   }
 
@@ -120,7 +122,9 @@ private:
   static void serializeList(Serializer* serializer, data::stream::ConsistentOutputStream* stream, const oatpp::Void& polymorph) {
 
     if(!polymorph) {
-      stream->writeSimple("null", 4);
+      if(serializer->getConfig()->includeNullFields) {
+        stream->writeSimple("null", 4);
+      }
       return;
     }
 
@@ -144,7 +148,9 @@ private:
   static void serializeKeyValue(Serializer* serializer, data::stream::ConsistentOutputStream* stream, const oatpp::Void& polymorph) {
 
     if(!polymorph) {
-      stream->writeSimple("null", 4);
+      if(serializer->getConfig()->includeNullFields) {
+        stream->writeSimple("null", 4);
+      }
       return;
     }
 


### PR DESCRIPTION
Hi there

I have limited experience working with JSON and webservices, so maybe I am missing something, but shouldn't the serializer respect the includeNullFields configuration option for all serialization?

If so, here is my PR to fix that... 😄 

/ Thomas