### PR TITLE
Streams: `FIFOStream` implementation and `BufferedInputStream` API

### DIFF
--- a/changelog/1.3.0.md
+++ b/changelog/1.3.0.md
@@ -54,12 +54,32 @@ Now it's much easier to use `oatpp::String` since `oatpp::String` is now wrapper
 [#408](https://github.com/oatpp/oatpp/issues/408)
 
 ```cpp
-auto connectionPool = std::make_shared<ClientConnectionPool>(
-        connectionProvider /* connection provider */, 
-        10 /* max connections */, 
-        std::chrono::seconds(5) /* max lifetime of idle connection */
-        std::chrono::seconds(10) /* optional timeout to get available connection from the pool */
-);
+{
+
+  auto connectionProvider = oatpp::network::tcp::client::ConnectionProvider::createShared({"httpbin.org", 80});
+
+  auto pool = oatpp::network::ClientConnectionPool::createShared(connectionProvider,
+                                                                 1,
+                                                                 std::chrono::seconds(10),
+                                                                 std::chrono::seconds(5));
+
+  OATPP_LOGD("TEST", "start")
+
+  auto c1 = pool->get(); //<--- this one will succeed
+  OATPP_LOGD("TEST", "c1=%llu", c1.get())
+
+  auto c2 = pool->get(); //<--- this one will fail in 5 sec. Since Max-Resources is 1, Pool timeout is 5 sec. And c1 is not freed.
+  OATPP_LOGD("TEST", "c2=%llu", c2.get())
+
+}
+```
+
+Output:
+
+```
+ D |2021-08-04 01:32:56 1628029976986744| TEST:start
+ D |2021-08-04 01:32:57 1628029977126940| TEST:c1=140716915331208
+ D |2021-08-04 01:33:02 1628029982128324| TEST:c2=0
 ```
 
 ## JSON Serializer Escape Flags

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,6 +107,8 @@ add_library(oatpp
         oatpp/core/data/stream/BufferStream.hpp
         oatpp/core/data/stream/ChunkedBuffer.cpp
         oatpp/core/data/stream/ChunkedBuffer.hpp
+        oatpp/core/data/stream/FIFOStream.cpp
+        oatpp/core/data/stream/FIFOStream.hpp
         oatpp/core/data/stream/FileStream.cpp
         oatpp/core/data/stream/FileStream.hpp
         oatpp/core/data/stream/Stream.cpp

--- a/src/oatpp/core/data/stream/BufferStream.cpp
+++ b/src/oatpp/core/data/stream/BufferStream.cpp
@@ -238,4 +238,27 @@ void BufferInputStream::setCurrentPosition(v_buff_size position) {
   m_position = position;
 }
 
+v_io_size BufferInputStream::peek(void *data, v_buff_size count, async::Action &action) {
+  (void) action;
+
+  v_buff_size desiredAmount = count;
+  if(desiredAmount > m_size - m_position) {
+    desiredAmount = m_size - m_position;
+  }
+  std::memcpy(data, &m_data[m_position], desiredAmount);
+  return desiredAmount;
+}
+
+v_io_size BufferInputStream::availableToRead() const {
+  return m_size - m_position;
+}
+
+v_io_size BufferInputStream::commitReadOffset(v_buff_size count) {
+  if(count > m_size - m_position) {
+    count = m_size - m_position;
+  }
+  m_position += count;
+  return count;
+}
+
 }}}

--- a/src/oatpp/core/data/stream/BufferStream.hpp
+++ b/src/oatpp/core/data/stream/BufferStream.hpp
@@ -146,7 +146,7 @@ public:
 /**
  * BufferInputStream
  */
-class BufferInputStream : public InputStream {
+class BufferInputStream : public BufferedInputStream {
 public:
   static data::stream::DefaultInitializedContext DEFAULT_CONTEXT;
 private:
@@ -245,6 +245,26 @@ public:
    */
   void setCurrentPosition(v_buff_size position);
 
+  /**
+   * Peek up to count of bytes int he buffer
+   * @param data
+   * @param count
+   * @return [1..count], IOErrors.
+   */
+  v_io_size peek(void *data, v_buff_size count, async::Action& action) override;
+
+  /**
+   * Amount of bytes currently available to read from buffer.
+   * @return &id:oatpp::v_io_size;.
+   */
+  v_io_size availableToRead() const override;
+
+  /**
+   * Commit read offset
+   * @param count
+   * @return [1..count], IOErrors.
+   */
+  v_io_size commitReadOffset(v_buff_size count) override;
 
 };
 

--- a/src/oatpp/core/data/stream/FIFOStream.cpp
+++ b/src/oatpp/core/data/stream/FIFOStream.cpp
@@ -69,7 +69,7 @@ v_io_size FIFOInputStream::write(const void *data, v_buff_size count, async::Act
 
 void FIFOInputStream::reserveBytesUpfront(v_buff_size count) {
 
-  v_buff_size capacityNeeded = m_fifo->availableToRead() + count;
+  v_buff_size capacityNeeded = availableToRead() + count;
 
   if(capacityNeeded > m_fifo->getBufferSize()) {
 
@@ -113,6 +113,23 @@ v_io_size FIFOInputStream::flushToStream(data::stream::OutputStream *stream) {
 
 async::CoroutineStarter FIFOInputStream::flushToStreamAsync(const std::shared_ptr<data::stream::OutputStream> &stream) {
   return m_fifo->flushToStreamAsync(stream);
+}
+
+v_io_size FIFOInputStream::availableToWrite() {
+  return m_fifo->availableToWrite();
+}
+
+v_io_size FIFOInputStream::peek(void *data, v_buff_size count, async::Action &action) {
+  (void) action;
+  return m_fifo->peek(data, count);
+}
+
+v_io_size FIFOInputStream::availableToRead() const {
+  return m_fifo->availableToRead();
+}
+
+v_io_size FIFOInputStream::commitReadOffset(v_buff_size count) {
+  return m_fifo->commitReadOffset(count);
 }
 
 }}}

--- a/src/oatpp/core/data/stream/FIFOStream.cpp
+++ b/src/oatpp/core/data/stream/FIFOStream.cpp
@@ -1,0 +1,118 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Benedikt-Alexander Mokroß <github@bamkrs.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+
+#include "FIFOStream.hpp"
+#include "oatpp/core/utils/Binary.hpp"
+
+namespace oatpp { namespace data { namespace stream {
+
+data::stream::DefaultInitializedContext FIFOInputStream::DEFAULT_CONTEXT(data::stream::StreamType::STREAM_FINITE);
+
+FIFOInputStream::FIFOInputStream(v_buff_size initialSize)
+  : m_memoryHandle(std::make_shared<std::string>(initialSize, (char)0))
+  , m_fifo(std::make_shared<data::buffer::FIFOBuffer>((void*)m_memoryHandle->data(), m_memoryHandle->size(), 0, 0, false)) {
+
+}
+
+void FIFOInputStream::reset() {
+  m_fifo->setBufferPosition(0, 0, false);
+}
+
+v_io_size FIFOInputStream::read(void *data, v_buff_size count, async::Action& action) {
+  (void) action;
+  return m_fifo->read(data, count);
+}
+
+void FIFOInputStream::setInputStreamIOMode(IOMode ioMode) {
+  m_ioMode = ioMode;
+}
+
+IOMode FIFOInputStream::getInputStreamIOMode() {
+  return m_ioMode;
+}
+
+Context& FIFOInputStream::getInputStreamContext() {
+  return DEFAULT_CONTEXT;
+}
+
+std::shared_ptr<std::string> FIFOInputStream::getDataMemoryHandle() {
+  return m_memoryHandle;
+}
+
+v_io_size FIFOInputStream::write(const void *data, v_buff_size count, async::Action &action) {
+  (void) action;
+  reserveBytesUpfront(count);
+  return m_fifo->write(data, count);
+}
+
+void FIFOInputStream::reserveBytesUpfront(v_buff_size count) {
+
+  v_buff_size capacityNeeded = m_fifo->availableToRead() + count;
+
+  if(capacityNeeded > m_fifo->getBufferSize()) {
+
+    v_buff_size newCapacity = utils::Binary::nextP2(capacityNeeded);
+
+    if(newCapacity < 0 || (m_fifo->getBufferSize() > 0 && newCapacity > m_fifo->getBufferSize())) {
+      newCapacity = m_fifo->getBufferSize();
+    }
+
+    if(newCapacity < capacityNeeded) {
+      throw std::runtime_error("[oatpp::data::stream::BufferOutputStream::reserveBytesUpfront()]: Error. Unable to allocate requested memory.");
+    }
+
+    // ToDo: In-Memory-Resize
+    auto newHandle = std::make_shared<std::string>(newCapacity, (char)0);
+    v_io_size oldSize = m_fifo->availableToRead();
+    m_fifo->read((void*)newHandle->data(), oldSize);
+    auto newFifo = std::make_shared<data::buffer::FIFOBuffer>((void*)newHandle->data(), newHandle->size(), 0, oldSize, true);
+    m_memoryHandle = newHandle;
+    m_fifo = newFifo;
+  }
+
+}
+
+v_io_size FIFOInputStream::readAndWriteToStream(data::stream::OutputStream *stream,
+                                                v_buff_size count,
+                                                async::Action &action) {
+  return m_fifo->readAndWriteToStream(stream, count, action);
+}
+
+v_io_size FIFOInputStream::readFromStreamAndWrite(data::stream::InputStream *stream,
+                                                  v_buff_size count,
+                                                  async::Action &action) {
+  reserveBytesUpfront(count);
+  return m_fifo->readFromStreamAndWrite(stream, count, action);
+}
+
+v_io_size FIFOInputStream::flushToStream(data::stream::OutputStream *stream) {
+  return m_fifo->flushToStream(stream);
+}
+
+async::CoroutineStarter FIFOInputStream::flushToStreamAsync(const std::shared_ptr<data::stream::OutputStream> &stream) {
+  return m_fifo->flushToStreamAsync(stream);
+}
+
+}}}

--- a/src/oatpp/core/data/stream/FIFOStream.hpp
+++ b/src/oatpp/core/data/stream/FIFOStream.hpp
@@ -34,7 +34,7 @@ namespace oatpp { namespace data { namespace stream {
 /**
  * FIFOInputStream
  */
-class FIFOInputStream : public InputStream, public WriteCallback {
+class FIFOInputStream : public BufferedInputStream, public WriteCallback {
  public:
   static data::stream::DefaultInitializedContext DEFAULT_CONTEXT;
  private:
@@ -104,6 +104,27 @@ class FIFOInputStream : public InputStream, public WriteCallback {
    */
   v_io_size write(const void *data, v_buff_size count, async::Action &action) override;
 
+  /**
+   * Peek up to count of bytes int he buffer
+   * @param data
+   * @param count
+   * @return [1..count], IOErrors.
+   */
+  v_io_size peek(void *data, v_buff_size count, async::Action& action) override;
+
+  /**
+   * Amount of bytes currently available to read from buffer.
+   * @return &id:oatpp::v_io_size;.
+   */
+  v_io_size availableToRead() const override;
+
+  /**
+   * Commit read offset
+   * @param count
+   * @return [1..count], IOErrors.
+   */
+  v_io_size commitReadOffset(v_buff_size count) override;
+
   void reserveBytesUpfront(v_buff_size count);
 
   /**
@@ -137,6 +158,12 @@ class FIFOInputStream : public InputStream, public WriteCallback {
    * @return - &id:async::CoroutineStarter;.
    */
   async::CoroutineStarter flushToStreamAsync(const std::shared_ptr<data::stream::OutputStream>& stream);
+
+  /**
+   * Amount of buffer space currently available for data writes.
+   * @return &id:oatpp::v_io_size;.
+   */
+  v_io_size availableToWrite();
 };
 
 }}}

--- a/src/oatpp/core/data/stream/FIFOStream.hpp
+++ b/src/oatpp/core/data/stream/FIFOStream.hpp
@@ -1,0 +1,144 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Benedikt-Alexander Mokroß <github@bamkrs.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#ifndef oatpp_data_stream_FIFOStream_hpp
+#define oatpp_data_stream_FIFOStream_hpp
+
+#include "Stream.hpp"
+#include "oatpp/core/data/buffer/FIFOBuffer.hpp"
+
+namespace oatpp { namespace data { namespace stream {
+
+
+/**
+ * FIFOInputStream
+ */
+class FIFOInputStream : public InputStream, public WriteCallback {
+ public:
+  static data::stream::DefaultInitializedContext DEFAULT_CONTEXT;
+ private:
+  std::shared_ptr<std::string> m_memoryHandle;
+  std::shared_ptr<data::buffer::FIFOBuffer> m_fifo;
+  IOMode m_ioMode;
+ public:
+
+  /**
+   * Constructor.
+   * @param data - buffer.
+   */
+  FIFOInputStream(v_buff_size initialSize = 2048);
+
+  static std::shared_ptr<FIFOInputStream> createShared(v_buff_size initialSize = 2048) {
+    return std::make_shared<FIFOInputStream>(2048);
+  }
+
+  /**
+   * Same as `reset(nullptr, nullptr, 0);.`
+   */
+  void reset();
+
+  /**
+   * Read data from stream. <br>
+   * It is a legal case if return result < count. Caller should handle this!
+   * *Calls to this method are always NON-BLOCKING*
+   * @param data - buffer to read data to.
+   * @param count - size of the buffer.
+   * @param action - async specific action. If action is NOT &id:oatpp::async::Action::TYPE_NONE;, then
+   * caller MUST return this action on coroutine iteration.
+   * @return - actual number of bytes read. 0 - designates end of the buffer.
+   */
+  v_io_size read(void *data, v_buff_size count, async::Action& action) override;
+
+  /**
+   * Set stream I/O mode.
+   * @throws
+   */
+  void setInputStreamIOMode(IOMode ioMode) override;
+
+  /**
+   * Get stream I/O mode.
+   * @return
+   */
+  IOMode getInputStreamIOMode() override;
+
+  /**
+   * Get stream context.
+   * @return
+   */
+  Context& getInputStreamContext() override;
+
+  /**
+   * Get data memory handle.
+   * @return - data memory handle.
+   */
+  std::shared_ptr<std::string> getDataMemoryHandle();
+
+  /**
+   * Write operation callback.
+   * @param data - pointer to data.
+   * @param count - size of the data in bytes.
+   * @param action - async specific action. If action is NOT &id:oatpp::async::Action::TYPE_NONE;, then
+   * caller MUST return this action on coroutine iteration.
+   * @return - actual number of bytes written. 0 - to indicate end-of-file.
+   */
+  v_io_size write(const void *data, v_buff_size count, async::Action &action) override;
+
+  void reserveBytesUpfront(v_buff_size count);
+
+  /**
+ * call read and then write bytes read to output stream
+ * @param stream
+ * @param count
+ * @param action
+ * @return [1..count], IOErrors.
+ */
+  v_io_size readAndWriteToStream(data::stream::OutputStream* stream, v_buff_size count, async::Action& action);
+
+  /**
+   * call stream.read() and then write bytes read to buffer
+   * @param stream
+   * @param count
+   * @param action
+   * @return
+   */
+  v_io_size readFromStreamAndWrite(data::stream::InputStream* stream, v_buff_size count, async::Action& action);
+
+  /**
+   * flush all availableToRead bytes to stream
+   * @param stream
+   * @return
+   */
+  v_io_size flushToStream(data::stream::OutputStream* stream);
+
+  /**
+   * flush all availableToRead bytes to stream in asynchronous manner
+   * @param stream - &id:data::stream::OutputStream;.
+   * @return - &id:async::CoroutineStarter;.
+   */
+  async::CoroutineStarter flushToStreamAsync(const std::shared_ptr<data::stream::OutputStream>& stream);
+};
+
+}}}
+
+#endif // oatpp_data_stream_FIFOStream_hpp

--- a/src/oatpp/core/data/stream/Stream.hpp
+++ b/src/oatpp/core/data/stream/Stream.hpp
@@ -351,6 +351,38 @@ public:
 };
 
 /**
+ * Buffered Input Stream
+ */
+class BufferedInputStream : public InputStream {
+ public:
+  /**
+   * Default virtual destructor.
+   */
+  virtual ~BufferedInputStream() = default;
+
+  /**
+   * Peek up to count of bytes int he buffer
+   * @param data
+   * @param count
+   * @return [1..count], IOErrors.
+   */
+  virtual v_io_size peek(void *data, v_buff_size count, async::Action& action) = 0;
+
+  /**
+   * Amount of bytes currently available to read from buffer.
+   * @return &id:oatpp::v_io_size;.
+   */
+  virtual v_io_size availableToRead() const = 0;
+
+  /**
+   * Commit read offset
+   * @param count
+   * @return [1..count], IOErrors.
+   */
+  virtual v_io_size commitReadOffset(v_buff_size count) = 0;
+};
+
+/**
  * I/O Stream.
  */
 class IOStream : public InputStream, public OutputStream {

--- a/src/oatpp/core/data/stream/StreamBufferedProxy.cpp
+++ b/src/oatpp/core/data/stream/StreamBufferedProxy.cpp
@@ -101,5 +101,9 @@ oatpp::data::stream::IOMode InputStreamBufferedProxy::getInputStreamIOMode() {
 Context& InputStreamBufferedProxy::getInputStreamContext() {
   return m_inputStream->getInputStreamContext();
 }
-  
+
+v_io_size InputStreamBufferedProxy::availableToRead() const {
+  return m_buffer.availableToRead();
+}
+
 }}}

--- a/src/oatpp/core/data/stream/StreamBufferedProxy.hpp
+++ b/src/oatpp/core/data/stream/StreamBufferedProxy.hpp
@@ -82,7 +82,7 @@ public:
   
 };
   
-class InputStreamBufferedProxy : public oatpp::base::Countable, public InputStream {
+class InputStreamBufferedProxy : public oatpp::base::Countable, public BufferedInputStream {
 public:
   OBJECT_POOL(InputStreamBufferedProxy_Pool, InputStreamBufferedProxy, 32)
   SHARED_OBJECT_POOL(Shared_InputStreamBufferedProxy_Pool, InputStreamBufferedProxy, 32)
@@ -119,9 +119,11 @@ public:
   
   v_io_size read(void *data, v_buff_size count, async::Action& action) override;
 
-  v_io_size peek(void *data, v_buff_size count, async::Action& action);
+  v_io_size peek(void *data, v_buff_size count, async::Action& action) override;
 
-  v_io_size commitReadOffset(v_buff_size count);
+  v_io_size commitReadOffset(v_buff_size count) override;
+
+  v_io_size availableToRead() const override;
 
   /**
    * Set InputStream I/O mode.

--- a/src/oatpp/web/client/HttpRequestExecutor.hpp
+++ b/src/oatpp/web/client/HttpRequestExecutor.hpp
@@ -51,20 +51,44 @@ public:
    * For more details see &id:oatpp::web::client::RequestExecutor::ConnectionHandle;.
    */
   class HttpConnectionHandle : public ConnectionHandle {
+  private:
+    /* provider which created this connection */
+    std::shared_ptr<ClientConnectionProvider> m_connectionProvider;
+    std::shared_ptr<oatpp::data::stream::IOStream> m_connection;
+    bool m_valid;
+    bool m_invalidateOnDestroy;
   public:
 
     /**
      * Constructor.
+     * @param connectionProvider - connection provider which created this connection.
      * @param stream - &id:oatpp::data::stream::IOStream;.
      */
-    HttpConnectionHandle(const std::shared_ptr<oatpp::data::stream::IOStream>& stream)
-      : connection(stream)
-    {}
+    HttpConnectionHandle(const std::shared_ptr<ClientConnectionProvider>& connectionProvider,
+                         const std::shared_ptr<oatpp::data::stream::IOStream>& stream);
 
     /**
-     * Connection.
+     * Destructor.
      */
-    std::shared_ptr<oatpp::data::stream::IOStream> connection;
+    ~HttpConnectionHandle() override;
+
+    /**
+     * Get connection I/O stream.
+     * @return
+     */
+    std::shared_ptr<oatpp::data::stream::IOStream> getConnection();
+
+    /**
+     * Invalidate this connection.
+     */
+    void invalidate();
+
+    /**
+     * Set if connection should be invalidated on destroy of ConnectionHandle.
+     * @param invalidateOnDestroy
+     */
+    void setInvalidateOnDestroy(bool invalidateOnDestroy);
+
   };
 public:
 


### PR DESCRIPTION
Oat++ Streams are great. However, I always missed an easy to use Stream-Buffer where we can write to AND read from.
`FIFOStream` aims to archive this. Using `oatpp::data::buffer::FIFOBuffer` we now have the ability to have an buffered write-callback enabled `InputStream`.

Also `BufferedInputStream` was introduced. It should unify the API's used for the several buffered `InputStream` implementations.