### PR TITLE
`FIFOBuffer` should accept an `WriteCallback`/`ReadCallback`

### DIFF
--- a/src/oatpp/core/data/buffer/FIFOBuffer.cpp
+++ b/src/oatpp/core/data/buffer/FIFOBuffer.cpp
@@ -246,7 +246,7 @@ v_io_size FIFOBuffer::write(const void *data, v_buff_size count) {
   
 }
 
-v_io_size FIFOBuffer::readAndWriteToStream(data::stream::OutputStream* stream, v_buff_size count, async::Action& action) {
+v_io_size FIFOBuffer::readAndWriteToStream(data::stream::WriteCallback* stream, v_buff_size count, async::Action& action) {
 
   if(!m_canRead) {
     return IOError::RETRY_READ;
@@ -299,7 +299,7 @@ v_io_size FIFOBuffer::readAndWriteToStream(data::stream::OutputStream* stream, v
 
 }
 
-v_io_size FIFOBuffer::readFromStreamAndWrite(data::stream::InputStream* stream, v_buff_size count, async::Action& action) {
+v_io_size FIFOBuffer::readFromStreamAndWrite(data::stream::ReadCallback* stream, v_buff_size count, async::Action& action) {
 
   if(m_canRead && m_writePosition == m_readPosition) {
     return IOError::RETRY_WRITE;

--- a/src/oatpp/core/data/buffer/FIFOBuffer.hpp
+++ b/src/oatpp/core/data/buffer/FIFOBuffer.hpp
@@ -123,7 +123,7 @@ public:
    * @param action
    * @return [1..count], IOErrors.
    */
-  v_io_size readAndWriteToStream(data::stream::OutputStream* stream, v_buff_size count, async::Action& action);
+  v_io_size readAndWriteToStream(data::stream::WriteCallback* stream, v_buff_size count, async::Action& action);
 
   /**
    * call stream.read() and then write bytes read to buffer
@@ -132,7 +132,7 @@ public:
    * @param action
    * @return
    */
-  v_io_size readFromStreamAndWrite(data::stream::InputStream* stream, v_buff_size count, async::Action& action);
+  v_io_size readFromStreamAndWrite(data::stream::ReadCallback* stream, v_buff_size count, async::Action& action);
 
   /**
    * flush all availableToRead bytes to stream


### PR DESCRIPTION
`FIFOBuffer` should accept an `WriteCallback`/`ReadCallback` to its `readAndWriteToStream` and `readFromStreamAndWrite` functions.

There is no need to specialize on a `Stream`.

Its an non-breaking change. Also renaming the functions to `readAndWriteToCallback` and `readFromCallbackAndWrite` would break things.