### PR TITLE
WIP: Stream API rework

### DIFF
--- a/src/oatpp/core/data/buffer/FIFOBuffer.cpp
+++ b/src/oatpp/core/data/buffer/FIFOBuffer.cpp
@@ -246,7 +246,7 @@ v_io_size FIFOBuffer::write(const void *data, v_buff_size count) {
   
 }
 
-v_io_size FIFOBuffer::readAndWriteToStream(data::stream::OutputStream* stream, v_buff_size count, async::Action& action) {
+v_io_size FIFOBuffer::readAndWriteToStream(data::stream::WriteCallback* stream, v_buff_size count, async::Action& action) {
 
   if(!m_canRead) {
     return IOError::RETRY_READ;
@@ -299,7 +299,7 @@ v_io_size FIFOBuffer::readAndWriteToStream(data::stream::OutputStream* stream, v
 
 }
 
-v_io_size FIFOBuffer::readFromStreamAndWrite(data::stream::InputStream* stream, v_buff_size count, async::Action& action) {
+v_io_size FIFOBuffer::readFromStreamAndWrite(data::stream::ReadCallback* stream, v_buff_size count, async::Action& action) {
 
   if(m_canRead && m_writePosition == m_readPosition) {
     return IOError::RETRY_WRITE;

--- a/src/oatpp/core/data/buffer/FIFOBuffer.hpp
+++ b/src/oatpp/core/data/buffer/FIFOBuffer.hpp
@@ -123,7 +123,7 @@ public:
    * @param action
    * @return [1..count], IOErrors.
    */
-  v_io_size readAndWriteToStream(data::stream::OutputStream* stream, v_buff_size count, async::Action& action);
+  v_io_size readAndWriteToStream(data::stream::WriteCallback* stream, v_buff_size count, async::Action& action);
 
   /**
    * call stream.read() and then write bytes read to buffer
@@ -132,7 +132,7 @@ public:
    * @param action
    * @return
    */
-  v_io_size readFromStreamAndWrite(data::stream::InputStream* stream, v_buff_size count, async::Action& action);
+  v_io_size readFromStreamAndWrite(data::stream::ReadCallback* stream, v_buff_size count, async::Action& action);
 
   /**
    * flush all availableToRead bytes to stream

--- a/src/oatpp/core/data/stream/BufferStream.cpp
+++ b/src/oatpp/core/data/stream/BufferStream.cpp
@@ -128,37 +128,56 @@ oatpp::String BufferOutputStream::getSubstring(v_buff_size pos, v_buff_size coun
   }
 }
 
-oatpp::v_io_size BufferOutputStream::flushToStream(OutputStream* stream) {
+v_io_size BufferOutputStream::flushBufferToStream(stream::WriteCallback* stream) {
   return stream->writeExactSizeDataSimple(m_data, m_position);
 }
 
-oatpp::async::CoroutineStarter BufferOutputStream::flushToStreamAsync(const std::shared_ptr<BufferOutputStream>& _this, const std::shared_ptr<OutputStream>& stream) {
+oatpp::async::CoroutineStarter BufferOutputStream::flushBufferToStreamAsync(const std::shared_ptr<BufferOutputStream>& _this, const std::shared_ptr<WriteCallback>& stream) {
+  return writeBufferToStreamAsync(_this, stream, _this->m_position);
+}
 
+oatpp::async::CoroutineStarter BufferOutputStream::writeBufferToStreamAsync(const std::shared_ptr<BufferOutputStream> &_this,
+                                                                            const std::shared_ptr<WriteCallback> &stream,
+                                                                            v_buff_size count) {
   class WriteDataCoroutine : public oatpp::async::Coroutine<WriteDataCoroutine> {
-  private:
+   private:
     std::shared_ptr<BufferOutputStream> m_this;
-    std::shared_ptr<oatpp::data::stream::OutputStream> m_stream;
+    std::shared_ptr<oatpp::data::stream::WriteCallback> m_stream;
     data::buffer::InlineWriteData m_inlineData;
-  public:
+    v_buff_size m_count;
+   public:
 
     WriteDataCoroutine(const std::shared_ptr<BufferOutputStream>& _this,
-                       const std::shared_ptr<oatpp::data::stream::OutputStream>& stream)
-      : m_this(_this)
-      , m_stream(stream)
+                       const std::shared_ptr<oatpp::data::stream::WriteCallback>& stream,
+                       v_buff_size count)
+        : m_this(_this)
+        , m_stream(stream)
+        , m_count(count)
     {}
 
     Action act() override {
       if(m_inlineData.currBufferPtr == nullptr) {
         m_inlineData.currBufferPtr = m_this->m_data;
-        m_inlineData.bytesLeft = m_this->m_position;
+        m_inlineData.bytesLeft = std::min(m_this->m_position, m_count);
       }
       return m_stream.get()->writeExactSizeDataAsyncInline(m_inlineData, finish());
     }
 
   };
+  return WriteDataCoroutine::start(_this, stream, count);
+}
 
-  return WriteDataCoroutine::start(_this, stream);
+v_io_size BufferOutputStream::writeBufferToStream(stream::WriteCallback *writeCallback, v_buff_size count) {
+  return writeCallback->writeSimple(m_data, std::min(m_position, count));
+}
 
+async::CoroutineStarter BufferOutputStream::writeBufferToStreamAsync(const std::shared_ptr<data::stream::WriteCallback> &stream,
+                                                                     v_buff_size count) {
+  return BufferOutputStream::writeBufferToStreamAsync(shared_from_this(), stream, count);
+}
+
+v_buff_size BufferOutputStream::getSize() {
+  return m_position;
 }
 
 

--- a/src/oatpp/core/data/stream/BufferStream.hpp
+++ b/src/oatpp/core/data/stream/BufferStream.hpp
@@ -32,7 +32,7 @@ namespace oatpp { namespace data{ namespace stream {
 /**
  * BufferOutputStream
  */
-class BufferOutputStream : public ConsistentOutputStream {
+class BufferOutputStream : public BufferedOutputStream, public std::enable_shared_from_this<BufferOutputStream> {
 public:
   static data::stream::DefaultInitializedContext DEFAULT_CONTEXT;
 private:
@@ -99,6 +99,7 @@ public:
    * @return
    */
   v_buff_size getCapacity();
+  v_buff_size getSize() override;
 
   /**
    * Get current data write position.
@@ -131,7 +132,23 @@ public:
    * @param stream - stream to flush all data to.
    * @return - actual amount of bytes flushed.
    */
-  oatpp::v_io_size flushToStream(OutputStream* stream);
+  v_io_size flushBufferToStream(stream::WriteCallback* stream) override;
+
+  /**
+   * Writes up to count of buffered data to &l:WriteCallback;.
+   * @param writeCallback - write-enabled object to write to
+   * @param count - maximum amount of bytes to written.
+   * @return - actual number of bytes written. &id:oatpp::v_io_size;. <br>
+   */
+  v_io_size writeBufferToStream(stream::WriteCallback *writeCallback, v_buff_size count) override;
+
+  /**
+   * Writes up to count buffered data to &l:WriteCallback; in an async context.
+   * @param writeCallback - write-enabled object to write to
+   * @param count - maximum amount of bytes to written.
+   * @return - &id:async::CoroutineStarter;.
+   */
+  async::CoroutineStarter writeBufferToStreamAsync(const std::shared_ptr<data::stream::WriteCallback>& stream, v_buff_size count) override;
 
   /**
    * Write all bytes from buffer to stream in async manner.
@@ -139,8 +156,16 @@ public:
    * @param stream - stream to flush all data to.
    * @return - &id:oatpp::async::CoroutineStarter;.
    */
-  static oatpp::async::CoroutineStarter flushToStreamAsync(const std::shared_ptr<BufferOutputStream>& _this, const std::shared_ptr<OutputStream>& stream);
+  static oatpp::async::CoroutineStarter flushBufferToStreamAsync(const std::shared_ptr<BufferOutputStream>& _this, const std::shared_ptr<WriteCallback>& stream);
 
+  /**
+   * Write all bytes from buffer to stream in async manner.
+   * @param _this - pointer to `this` buffer.
+   * @param stream - stream to flush all data to.
+   * @return - &id:oatpp::async::CoroutineStarter;.
+   */
+  static oatpp::async::CoroutineStarter writeBufferToStreamAsync(const std::shared_ptr<BufferOutputStream>& _this, const std::shared_ptr<WriteCallback>& stream,
+                                                                 v_buff_size count);
 };
 
 /**

--- a/src/oatpp/core/data/stream/ChunkedBuffer.hpp
+++ b/src/oatpp/core/data/stream/ChunkedBuffer.hpp
@@ -36,7 +36,7 @@ namespace oatpp { namespace data{ namespace stream {
 /**
  * Buffer wich can grow by chunks and implements &id:oatpp::data::stream::ConsistentOutputStream; interface.
  */
-class ChunkedBuffer : public oatpp::base::Countable, public ConsistentOutputStream, public std::enable_shared_from_this<ChunkedBuffer> {
+class ChunkedBuffer : public oatpp::base::Countable, public BufferedOutputStream, public std::enable_shared_from_this<ChunkedBuffer> {
 public:
   static data::stream::DefaultInitializedContext DEFAULT_CONTEXT;
 public:
@@ -214,20 +214,36 @@ public:
   }
 
   /**
-   * Write all data from ChunkedBuffer to &id:oatpp::data::stream::OutputStream;.
-   * ChunkedBuffer will not be cleared during this call!
-   * @param stream - &id:oatpp::data::stream::OutputStream; stream to write all data to.
-   * @return - `true` if no errors occured. **will be refactored to return actual amount of bytes flushed**.
+   * Writes all available buffered data to &l:WriteCallback;.
+   * @param writeCallback - write-enabled object to write to
+   * @return - actual number of bytes written. &id:oatpp::v_io_size;. <br>
    */
-  bool flushToStream(OutputStream* stream);
+  v_io_size flushBufferToStream(stream::WriteCallback *writeCallback) override;
 
   /**
-   * Write all data from ChunkedBuffer to &id:oatpp::data::stream::OutputStream; in asynchronous manner.
-   * @param stream - &id:oatpp::data::stream::OutputStream; stream to write all data to.
-   * @return - &id:oatpp::async::CoroutineStarter;.
+   * Writes up to count of buffered data to &l:WriteCallback;.
+   * @param writeCallback - write-enabled object to write to
+   * @param count - maximum amount of bytes to written.
+   * @return - actual number of bytes written. &id:oatpp::v_io_size;. <br>
    */
-  oatpp::async::CoroutineStarter flushToStreamAsync(const std::shared_ptr<OutputStream>& stream);
-  
+  v_io_size writeBufferToStream(stream::WriteCallback *writeCallback, v_buff_size count) override;
+
+  /**
+   * Writes all available buffered data to &l:WriteCallback; in an async context.
+   * @param writeCallback - write-enabled object to write to
+   * @param count - maximum amount of bytes to written.
+   * @return - &id:async::CoroutineStarter;.
+   */
+  async::CoroutineStarter flushBufferToStreamAsync(const std::shared_ptr<data::stream::WriteCallback>& stream) override;
+
+  /**
+   * Writes up to count buffered data to &l:WriteCallback; in an async context.
+   * @param writeCallback - write-enabled object to write to
+   * @param count - maximum amount of bytes to written.
+   * @return - &id:async::CoroutineStarter;.
+   */
+  async::CoroutineStarter writeBufferToStreamAsync(const std::shared_ptr<data::stream::WriteCallback>& stream, v_buff_size count) override;
+
   std::shared_ptr<Chunks> getChunks();
 
   /**

--- a/src/oatpp/core/data/stream/FIFOStream.cpp
+++ b/src/oatpp/core/data/stream/FIFOStream.cpp
@@ -95,25 +95,14 @@ void FIFOInputStream::reserveBytesUpfront(v_buff_size count) {
 
 }
 
-v_io_size FIFOInputStream::readAndWriteToStream(data::stream::OutputStream *stream,
-                                                v_buff_size count,
-                                                async::Action &action) {
-  return m_fifo->readAndWriteToStream(stream, count, action);
-}
-
-v_io_size FIFOInputStream::readFromStreamAndWrite(data::stream::InputStream *stream,
-                                                  v_buff_size count,
-                                                  async::Action &action) {
-  reserveBytesUpfront(count);
-  return m_fifo->readFromStreamAndWrite(stream, count, action);
-}
-
-v_io_size FIFOInputStream::flushToStream(data::stream::OutputStream *stream) {
-  return m_fifo->flushToStream(stream);
-}
-
-async::CoroutineStarter FIFOInputStream::flushToStreamAsync(const std::shared_ptr<data::stream::OutputStream> &stream) {
-  return m_fifo->flushToStreamAsync(stream);
+v_io_size FIFOInputStream::writeBufferToStream(stream::WriteCallback *writeCallback, v_buff_size count) {
+  async::Action action;
+  v_io_size size = m_fifo->readAndWriteToStream(writeCallback, count, action);
+  if(!action.isNone()) {
+    OATPP_LOGE("[oatpp::data::stream::FIFOInputStream::writeBufferToStream()]", "Error. writeSimple is called on a stream in Async mode.");
+    throw std::runtime_error("[oatpp::data::stream::FIFOInputStream::writeBufferToStream()]: Error. writeSimple is called on a stream in Async mode.");
+  }
+  return size;
 }
 
 v_io_size FIFOInputStream::availableToWrite() {

--- a/src/oatpp/core/data/stream/FIFOStream.hpp
+++ b/src/oatpp/core/data/stream/FIFOStream.hpp
@@ -132,36 +132,12 @@ class FIFOInputStream : public BufferedInputStream, public WriteCallback {
   void reserveBytesUpfront(v_buff_size count);
 
   /**
-   * call read and then write bytes read to output stream
-   * @param stream
-   * @param count
-   * @param action
-   * @return [1..count], IOErrors.
+   * Writes up to count of buffered data to &l:WriteCallback;.
+   * @param writeCallback - write-enabled object to write to
+   * @param count - maximum amount of bytes to written.
+   * @return - actual number of bytes written. &id:oatpp::v_io_size;. <br>
    */
-  v_io_size readAndWriteToStream(data::stream::OutputStream* stream, v_buff_size count, async::Action& action);
-
-  /**
-   * call stream.read() and then write bytes read to buffer
-   * @param stream
-   * @param count
-   * @param action
-   * @return
-   */
-  v_io_size readFromStreamAndWrite(data::stream::InputStream* stream, v_buff_size count, async::Action& action);
-
-  /**
-   * flush all availableToRead bytes to stream
-   * @param stream
-   * @return
-   */
-  v_io_size flushToStream(data::stream::OutputStream* stream);
-
-  /**
-   * flush all availableToRead bytes to stream in asynchronous manner
-   * @param stream - &id:data::stream::OutputStream;.
-   * @return - &id:async::CoroutineStarter;.
-   */
-  async::CoroutineStarter flushToStreamAsync(const std::shared_ptr<data::stream::OutputStream>& stream);
+  v_io_size writeBufferToStream(stream::WriteCallback *writeCallback, v_buff_size count) override;
 
   /**
    * Amount of buffer space currently available for data writes.

--- a/src/oatpp/core/data/stream/Stream.cpp
+++ b/src/oatpp/core/data/stream/Stream.cpp
@@ -285,6 +285,40 @@ StreamType DefaultInitializedContext::getStreamType() const {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// BufferedInputStream
+
+v_io_size BufferedInputStream::flushBufferToStream(stream::WriteCallback *writeCallback) {
+  return writeBufferToStream(writeCallback, availableToRead());
+}
+
+async::CoroutineStarter BufferedInputStream::flushBufferToStreamAsync(const std::shared_ptr<data::stream::WriteCallback> &stream) {
+  return writeBufferToStreamAsync(stream, availableToRead());
+}
+
+v_io_size BufferedInputStream::writeBufferToStream(stream::WriteCallback *writeCallback, v_buff_size count) {
+  auto ioBuffer = buffer::IOBuffer::createShared();
+  count = std::min(count, availableToRead());
+  transfer(this, writeCallback, count, ioBuffer->getData(), ioBuffer->getSize());
+  return count;
+}
+
+async::CoroutineStarter BufferedInputStream::writeBufferToStreamAsync(const std::shared_ptr<data::stream::WriteCallback>& stream, v_buff_size count) {
+  auto ioBuffer = buffer::IOBuffer::createShared();
+  return transferAsync(this, stream, count, ioBuffer);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// BufferedOutputStream
+
+v_io_size BufferedOutputStream::flushBufferToStream(stream::WriteCallback *writeCallback) {
+  return writeBufferToStream(writeCallback, getSize());
+}
+
+async::CoroutineStarter BufferedOutputStream::flushBufferToStreamAsync(const std::shared_ptr<data::stream::WriteCallback> &stream) {
+  return writeBufferToStreamAsync(stream, getSize());
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // IOStream
 
 void IOStream::initContexts() {
@@ -805,5 +839,6 @@ async::CoroutineStarter transferAsync(const base::ObjectHandle<ReadCallback>& re
   return TransferCoroutine::start(readCallback, writeCallback, transferSize, buffer, processor);
 
 }
-  
+
+
 }}}

--- a/src/oatpp/core/data/stream/Stream.hpp
+++ b/src/oatpp/core/data/stream/Stream.hpp
@@ -350,10 +350,49 @@ public:
 
 };
 
+class BufferedStream {
+ public:
+  /**
+   * Virtual default destructor
+   */
+  virtual ~BufferedStream() = default;
+
+  /**
+   * Writes all available buffered data to &l:WriteCallback;.
+   * @param writeCallback - write-enabled object to write to
+   * @return - actual number of bytes written. &id:oatpp::v_io_size;. <br>
+   */
+  virtual v_io_size flushBufferToStream(stream::WriteCallback *writeCallback) = 0;
+
+  /**
+   * Writes all available buffered data to &l:WriteCallback; in an async context.
+   * @param writeCallback - write-enabled object to write to
+   * @param count - maximum amount of bytes to written.
+   * @return - &id:async::CoroutineStarter;.
+   */
+  virtual async::CoroutineStarter flushBufferToStreamAsync(const std::shared_ptr<data::stream::WriteCallback>& stream) = 0;
+
+  /**
+   * Writes up to count of buffered data to &l:WriteCallback;.
+   * @param writeCallback - write-enabled object to write to
+   * @param count - maximum amount of bytes to written.
+   * @return - actual number of bytes written. &id:oatpp::v_io_size;. <br>
+   */
+  virtual v_io_size writeBufferToStream(stream::WriteCallback *writeCallback, v_buff_size count) = 0;
+
+  /**
+   * Writes up to count buffered data to &l:WriteCallback; in an async context.
+   * @param writeCallback - write-enabled object to write to
+   * @param count - maximum amount of bytes to written.
+   * @return - &id:async::CoroutineStarter;.
+   */
+  virtual async::CoroutineStarter writeBufferToStreamAsync(const std::shared_ptr<data::stream::WriteCallback>& stream, v_buff_size count) = 0;
+};
+
 /**
  * Buffered Input Stream
  */
-class BufferedInputStream : public InputStream {
+class BufferedInputStream : public InputStream, public BufferedStream {
  public:
   /**
    * Default virtual destructor.
@@ -361,7 +400,7 @@ class BufferedInputStream : public InputStream {
   virtual ~BufferedInputStream() = default;
 
   /**
-   * Peek up to count of bytes int he buffer
+   * Peek up to count of bytes in the buffer
    * @param data
    * @param count
    * @return [1..count], IOErrors.
@@ -380,6 +419,37 @@ class BufferedInputStream : public InputStream {
    * @return [1..count], IOErrors.
    */
   virtual v_io_size commitReadOffset(v_buff_size count) = 0;
+
+  /**
+   * Writes all available buffered data to &l:WriteCallback;.
+   * @param writeCallback - write-enabled object to write to
+   * @return - actual number of bytes written. &id:oatpp::v_io_size;. <br>
+   */
+  virtual v_io_size flushBufferToStream(stream::WriteCallback *writeCallback) override;
+
+  /**
+   * Writes all available buffered data to &l:WriteCallback; in an async context.
+   * @param writeCallback - write-enabled object to write to
+   * @param count - maximum amount of bytes to written.
+   * @return - &id:async::CoroutineStarter;.
+   */
+  virtual async::CoroutineStarter flushBufferToStreamAsync(const std::shared_ptr<data::stream::WriteCallback>& stream) override;
+
+  /**
+   * Writes up to count of buffered data to &l:WriteCallback;.
+   * @param writeCallback - write-enabled object to write to
+   * @param count - maximum amount of bytes to written.
+   * @return - actual number of bytes written. &id:oatpp::v_io_size;. <br>
+   */
+  virtual v_io_size writeBufferToStream(stream::WriteCallback *writeCallback, v_buff_size count) override;
+
+  /**
+   * Writes up to count buffered data to &l:WriteCallback; in an async context.
+   * @param writeCallback - write-enabled object to write to
+   * @param count - maximum amount of bytes to written.
+   * @return - &id:async::CoroutineStarter;.
+   */
+  virtual async::CoroutineStarter writeBufferToStreamAsync(const std::shared_ptr<data::stream::WriteCallback>& stream, v_buff_size count) override;
 };
 
 /**
@@ -516,6 +586,35 @@ ConsistentOutputStream& operator << (ConsistentOutputStream& s, T value) {
 //ConsistentOutputStream& operator << (ConsistentOutputStream& s, v_float32 value);
 //ConsistentOutputStream& operator << (ConsistentOutputStream& s, v_float64 value);
 //ConsistentOutputStream& operator << (ConsistentOutputStream& s, bool value);
+
+class BufferedOutputStream : public ConsistentOutputStream, public BufferedStream {
+ public:
+  /**
+   * Default virtual destructor.
+   */
+  virtual ~BufferedOutputStream() = default;
+
+  /**
+   * Returns the amount of written bytes to the buffer
+   * @return - actual number of bytes in buffer. &id:oatpp::v_io_size;. <br>
+   */
+  virtual v_io_size getSize() = 0;
+
+  /**
+   * Writes all available buffered data to &l:WriteCallback;.
+   * @param writeCallback - write-enabled object to write to
+   * @return - actual number of bytes written. &id:oatpp::v_io_size;. <br>
+   */
+  virtual v_io_size flushBufferToStream(stream::WriteCallback *writeCallback) override;
+
+  /**
+   * Writes all available buffered data to &l:WriteCallback; in an async context.
+   * @param writeCallback - write-enabled object to write to
+   * @param count - maximum amount of bytes to written.
+   * @return - &id:async::CoroutineStarter;.
+   */
+  virtual async::CoroutineStarter flushBufferToStreamAsync(const std::shared_ptr<data::stream::WriteCallback>& stream) override;
+};
 
 /**
  * Error of Asynchronous stream transfer.

--- a/src/oatpp/web/protocol/http/outgoing/Request.cpp
+++ b/src/oatpp/web/protocol/http/outgoing/Request.cpp
@@ -123,15 +123,15 @@ void Request::send(data::stream::OutputStream* stream){
 
       if(bodySize + buffer.getCurrentPosition() < buffer.getCapacity()) {
         buffer.writeSimple(m_body->getKnownData(), bodySize);
-        buffer.flushToStream(stream);
+        buffer.flushBufferToStream(stream);
       } else {
-        buffer.flushToStream(stream);
+        buffer.flushBufferToStream(stream);
         stream->writeExactSizeDataSimple(m_body->getKnownData(), bodySize);
       }
 
     } else {
 
-      buffer.flushToStream(stream);
+      buffer.flushBufferToStream(stream);
 
       http::encoding::EncoderChunked chunkedEncoder;
 
@@ -142,7 +142,7 @@ void Request::send(data::stream::OutputStream* stream){
     }
 
   } else {
-    buffer.flushToStream(stream);
+    buffer.flushBufferToStream(stream);
   }
   
 }
@@ -203,11 +203,11 @@ oatpp::async::CoroutineStarter Request::sendAsync(std::shared_ptr<Request> _this
           if(bodySize + m_headersWriteBuffer->getCurrentPosition() < m_headersWriteBuffer->getCapacity()) {
 
             m_headersWriteBuffer->writeSimple(m_this->m_body->getKnownData(), bodySize);
-            return oatpp::data::stream::BufferOutputStream::flushToStreamAsync(m_headersWriteBuffer, m_stream)
+            return oatpp::data::stream::BufferOutputStream::flushBufferToStreamAsync(m_headersWriteBuffer, m_stream)
               .next(finish());
           } else {
 
-            return oatpp::data::stream::BufferOutputStream::flushToStreamAsync(m_headersWriteBuffer, m_stream)
+            return oatpp::data::stream::BufferOutputStream::flushBufferToStreamAsync(m_headersWriteBuffer, m_stream)
               .next(m_stream->writeExactSizeDataAsync(m_this->m_body->getKnownData(), bodySize))
               .next(finish());
           }
@@ -215,7 +215,7 @@ oatpp::async::CoroutineStarter Request::sendAsync(std::shared_ptr<Request> _this
         } else {
 
           auto chunkedEncoder = std::make_shared<http::encoding::EncoderChunked>();
-          return oatpp::data::stream::BufferOutputStream::flushToStreamAsync(m_headersWriteBuffer, m_stream)
+          return oatpp::data::stream::BufferOutputStream::flushBufferToStreamAsync(m_headersWriteBuffer, m_stream)
                  .next(data::stream::transferAsync(m_this->m_body, m_stream, 0, data::buffer::IOBuffer::createShared(), chunkedEncoder))
                  .next(finish());
 
@@ -223,7 +223,7 @@ oatpp::async::CoroutineStarter Request::sendAsync(std::shared_ptr<Request> _this
 
       } else {
 
-        return oatpp::data::stream::BufferOutputStream::flushToStreamAsync(m_headersWriteBuffer, m_stream)
+        return oatpp::data::stream::BufferOutputStream::flushBufferToStreamAsync(m_headersWriteBuffer, m_stream)
           .next(finish());
       }
       

--- a/src/oatpp/web/protocol/http/outgoing/Response.cpp
+++ b/src/oatpp/web/protocol/http/outgoing/Response.cpp
@@ -137,22 +137,22 @@ void Response::send(data::stream::OutputStream* stream,
       if (bodySize >= 0) {
 
         if(m_body->getKnownData() == nullptr) {
-          headersWriteBuffer->flushToStream(stream);
+          headersWriteBuffer->flushBufferToStream(stream);
           /* Reuse headers buffer */
           /* Transfer without chunked encoder */
           data::stream::transfer(m_body, stream, 0, headersWriteBuffer->getData(), headersWriteBuffer->getCapacity());
         } else { 
           if (bodySize + headersWriteBuffer->getCurrentPosition() < headersWriteBuffer->getCapacity()) {
             headersWriteBuffer->writeSimple(m_body->getKnownData(), bodySize);
-            headersWriteBuffer->flushToStream(stream);
+            headersWriteBuffer->flushBufferToStream(stream);
           } else {
-            headersWriteBuffer->flushToStream(stream);
+            headersWriteBuffer->flushBufferToStream(stream);
             stream->writeExactSizeDataSimple(m_body->getKnownData(), bodySize);
           }
         }
       } else {
 
-        headersWriteBuffer->flushToStream(stream);
+        headersWriteBuffer->flushBufferToStream(stream);
 
         http::encoding::EncoderChunked chunkedEncoder;
 
@@ -163,7 +163,7 @@ void Response::send(data::stream::OutputStream* stream,
 
     } else {
 
-      headersWriteBuffer->flushToStream(stream);
+      headersWriteBuffer->flushBufferToStream(stream);
 
       http::encoding::EncoderChunked chunkedEncoder;
       auto contentEncoder = contentEncoderProvider->getProcessor();
@@ -179,7 +179,7 @@ void Response::send(data::stream::OutputStream* stream,
     }
 
   } else {
-    headersWriteBuffer->flushToStream(stream);
+    headersWriteBuffer->flushBufferToStream(stream);
   }
 
 }
@@ -256,12 +256,12 @@ oatpp::async::CoroutineStarter Response::sendAsync(const std::shared_ptr<Respons
             if (bodySize + m_headersWriteBuffer->getCurrentPosition() < m_headersWriteBuffer->getCapacity()) {
 
               m_headersWriteBuffer->writeSimple(m_this->m_body->getKnownData(), bodySize);
-              return oatpp::data::stream::BufferOutputStream::flushToStreamAsync(m_headersWriteBuffer, m_stream)
+              return oatpp::data::stream::BufferOutputStream::flushBufferToStreamAsync(m_headersWriteBuffer, m_stream)
                 .next(finish());
 
             } else {
 
-              return oatpp::data::stream::BufferOutputStream::flushToStreamAsync(m_headersWriteBuffer, m_stream)
+              return oatpp::data::stream::BufferOutputStream::flushBufferToStreamAsync(m_headersWriteBuffer, m_stream)
                 .next(m_stream->writeExactSizeDataAsync(m_this->m_body->getKnownData(), bodySize))
                 .next(finish());
             }
@@ -269,7 +269,7 @@ oatpp::async::CoroutineStarter Response::sendAsync(const std::shared_ptr<Respons
           } else {
 
             auto chunkedEncoder = std::make_shared<http::encoding::EncoderChunked>();
-            return oatpp::data::stream::BufferOutputStream::flushToStreamAsync(m_headersWriteBuffer, m_stream)
+            return oatpp::data::stream::BufferOutputStream::flushBufferToStreamAsync(m_headersWriteBuffer, m_stream)
               .next(data::stream::transferAsync(m_this->m_body, m_stream, 0, data::buffer::IOBuffer::createShared(), chunkedEncoder))
               .next(finish());
 
@@ -285,7 +285,7 @@ oatpp::async::CoroutineStarter Response::sendAsync(const std::shared_ptr<Respons
             chunkedEncoder
           }));
 
-          return oatpp::data::stream::BufferOutputStream::flushToStreamAsync(m_headersWriteBuffer, m_stream)
+          return oatpp::data::stream::BufferOutputStream::flushBufferToStreamAsync(m_headersWriteBuffer, m_stream)
             .next(data::stream::transferAsync(m_this->m_body, m_stream, 0, data::buffer::IOBuffer::createShared(), pipeline)
             . next(finish()));
 
@@ -293,7 +293,7 @@ oatpp::async::CoroutineStarter Response::sendAsync(const std::shared_ptr<Respons
 
       } else {
 
-        return oatpp::data::stream::BufferOutputStream::flushToStreamAsync(m_headersWriteBuffer, m_stream)
+        return oatpp::data::stream::BufferOutputStream::flushBufferToStreamAsync(m_headersWriteBuffer, m_stream)
           .next(finish());
       }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,8 @@ add_executable(oatppAllTests
         oatpp/core/data/stream/BufferStreamTest.hpp
         oatpp/core/data/stream/ChunkedBufferTest.cpp
         oatpp/core/data/stream/ChunkedBufferTest.hpp
+        oatpp/core/data/stream/FIFOStreamTest.cpp
+        oatpp/core/data/stream/FIFOStreamTest.hpp
         oatpp/core/parser/CaretTest.cpp
         oatpp/core/parser/CaretTest.hpp
         oatpp/core/provider/PoolTest.cpp

--- a/test/oatpp/AllTestsMain.cpp
+++ b/test/oatpp/AllTestsMain.cpp
@@ -47,6 +47,7 @@
 
 #include "oatpp/core/data/stream/BufferStreamTest.hpp"
 #include "oatpp/core/data/stream/ChunkedBufferTest.hpp"
+#include "oatpp/core/data/stream/FIFOStreamTest.hpp"
 #include "oatpp/core/data/share/LazyStringMapTest.hpp"
 #include "oatpp/core/data/share/StringTemplateTest.hpp"
 #include "oatpp/core/data/share/MemoryLabelTest.hpp"
@@ -90,6 +91,7 @@ void runTests() {
 
   OATPP_RUN_TEST(oatpp::test::core::data::stream::ChunkedBufferTest);
   OATPP_RUN_TEST(oatpp::test::core::data::stream::BufferStreamTest);
+  OATPP_RUN_TEST(oatpp::test::core::data::stream::FIFOStreamTest);
 
   OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::ObjectWrapperTest);
   OATPP_RUN_TEST(oatpp::test::core::data::mapping::type::TypeTest);

--- a/test/oatpp/core/data/stream/BufferStreamTest.cpp
+++ b/test/oatpp/core/data/stream/BufferStreamTest.cpp
@@ -144,6 +144,55 @@ void BufferStreamTest::onRun() {
 
   }
 
+  {
+
+    BufferOutputStream streamA(0);
+    BufferOutputStream streamB(0);
+
+    oatpp::String sample = "0123456789";
+    oatpp::String text = "";
+
+    for(v_int32 i = 0; i < 1024; i++ ) {
+      text = text + sample;
+    }
+
+    for(v_int32 i = 0; i < 1024; i++ ) {
+      streamA << sample;
+    }
+
+    streamA.flushBufferToStream(&streamB);
+
+    OATPP_ASSERT(text == streamB.toString());
+
+  }
+
+  {
+
+    BufferOutputStream streamA(0);
+    BufferOutputStream streamB(0);
+
+    oatpp::String sample = "0123456789";
+    oatpp::String text = "";
+
+    for(v_int32 i = 0; i < 1024; i++ ) {
+      text = text + sample;
+    }
+
+    for(v_int32 i = 0; i < 1024; i++ ) {
+      streamA << sample;
+    }
+
+    streamA.writeBufferToStream(&streamB, 25);
+
+    OATPP_ASSERT(oatpp::String(text->substr(0, 25)) == streamB.toString());
+
+
+    // consistent stream does not advance after reading. Use FIFOStream for this!
+    streamA.writeBufferToStream(&streamB, 7);
+
+    OATPP_ASSERT(oatpp::String(text->substr(0, 7)) == streamB.toString());
+  }
+
 }
 
 }}}}}

--- a/test/oatpp/core/data/stream/ChunkedBufferTest.cpp
+++ b/test/oatpp/core/data/stream/ChunkedBufferTest.cpp
@@ -123,7 +123,37 @@ void ChunkedBufferTest::onRun() {
 
   }
 
+  {
 
+    ChunkedBuffer streamA;
+    ChunkedBuffer streamB;
+
+    for(v_int32 i = 0; i < ChunkedBuffer::CHUNK_ENTRY_SIZE * 10; i++) {
+      streamA.writeSimple("0123456789", 10);
+    }
+
+    auto wholeText = streamA.toString();
+    streamA.flushBufferToStream(&streamB);
+
+    OATPP_ASSERT(streamA.toString() == streamB.toString());
+
+  }
+
+  {
+
+    ChunkedBuffer streamA;
+    ChunkedBuffer streamB;
+
+    for(v_int32 i = 0; i < ChunkedBuffer::CHUNK_ENTRY_SIZE * 10; i++) {
+      streamA.writeSimple("0123456789", 10);
+    }
+
+    auto wholeText = streamA.toString();
+    streamA.writeBufferToStream(&streamB, 20);
+
+    OATPP_ASSERT(oatpp::String("01234567890123456789") == streamB.toString());
+
+  }
 }
 
 }}}}}

--- a/test/oatpp/core/data/stream/FIFOStreamTest.cpp
+++ b/test/oatpp/core/data/stream/FIFOStreamTest.cpp
@@ -1,0 +1,91 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Benedikt-Alexander Mokroß <github@bamkrs.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#include "FIFOStreamTest.hpp"
+
+#include "oatpp/core/data/stream/FIFOStream.hpp"
+#include "oatpp/core/data/stream/BufferStream.hpp"
+#include "oatpp/core/utils/ConversionUtils.hpp"
+#include "oatpp/core/utils/Binary.hpp"
+
+namespace oatpp { namespace test { namespace core { namespace data { namespace stream {
+
+void FIFOStreamTest::onRun() {
+
+  typedef oatpp::data::stream::FIFOInputStream FIFOInputStream;
+  typedef oatpp::data::stream::BufferOutputStream BufferOutputStream;
+
+  {
+    FIFOInputStream stream;
+
+    stream.writeSimple("0123456789");
+
+    OATPP_ASSERT(stream.availableToRead() == 10);
+
+    oatpp::String string(3);
+    stream.readExactSizeDataSimple((void*)string->data(), 3);
+
+    OATPP_ASSERT(stream.availableToRead() == 7);
+    OATPP_ASSERT(string == oatpp::String("012"));
+
+    stream.writeSimple("ABCDEF");
+    OATPP_ASSERT(stream.availableToRead() == 13);
+
+    BufferOutputStream outStream;
+    stream.flushBufferToStream(&outStream);
+
+    OATPP_ASSERT(outStream.toString() == oatpp::String("3456789ABCDEF"));
+
+  }
+
+  {
+    FIFOInputStream stream;
+
+    stream.writeSimple("0123456789");
+
+    BufferOutputStream outStream;
+    stream.writeBufferToStream(&outStream, 4);
+
+    OATPP_ASSERT(stream.availableToRead() == 6);
+    OATPP_ASSERT(outStream.toString() == oatpp::String("0123"));
+
+    stream.writeBufferToStream(&outStream, 1);
+    OATPP_ASSERT(stream.availableToRead() == 5);
+    OATPP_ASSERT(outStream.toString() == oatpp::String("01234"));
+
+    stream.writeBufferToStream(&outStream, 5);
+    OATPP_ASSERT(stream.availableToRead() == 0);
+    OATPP_ASSERT(outStream.toString() == oatpp::String("0123456789"));
+
+    stream.writeSimple("ABCDEF");
+    OATPP_ASSERT(stream.availableToRead() == 6);
+    stream.flushBufferToStream(&outStream);
+    OATPP_ASSERT(stream.availableToRead() == 0);
+    OATPP_ASSERT(outStream.toString() == oatpp::String("0123456789ABCDEF"));
+
+  }
+
+}
+
+}}}}}

--- a/test/oatpp/core/data/stream/FIFOStreamTest.hpp
+++ b/test/oatpp/core/data/stream/FIFOStreamTest.hpp
@@ -1,0 +1,43 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Benedikt-Alexander Mokroß <github@bamkrs.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#ifndef oatpp_test_core_data_stream_FIFOStream_hpp
+#define oatpp_test_core_data_stream_FIFOStream_hpp
+
+#include "oatpp-test/UnitTest.hpp"
+
+namespace oatpp { namespace test { namespace core { namespace data { namespace stream {
+
+class FIFOStreamTest : public UnitTest{
+public:
+
+  FIFOStreamTest():UnitTest("TEST[core::data::stream::FIFOStreamTest]"){}
+  void onRun() override;
+
+};
+
+}}}}}
+
+
+#endif // oatpp_test_core_data_stream_FIFOStream_hpp


### PR DESCRIPTION
Following my last stream API PR, this one build upon the concepts of the first PR and majorly touches all streams that somehow use a buffer. 
Again, all `OutputStream` had a similiar API with similar features. Namely the `flushToStream` function. However, those streams did not inherit from an common base class so it is hard to use different implementations in a general context. 

The new `BufferedStream` interface packs a set of functions that were found on all buffered streams (Input and Output) and provides default implementations using `stream::transfer`.
Those default implementations can be overridden to maximize performance like in `FIFOStream` which directly writes to the next streams `WriteCallback` instead of using `stream::transfer` which requires an intermediate buffer.

For input-streams, the implementation is quite trivial and builds upon already existing APIs. For output-streams a lot of specialized implementation is needed. 

The PR introduces breaking changes to the current API and is still a WIP. 

ToDo:

- [ ]  `writeBufferToStream` with read-offsets. 
- [ ]  Introduce better names for functions