### PR TITLE
oatpp::String works better with std::string

### DIFF
--- a/changelog/1.3.0.md
+++ b/changelog/1.3.0.md
@@ -26,8 +26,14 @@ Now it's much easier to use `oatpp::String` since `oatpp::String` is now wrapper
 
 {
   oatpp::String s1 = "Hello";
-  std::string s2 = *s1;
+  std::string s2 = *s1;   // *s1 returns a refernce to the internal std::string object
 }
+
+{
+  oatpp::String s1 = "Hello";
+  std::string s2 = s1;   // s1 is used a l-value with a typecast operator
+}
+
 
 {
   oatpp::String s1 = "Hello";
@@ -129,7 +135,7 @@ res='"https://oatpp.io/"' # solidus isn't escaped
 ## data::stream::FIFOStream
 
 The new `FIFOStream` stream is a buffered
-[`InputStream`](https://oatpp.io/api/latest/oatpp/core/data/stream/Stream/#inputstream) with an 
+[`InputStream`](https://oatpp.io/api/latest/oatpp/core/data/stream/Stream/#inputstream) with an
 [`WriteCallback`](https://oatpp.io/api/latest/oatpp/core/data/stream/Stream/#writecallback).
 Check the corresponding documentation on how to use these interfaces.
 

--- a/src/oatpp/core/data/mapping/type/Primitive.hpp
+++ b/src/oatpp/core/data/mapping/type/Primitive.hpp
@@ -32,6 +32,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <iterator>
 
 namespace oatpp { namespace data { namespace mapping { namespace type {
 
@@ -128,7 +129,8 @@ public:
 
   operator std::string() const
   {
-      return this->m_ptr.operator*();
+    if (this->m_ptr == nullptr) throw std::runtime_error("m_ptr points to null.");
+    return this->m_ptr.operator*();
   }
 
   template<typename T,
@@ -175,6 +177,7 @@ public:
 
 
   inline bool equalsCI(const std::string &sb) {
+    if (this->m_ptr == nullptr ) return false;
     const std::string& sa = this->m_ptr.operator*();
     return (sa.size() == sb.size()) && std::equal(sa.begin(), sa.end(), sb.begin(),
                       [] (char a, char b) -> bool {
@@ -183,13 +186,29 @@ public:
   }
 
   inline bool equalsCI(const String &b) {
+    if (this->m_ptr == nullptr && b.m_ptr == nullptr) return true;
+    if (this->m_ptr == nullptr && b.m_ptr != nullptr) return false;
+    if (this->m_ptr != nullptr && b.m_ptr == nullptr) return false;
     const std::string& sb = *b;
     return this->equalsCI(sb);
   }
 
   inline bool equalsCI(const char *b) {
-    const std::string sb(b);
-    return this->equalsCI(sb);
+    if (this->m_ptr == nullptr && b == nullptr) return true;
+    if (this->m_ptr == nullptr && b != nullptr) return false;
+    if (this->m_ptr != nullptr && b == nullptr) return false;
+
+    size_t lb = strlen(b);
+    const std::string& sa = this->m_ptr.operator*();
+
+    if (sa.size() != lb) return false;
+    const char *ba = b;
+
+    for ( const auto &ca: sa ) {
+      if ( std::tolower(ca) != std::tolower(*ba)) return false;
+      ba++;
+    }
+    return true;
   }
 
   template<typename T,

--- a/src/oatpp/core/data/mapping/type/Primitive.hpp
+++ b/src/oatpp/core/data/mapping/type/Primitive.hpp
@@ -124,12 +124,13 @@ public:
   {}
 
   const std::string& operator*() const {
+    if (this->m_ptr == nullptr) throw std::runtime_error("[oatpp::data::mapping::type::String] Error: m_ptr points to null.");
     return this->m_ptr.operator*();
   }
 
   operator std::string() const
   {
-    if (this->m_ptr == nullptr) throw std::runtime_error("m_ptr points to null.");
+    if (this->m_ptr == nullptr) throw std::runtime_error("[oatpp::data::mapping::type::String] Error: m_ptr points to null.");
     return this->m_ptr.operator*();
   }
 

--- a/src/oatpp/core/data/mapping/type/Primitive.hpp
+++ b/src/oatpp/core/data/mapping/type/Primitive.hpp
@@ -30,10 +30,13 @@
 #include "oatpp/core/base/memory/ObjectPool.hpp"
 #include "oatpp/core/base/Countable.hpp"
 
+#include <algorithm>
+#include <cctype>
+
 namespace oatpp { namespace data { namespace mapping { namespace type {
-  
+
 namespace __class {
-  
+
   class String; // FWD
 
   class Int8; // FWD
@@ -52,7 +55,7 @@ namespace __class {
   class Float64; // FWD
 
   class Boolean; // FWD
-  
+
 }
 
 /**
@@ -62,13 +65,13 @@ class String : public type::ObjectWrapper<std::string, __class::String> {
 public:
   String(const std::shared_ptr<std::string>& ptr, const type::Type* const valueType);
 public:
-  
+
   String() {}
 
   explicit String(v_buff_size size)
     : type::ObjectWrapper<std::string, __class::String>(std::make_shared<std::string>(size, 0))
   {}
-  
+
   String(const char* data, v_buff_size size)
     : type::ObjectWrapper<std::string, __class::String>(std::make_shared<std::string>(data, size))
   {}
@@ -102,25 +105,30 @@ public:
         std::make_shared<std::string>(std::forward<std::string>(str))
       )
   {}
-  
+
   String(const std::shared_ptr<std::string>& ptr)
     : type::ObjectWrapper<std::string, __class::String>(ptr)
   {}
-  
+
   String(std::shared_ptr<std::string>&& ptr)
     : type::ObjectWrapper<std::string, __class::String>(std::forward<std::shared_ptr<std::string>>(ptr))
   {}
-  
+
   String(const String& other)
     : type::ObjectWrapper<std::string, __class::String>(other)
   {}
-  
+
   String(String&& other)
     : type::ObjectWrapper<std::string, __class::String>(std::forward<String>(other))
   {}
 
   const std::string& operator*() const {
     return this->m_ptr.operator*();
+  }
+
+  operator std::string() const
+  {
+      return this->m_ptr.operator*();
   }
 
   template<typename T,
@@ -163,6 +171,25 @@ public:
   inline String& operator = (String&& other) noexcept {
     m_ptr = std::move(other.m_ptr);
     return *this;
+  }
+
+
+  inline bool equalsCI(const std::string &sb) {
+    const std::string& sa = this->m_ptr.operator*();
+    return (sa.size() == sb.size()) && std::equal(sa.begin(), sa.end(), sb.begin(),
+                      [] (char a, char b) -> bool {
+                          return std::tolower(a) == std::tolower(b);
+                      });
+  }
+
+  inline bool equalsCI(const String &b) {
+    const std::string& sb = *b;
+    return this->equalsCI(sb);
+  }
+
+  inline bool equalsCI(const char *b) {
+    const std::string sb(b);
+    return this->equalsCI(sb);
   }
 
   template<typename T,
@@ -219,9 +246,9 @@ public:
   inline bool operator != (const String &other) const {
     return !operator == (other);
   }
-  
+
 };
-  
+
 String operator + (const char* a, const String& b);
 String operator + (const String& a, const char* b);
 String operator + (const String& a, const String& b);
@@ -301,7 +328,7 @@ public:
   inline operator TValueType() const {
     return *this->m_ptr;
   }
-  
+
 };
 
 /**
@@ -471,29 +498,29 @@ template<>
 struct ObjectWrapperByUnderlyingType <bool> {
   typedef Boolean ObjectWrapper;
 };
-  
+
 namespace __class {
-  
+
   class String {
   public:
     static const ClassId CLASS_ID;
-    
+
     static Type* getType(){
       static Type type(CLASS_ID, nullptr);
       return &type;
     }
-    
+
   };
-  
+
   class Int8 {
   public:
     static const ClassId CLASS_ID;
-    
+
     static Type* getType(){
       static Type type(CLASS_ID, nullptr);
       return &type;
     }
-    
+
   };
 
   class UInt8 {
@@ -510,12 +537,12 @@ namespace __class {
   class Int16 {
   public:
     static const ClassId CLASS_ID;
-    
+
     static Type* getType(){
       static Type type(CLASS_ID, nullptr);
       return &type;
     }
-    
+
   };
 
   class UInt16 {
@@ -528,16 +555,16 @@ namespace __class {
     }
 
   };
-  
+
   class Int32 {
   public:
     static const ClassId CLASS_ID;
-    
+
     static Type* getType(){
       static Type type(CLASS_ID, nullptr);
       return &type;
     }
-    
+
   };
 
   class UInt32 {
@@ -550,16 +577,16 @@ namespace __class {
     }
 
   };
-  
+
   class Int64 {
   public:
     static const ClassId CLASS_ID;
-    
+
     static Type* getType(){
       static Type type(CLASS_ID, nullptr);
       return &type;
     }
-    
+
   };
 
   class UInt64 {
@@ -576,53 +603,53 @@ namespace __class {
   class Float32 {
   public:
     static const ClassId CLASS_ID;
-    
+
     static Type* getType(){
       static Type type(CLASS_ID, nullptr);
       return &type;
     }
-    
+
   };
-  
+
   class Float64 {
   public:
     static const ClassId CLASS_ID;
-    
+
     static Type* getType(){
       static Type type(CLASS_ID, nullptr);
       return &type;
     }
-    
+
   };
-  
+
   class Boolean {
   public:
     static const ClassId CLASS_ID;
-    
+
     static Type* getType(){
       static Type type(CLASS_ID, nullptr);
       return &type;
     }
-    
+
   };
-  
+
 }
-  
+
 }}}}
 
 namespace std {
-  
+
   template<>
   struct hash<oatpp::data::mapping::type::String> {
-    
+
     typedef oatpp::data::mapping::type::String argument_type;
     typedef v_uint64 result_type;
-    
+
     result_type operator()(argument_type const& s) const noexcept {
       if(s.get() == nullptr) return 0;
       return hash<std::string> {} (*s);
     }
-    
+
   };
 
   template<>


### PR DESCRIPTION
As suggested in #470, the typecast operator from `oatpp::String` to `std::string` is included. 

Furthermore, to get `oatpp-swagger` running again, a case insensitive string comparison is required. For this purpose the `oatpp::String` class gets the following new methods:
```cpp
inline bool equalsCI(const std::string &sb) ;
inline bool equalsCI(const String &b);
inline bool equalsCI(const char *b);
```

Finally, trialling whitespaces are removed.

Closes: #470 