### PR TITLE
Try to fix cross compilation for Raspberry/Synology

### DIFF
--- a/src/oatpp/orm/Executor.cpp
+++ b/src/oatpp/orm/Executor.cpp
@@ -39,7 +39,7 @@ std::shared_ptr<QueryResult> Executor::execute(const oatpp::String& query,
                                                const std::shared_ptr<const data::mapping::TypeResolver>& typeResolver,
                                                const std::shared_ptr<Connection>& connection)
 {
-  const auto& qt = parseQueryTemplate(nullptr, query, {}, false);
+  const auto& qt = parseQueryTemplate(nullptr, query, ParamsTypeMap(), false);
   return execute(qt, params, typeResolver, connection);
 }
 


### PR DESCRIPTION
Hi,

It seems that GCC doesn't support well initializer for ParamsTypeMap ([see this build](https://github.com/Yadoms/yadoms/runs/3535646691?check_suite_focus=true)), error was something like :
`
/work/projects/external-libs/oatpp/src/oatpp_build/src/oatpp/orm/Executor.cpp:42:64: error: converting to 'const ParamsTypeMap {...}' from initializer list would use explicit constructor '...'
`

This PR suggest a simple workaround using default ctor of ParamsTypeMap instead of empty initializer at parseQueryTemplate call.
