### PR TITLE
Add ErrorHandler virtual destructor

### DIFF
--- a/src/oatpp/web/server/handler/ErrorHandler.hpp
+++ b/src/oatpp/web/server/handler/ErrorHandler.hpp
@@ -41,6 +41,10 @@ public:
    */
   typedef web::protocol::http::Headers Headers;
 public:
+  /**
+   * Virtual destructor since the class is ment to be derived from.
+   * */
+  virtual ~ErrorHandler() = default;
 
   /**
    * Implement this method!


### PR DESCRIPTION
Virtual destructor added to the ErrorHandler since derived class
destructor should be called when destroying an object via a pointer to
the base type (ErrorHandler in this case).

More info: https://stackoverflow.com/a/461224/6067014