### PR TITLE
Add option to include required fields in JSON even if `value == nullptr` and `includeNullFields == false`.

### DIFF
--- a/src/oatpp/parser/json/mapping/Serializer.cpp
+++ b/src/oatpp/parser/json/mapping/Serializer.cpp
@@ -160,7 +160,7 @@ void Serializer::serializeObject(Serializer* serializer,
   for (auto const& field : fields) {
 
     auto value = field->get(object);
-    if (value || config->includeNullFields || (field->info.required && config->honorRequired)) {
+    if (value || config->includeNullFields || (field->info.required && config->alwaysIncludeRequired)) {
       (first) ? first = false : stream->writeSimple(",", 1);
       serializeString(stream, (p_char8)field->name, std::strlen(field->name));
       stream->writeSimple(":", 1);

--- a/src/oatpp/parser/json/mapping/Serializer.hpp
+++ b/src/oatpp/parser/json/mapping/Serializer.hpp
@@ -65,14 +65,14 @@ public:
 
     /**
      * Include fields with value == nullptr into serialized json.
-     * Field will still be included when field-info `required` is set to true and &id:honorRequired is set to true.
+     * Field will still be included when field-info `required` is set to true and &id:alwaysIncludeRequired is set to true.
      */
     bool includeNullFields = true;
 
     /**
-     * Honor required fields in DTO_FIELD_INFO and include required fields even if they are `value == nullptr`
+     * Always include required fields (set in in DTO_FIELD_INFO) even if they are `value == nullptr`
      */
-    bool honorRequired = false;
+    bool alwaysIncludeRequired = false;
 
     /**
      * If `true` - insert string `"<unknown-type>"` in json field value in case unknown field found.


### PR DESCRIPTION
In some situations, some fields without a value still need to be included in the serialized JSON, even if `includeNullFields == false`.
With this PR, one can set the serializer-config's `honorRequired` to `true` and the serializer will include the null-field even if `includeNullFields` is set to false. 