### PR TITLE
Add a convenience invalidate() method to ResourceHandleTemplate. 

### DIFF
--- a/changelog/1.3.0.md
+++ b/changelog/1.3.0.md
@@ -33,7 +33,7 @@ Now it's much easier to use `oatpp::String` since `oatpp::String` is now wrapper
 
 {
   oatpp::String s1 = "Hello";
-  std::string s2 = *s1;   // *s1 returns a refernce to the internal std::string object
+  std::string s2 = *s1;   // *s1 returns a reference to the internal std::string object
 }
 
 {
@@ -43,7 +43,7 @@ Now it's much easier to use `oatpp::String` since `oatpp::String` is now wrapper
 
 {
   oatpp::String s1 = nullptr;
-  std::string s2 = s1;   // implicit cast from null-value trows runtime_error 
+  std::string s2 = s1;   // implicit cast from null-value throws runtime_error 
 }
 
 {
@@ -248,6 +248,9 @@ void reloadCert() {
 }
 ```
 
+Additionally, resource invalidation is no longer supported by ConnectionProvider. 
+Please use either ResourceHandleTemplate::invalidate() or Invalidator::invalidate(resource) directly.
+
 ## Proper Server Stoppage
 
 Fix to [#476](https://github.com/oatpp/oatpp/issues/476), [#269](https://github.com/oatpp/oatpp/issues/269)
@@ -332,7 +335,7 @@ ENDPOINT("POST", "upload", upload,
 
 ## Response::getBody()
 
-`oatpp::web::protocol::http::outgoing::Response` has a new method `getBody()` to retreive the body of the response.
+`oatpp::web::protocol::http::outgoing::Response` has a new method `getBody()` to retrieve the body of the response.
 This is handy for response interceptors.
 
 
@@ -355,7 +358,7 @@ You need to implement your own locking.
 
 `FIFOStream` also introduced a new interface
 [`BufferedInputStream`](https://oatpp.io/api/latest/oatpp/core/data/stream/Stream/#bufferedinputstream) which unifies
-the bufferd-stream-interface all existing buffered streams (`InputStreamBufferedProxy`, `BufferInputStream`,
+the buffered-stream-interface all existing buffered streams (`InputStreamBufferedProxy`, `BufferInputStream`,
 `FIFOStream`) to allow for generalisation.
 
 ## oatpp::parser::json::mapping::Serializer::Config::alwaysIncludeRequired

--- a/src/oatpp/core/provider/Provider.hpp
+++ b/src/oatpp/core/provider/Provider.hpp
@@ -81,6 +81,13 @@ struct ResourceHandleTemplate {
     return object.operator bool();
   }
 
+  /**
+   * Invalidates the resource so it can be disposed and cannot be reused anymore.
+   */
+  virtual void invalidate() {
+    invalidator->invalidate(object);
+  }
+
 };
 
 /**


### PR DESCRIPTION
- Client code:
```
      m_socket->getConnection().invalidator->invalidate(m_socket->getConnection().object);
```
is simplified to:
```
      m_socket->getConnection().invalidate();
```
- Updated migration doc;
- Fixed typos.