### PR TITLE
Dto polymorphic fields

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,10 +82,12 @@ add_library(oatpp
         oatpp/core/data/mapping/TypeResolver.hpp
         oatpp/core/data/mapping/type/Any.cpp
         oatpp/core/data/mapping/type/Any.hpp
+        oatpp/core/data/mapping/type/Collection.hpp
         oatpp/core/data/mapping/type/Enum.cpp
         oatpp/core/data/mapping/type/Enum.hpp
         oatpp/core/data/mapping/type/List.cpp
         oatpp/core/data/mapping/type/List.hpp
+        oatpp/core/data/mapping/type/Map.hpp
         oatpp/core/data/mapping/type/PairList.cpp
         oatpp/core/data/mapping/type/PairList.hpp
         oatpp/core/data/mapping/type/Object.cpp

--- a/src/oatpp/codegen/dto/base_define.hpp
+++ b/src/oatpp/codegen/dto/base_define.hpp
@@ -84,7 +84,8 @@ static bool Z__PROPERTY_INIT_##NAME(... /* default initializer for all cases */)
 } \
 \
 static TYPE Z__PROPERTY_INITIALIZER_PROXY_##NAME() { \
-  static bool initialized = Z__PROPERTY_INIT_##NAME(1 /* init info if found */); \
+  static bool initialized = Z__PROPERTY_INIT_##NAME(1 /* init info if found */,           \
+                                                    1 /* init type selector if found */); \
   (void)initialized; \
   return TYPE(); \
 } \
@@ -114,7 +115,8 @@ static bool Z__PROPERTY_INIT_##NAME(... /* default initializer for all cases */)
 } \
 \
 static TYPE Z__PROPERTY_INITIALIZER_PROXY_##NAME() { \
-  static bool initialized = Z__PROPERTY_INIT_##NAME(1 /* init info if found */); \
+  static bool initialized = Z__PROPERTY_INIT_##NAME(1 /* init info if found */,           \
+                                                    1 /* init type selector if found */); \
   (void)initialized; \
   return TYPE(); \
 } \
@@ -134,13 +136,31 @@ OATPP_MACRO_EXPAND(OATPP_MACRO_MACRO_SELECTOR(OATPP_MACRO_DTO_FIELD_, (__VA_ARGS
 
 #define DTO_FIELD_INFO(NAME) \
 \
-static bool Z__PROPERTY_INIT_##NAME(int) { \
+static bool Z__PROPERTY_INIT_##NAME(int, ...) { \
   Z__PROPERTY_INIT_##NAME(); /* call first initialization */ \
   Z__PROPERTY_ADD_INFO_##NAME(&Z__PROPERTY_SINGLETON_##NAME()->info); \
   return true; \
 } \
 \
 static void Z__PROPERTY_ADD_INFO_##NAME(oatpp::data::mapping::type::BaseObject::Property::Info* info)
+
+
+#define DTO_FIELD_TYPE_SELECTOR(NAME) \
+\
+class Z__PROPERTY_TYPE_SELECTOR_##NAME : public oatpp::BaseObject::Property::TypeSelector { \
+public: \
+  const oatpp::Type* selectType(oatpp::BaseObject *self) override { \
+    return Z__PROPERTY_TYPE_SELECTOR_METHOD_##NAME(static_cast<Z__CLASS*>(self)); \
+  } \
+}; \
+\
+static bool Z__PROPERTY_INIT_##NAME(int, int) { \
+  Z__PROPERTY_INIT_##NAME(1); /* call property info initialization */ \
+  Z__PROPERTY_SINGLETON_##NAME()->info.typeSelector = new Z__PROPERTY_TYPE_SELECTOR_##NAME(); \
+  return true; \
+} \
+\
+static oatpp::Type* Z__PROPERTY_TYPE_SELECTOR_METHOD_##NAME(Z__CLASS* self)
 
 // FOR EACH
 

--- a/src/oatpp/codegen/dto/base_define.hpp
+++ b/src/oatpp/codegen/dto/base_define.hpp
@@ -147,10 +147,10 @@ static void Z__PROPERTY_ADD_INFO_##NAME(oatpp::data::mapping::type::BaseObject::
 
 #define DTO_FIELD_TYPE_SELECTOR(NAME) \
 \
-class Z__PROPERTY_TYPE_SELECTOR_##NAME : public oatpp::BaseObject::Property::TypeSelector { \
+class Z__PROPERTY_TYPE_SELECTOR_##NAME : public oatpp::BaseObject::Property::FieldTypeSelector<Z__CLASS> { \
 public: \
-  const oatpp::Type* selectType(oatpp::BaseObject *self) override { \
-    return Z__PROPERTY_TYPE_SELECTOR_METHOD_##NAME(static_cast<Z__CLASS*>(self)); \
+  const oatpp::Type* selectFieldType(Z__CLASS* self) override { \
+    return self->Z__PROPERTY_TYPE_SELECTOR_METHOD_##NAME(); \
   } \
 }; \
 \
@@ -160,7 +160,7 @@ static bool Z__PROPERTY_INIT_##NAME(int, int) { \
   return true; \
 } \
 \
-static oatpp::Type* Z__PROPERTY_TYPE_SELECTOR_METHOD_##NAME(Z__CLASS* self)
+const oatpp::Type* Z__PROPERTY_TYPE_SELECTOR_METHOD_##NAME()
 
 // FOR EACH
 

--- a/src/oatpp/codegen/dto/base_undef.hpp
+++ b/src/oatpp/codegen/dto/base_undef.hpp
@@ -36,6 +36,10 @@
 
 #undef DTO_FIELD_INFO
 
+// Type Selector
+
+#undef DTO_FIELD_TYPE_SELECTOR
+
 // Hashcode & Equals
 
 #undef OATPP_MACRO_DTO_HC_EQ_PARAM_HC

--- a/src/oatpp/core/Types.hpp
+++ b/src/oatpp/core/Types.hpp
@@ -187,7 +187,7 @@ namespace oatpp {
   /**
    * Abstract Fields
    */
-  typedef data::mapping::type::PairListObjectWrapper<oatpp::String, oatpp::Void, data::mapping::type::__class::AbstractPairList> AbstractFields;
+  typedef Fields<oatpp::Void> AbstractFields;
 
   /**
    * Mapping-Enabled UnorderedMap<Key, Value>. &id:oatpp::data::mapping::type::UnorderedMap;.
@@ -204,7 +204,7 @@ namespace oatpp {
   /**
    * Abstract UnorderedFields
    */
-  typedef data::mapping::type::UnorderedMapObjectWrapper<oatpp::String, oatpp::Void, data::mapping::type::__class::AbstractUnorderedMap> AbstractUnorderedFields;
+  typedef UnorderedFields<oatpp::Void> AbstractUnorderedFields;
   
 }
 

--- a/src/oatpp/core/Types.hpp
+++ b/src/oatpp/core/Types.hpp
@@ -40,6 +40,12 @@ namespace oatpp {
   typedef oatpp::data::mapping::type::ClassId ClassId;
 
   /**
+   * ObjectWrapper.
+   */
+  template <class T, class Clazz = oatpp::data::mapping::type::__class::Void>
+  using ObjectWrapper = oatpp::data::mapping::type::ObjectWrapper<T, Clazz>;
+
+  /**
    * ObjectWrapper over the `void*`.
    */
   typedef oatpp::data::mapping::type::Void Void;

--- a/src/oatpp/core/data/Bundle.hpp
+++ b/src/oatpp/core/data/Bundle.hpp
@@ -68,13 +68,13 @@ public:
                                "Error. Data not found for key '" + *key + "'.");
     }
 
-    if(it->second.getValueType() != WrapperType::Class::getType()) {
+    if(!WrapperType::Class::getType()->extends(it->second.getValueType())) {
       throw std::runtime_error("[oatpp::data::Bundle::get()]: Error. Type mismatch for key '" + *key +
                                "'. Stored '" +
                                std::string(it->second.getValueType()->classId.name) +
                                "' vs requested '" + std::string(WrapperType::Class::getType()->classId.name) + "'.");
     }
-    return it->second.template staticCast<WrapperType>();
+    return it->second.template cast<WrapperType>();
   }
 
   /**

--- a/src/oatpp/core/data/mapping/ObjectMapper.hpp
+++ b/src/oatpp/core/data/mapping/ObjectMapper.hpp
@@ -110,7 +110,7 @@ public:
   template<class Wrapper>
   Wrapper readFromCaret(oatpp::parser::Caret& caret) const {
     auto type = Wrapper::Class::getType();
-    return read(caret, type).template staticCast<Wrapper>();
+    return read(caret, type).template cast<Wrapper>();
   }
 
   /**
@@ -125,7 +125,7 @@ public:
   Wrapper readFromString(const oatpp::String& str) const {
     auto type = Wrapper::Class::getType();
     oatpp::parser::Caret caret(str);
-    auto result = read(caret, type).template staticCast<Wrapper>();
+    auto result = read(caret, type).template cast<Wrapper>();
     if(!result) {
       throw oatpp::parser::ParsingError(caret.getErrorMessage(), caret.getErrorCode(), caret.getPosition());
     }

--- a/src/oatpp/core/data/mapping/TypeResolver.cpp
+++ b/src/oatpp/core/data/mapping/TypeResolver.cpp
@@ -65,11 +65,10 @@ TypeResolver::TypeResolver() {
 
 void TypeResolver::setKnownClass(const type::ClassId& classId, bool isKnown) {
   const v_uint32 id = classId.id;
-  if(id < m_knownClasses.size()) {
-    m_knownClasses[id] = isKnown;
-  } else {
-    throw std::runtime_error("[oatpp::data::mapping::TypeResolver::setKnownClass()]: Error. Unknown classId");
+  if(id >= m_knownClasses.size()) {
+    m_knownClasses.resize(id + 1, false);
   }
+  m_knownClasses[id] = isKnown;
 }
 
 void TypeResolver::addKnownClasses(const std::vector<type::ClassId>& knownClasses) {

--- a/src/oatpp/core/data/mapping/type/Any.cpp
+++ b/src/oatpp/core/data/mapping/type/Any.cpp
@@ -39,7 +39,7 @@ Any::Any(std::nullptr_t) : Any() {}
 Any::Any(const std::shared_ptr<AnyHandle>& handle, const Type* const type)
   : ObjectWrapper(handle, __class::Any::getType())
 {
-  // As an ObjectWrapper, Any must have this constructor. It is used in ObjectWrapper.staticCast<T>(...) method.
+  // As an ObjectWrapper, Any must have this constructor. It is used in ObjectWrapper.cast<T>(...) method.
   // However, unlike other ObjectWrappers Any won't change its valueType.
   // Any is always object wrapper above AnyHandler.
   (void)type;

--- a/src/oatpp/core/data/mapping/type/Any.cpp
+++ b/src/oatpp/core/data/mapping/type/Any.cpp
@@ -63,6 +63,16 @@ const Type* Any::getStoredType() const {
   return nullptr;
 }
 
+Void Any::retrieve(const Type* type) const {
+  if(m_ptr) {
+    if(!m_ptr->type->extends(type)) {
+      throw std::runtime_error("[oatpp::data::mapping::type::Any::retrieve()]: Error. The value type doesn't match.");
+    }
+    return Void(m_ptr->ptr, type);
+  }
+  return nullptr;
+}
+
 Any& Any::operator=(std::nullptr_t) {
   m_ptr.reset();
   return *this;

--- a/src/oatpp/core/data/mapping/type/Any.hpp
+++ b/src/oatpp/core/data/mapping/type/Any.hpp
@@ -126,6 +126,14 @@ public:
   const Type* getStoredType() const;
 
   /**
+   * Retrieve stored object of type `type`.
+   * @param type - &id:oatpp::Type;
+   * @return - &id:oatpp::Void;.
+   * @throws - `std::runtime_error` - if stored type and type requested do not match.
+   */
+  Void retrieve(const Type* type) const;
+
+  /**
    * Retrieve stored object.
    * @tparam WrapperType - type of the object to retrieve.
    * @return - ObjectWrapper of type - `WrapperType`.
@@ -133,19 +141,8 @@ public:
    */
   template<class WrapperType>
   WrapperType retrieve() const {
-
-    if(m_ptr) {
-
-      if(!m_ptr->type->extends(WrapperType::Class::getType())) {
-        throw std::runtime_error("[oatpp::data::mapping::type::Any::retrieve()]: Error. The value type doesn't match.");
-      }
-
-      return WrapperType(std::static_pointer_cast<typename WrapperType::ObjectType>(m_ptr->ptr), m_ptr->type);
-
-    }
-
-    return nullptr;
-
+    const auto& v = retrieve(WrapperType::Class::getType());
+    return WrapperType(std::static_pointer_cast<typename WrapperType::ObjectType>(v.getPtr()), WrapperType::Class::getType());
   }
 
   Any& operator=(std::nullptr_t);

--- a/src/oatpp/core/data/mapping/type/Collection.hpp
+++ b/src/oatpp/core/data/mapping/type/Collection.hpp
@@ -178,7 +178,7 @@ public:
 template<class ItemType>
 struct Collection::Inserter<std::unordered_set<ItemType>, ItemType> {
   static void insert(std::unordered_set<ItemType>* c, const ItemType& i) {
-    c->template emplace(i);
+    c->emplace(i);
   }
 };
 

--- a/src/oatpp/core/data/mapping/type/Collection.hpp
+++ b/src/oatpp/core/data/mapping/type/Collection.hpp
@@ -1,0 +1,189 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#ifndef oatpp_data_mapping_type_Collection_hpp
+#define oatpp_data_mapping_type_Collection_hpp
+
+#include "./Type.hpp"
+#include <unordered_set>
+
+namespace oatpp { namespace data { namespace mapping { namespace type {
+
+namespace __class {
+
+/**
+ * Abstract Collection. <br>
+ * Ex.: Vector, List, Set.
+ */
+class Collection {
+public:
+
+  /**
+   * Iterator.
+   */
+  struct Iterator {
+
+    /**
+     * Default virtual destructor.
+     */
+    virtual ~Iterator() = default;
+
+    /**
+     * Get current item.
+     * @return
+     */
+    virtual type::Void get() = 0;
+
+    /**
+     * Iterate to next item.
+     */
+    virtual void next() = 0;
+
+    /**
+     * Check if iterator finished.
+     * @return
+     */
+    virtual bool finished() = 0;
+
+  };
+
+public:
+
+  /**
+   * Polymorphic Dispatcher
+   */
+  class PolymorphicDispatcher {
+  public:
+
+    /**
+     * Virtual destructor.
+     */
+    virtual ~PolymorphicDispatcher() = default;
+
+    /**
+     * Create Collection.
+     * @return
+     */
+    virtual type::Void createObject() const = 0;
+
+    /**
+     * Get type of collection items.
+     * @return
+     */
+    virtual const type::Type* getItemType() const = 0;
+
+    /**
+     * Add item.
+     * @param object - Collection.
+     * @param item - Item to add.
+     */
+    virtual void addItem(const type::Void& object, const type::Void& item) const = 0;
+
+    /**
+     * Begin collection iteration.
+     * @param object - Collection.
+     * @return
+     */
+    virtual std::unique_ptr<Iterator> beginIteration(const type::Void& object) const = 0;
+
+  };
+
+  template<class ContainerType, class ItemType>
+  struct Inserter {
+
+    static void insert(ContainerType* c, const ItemType& i) {
+      c->emplace_back(i);
+    }
+
+  };
+
+};
+
+template<class ContainerType, class ItemType, class Clazz>
+class StandardCollection {
+public:
+
+  struct Iterator : public Collection::Iterator {
+
+    typename ContainerType::iterator iterator;
+    typename ContainerType::iterator end;
+
+    type::Void get() override {
+      return *iterator;
+    }
+
+    void next() override {
+      std::advance(iterator, 1);
+    }
+
+    bool finished() override {
+      return iterator == end;
+    }
+
+  };
+
+public:
+
+  class PolymorphicDispatcher : public Collection::PolymorphicDispatcher {
+  public:
+
+    type::Void createObject() const override {
+      return type::Void(std::make_shared<ContainerType>(), Clazz::getType());
+    }
+
+    const type::Type* getItemType() const override {
+      const type::Type* collectionType = Clazz::getType();
+      return collectionType->params[0];
+    }
+
+    void addItem(const type::Void& object, const type::Void& item) const override {
+      ContainerType* collection = static_cast<ContainerType*>(object.get());
+      const auto& collectionItem = item.template cast<ItemType>();
+      Collection::Inserter<ContainerType, ItemType>::insert(collection, collectionItem);
+    }
+
+    std::unique_ptr<Collection::Iterator> beginIteration(const type::Void& object) const override {
+      ContainerType* collection = static_cast<ContainerType*>(object.get());
+      auto iterator = new Iterator();
+      iterator->iterator = collection->begin();
+      iterator->end = collection->end();
+      return std::unique_ptr<Collection::Iterator>(iterator);
+    }
+
+  };
+
+};
+
+template<class ItemType>
+struct Collection::Inserter<std::unordered_set<ItemType>, ItemType> {
+  static void insert(std::unordered_set<ItemType>* c, const ItemType& i) {
+    c->template emplace(i);
+  }
+};
+
+}
+
+}}}}
+
+#endif //oatpp_data_mapping_type_Collection_hpp

--- a/src/oatpp/core/data/mapping/type/Enum.hpp
+++ b/src/oatpp/core/data/mapping/type/Enum.hpp
@@ -472,7 +472,7 @@ Void EnumInterpreterAsString<T, notnull>::toInterpretation(const Void& enumValue
     return Void(nullptr, String::Class::getType());
   }
 
-  const auto& ow = enumValue.staticCast<EnumOW>();
+  const auto& ow = enumValue.template cast<EnumOW>();
   const auto& entry = EnumOW::getEntryByValue(*ow);
   return entry.name.toString();
 }
@@ -495,7 +495,7 @@ Void EnumInterpreterAsString<T, notnull>::fromInterpretation(const Void& interVa
   }
 
   try {
-    const auto &entry = EnumOW::getEntryByName(interValue.staticCast<String>());
+    const auto &entry = EnumOW::getEntryByName(interValue.template cast<String>());
     return EnumOW(entry.value);
   } catch (const std::runtime_error&) { // TODO - add a specific error for this.
     error = EnumInterpreterError::ENTRY_NOT_FOUND;
@@ -528,7 +528,7 @@ Void EnumInterpreterAsNumber<T, notnull>::toInterpretation(const Void& enumValue
     return Void(nullptr, UTOW::Class::getType());
   }
 
-  const auto& ow = enumValue.staticCast<EnumOW>();
+  const auto& ow = enumValue.template cast<EnumOW>();
   return UTOW(static_cast<EnumUT>(*ow));
 
 }
@@ -555,7 +555,7 @@ Void EnumInterpreterAsNumber<T, notnull>::fromInterpretation(const Void& interVa
 
   try{
     const auto& entry = EnumOW::getEntryByUnderlyingValue(
-      interValue.staticCast<OW>()
+      interValue.template cast<OW>()
     );
     return EnumOW(entry.value);
   } catch (const std::runtime_error&) { // TODO - add a specific error for this.

--- a/src/oatpp/core/data/mapping/type/Enum.hpp
+++ b/src/oatpp/core/data/mapping/type/Enum.hpp
@@ -280,7 +280,7 @@ public:
    */
   template<class OtherInter>
   EnumObjectWrapper(const EnumObjectWrapper<T, OtherInter>& other)
-    : type::ObjectWrapper<T, EnumObjectClass>(other.getPtr())
+    : type::ObjectWrapper<T, EnumObjectClass>(other.m_ptr)
   {}
 
   /**
@@ -290,7 +290,7 @@ public:
    */
   template<class OtherInter>
   EnumObjectWrapper(EnumObjectWrapper<T, OtherInter>&& other)
-    : type::ObjectWrapper<T, EnumObjectClass>(std::move(other.getPtr()))
+    : type::ObjectWrapper<T, EnumObjectClass>(std::move(other.m_ptr))
   {}
 
   inline EnumObjectWrapper& operator = (std::nullptr_t) {
@@ -306,7 +306,7 @@ public:
 
   template<class OtherInter>
   inline EnumObjectWrapper& operator = (EnumObjectWrapper<T, OtherInter>&& other) {
-    this->m_ptr = std::forward<std::shared_ptr<T>>(other.m_ptr);
+    this->m_ptr = std::move(other.m_ptr);
     return *this;
   }
 

--- a/src/oatpp/core/data/mapping/type/List.hpp
+++ b/src/oatpp/core/data/mapping/type/List.hpp
@@ -25,6 +25,7 @@
 #ifndef oatpp_data_mapping_type_List_hpp
 #define oatpp_data_mapping_type_List_hpp
 
+#include "./Collection.hpp"
 #include "./Type.hpp"
 
 #include <list>
@@ -39,29 +40,11 @@ namespace __class {
    */
   class AbstractList {
   public:
+
     /**
      * Class Id.
      */
     static const ClassId CLASS_ID;
-  public:
-
-    /**
-     * Polymorphic Dispatcher
-     */
-    class PolymorphicDispatcher {
-    public:
-
-      virtual ~PolymorphicDispatcher() = default;
-
-      virtual type::Void createObject() const = 0;
-
-      /**
-       * Add item.
-       * @param object - List to add item to.
-       * @param item - Item to add.
-       */
-      virtual void addPolymorphicItem(const type::Void& object, const type::Void& item) const = 0;
-    };
 
   };
 
@@ -115,35 +98,19 @@ public:
 template<class T>
 using List = ListObjectWrapper<T, __class::List<T>>;
 
-typedef ListObjectWrapper<type::Void, __class::AbstractList> AbstractList;
+typedef List<Void> AbstractList;
 
 namespace __class {
 
   template<class T>
   class List : public AbstractList {
-  public:
-
-    class PolymorphicDispatcher : public AbstractList::PolymorphicDispatcher {
-    public:
-
-      type::Void createObject() const override {
-        return type::Void(std::make_shared<std::list<T>>(), getType());
-      }
-
-      void addPolymorphicItem(const type::Void& object, const type::Void& item) const override {
-        const auto& list = object.staticCast<type::List<T>>();
-        const auto& listItem = item.staticCast<T>();
-        list->push_back(listItem);
-      }
-
-    };
-
   private:
 
     static Type createType() {
       Type::Info info;
       info.params.push_back(T::Class::getType());
-      info.polymorphicDispatcher = new PolymorphicDispatcher();
+      info.polymorphicDispatcher = new typename StandardCollection<std::list<T>, T, List>::PolymorphicDispatcher();
+      info.isCollection = true;
       return Type(__class::AbstractList::CLASS_ID, info);
     }
 

--- a/src/oatpp/core/data/mapping/type/Map.hpp
+++ b/src/oatpp/core/data/mapping/type/Map.hpp
@@ -1,0 +1,212 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#ifndef oatpp_data_mapping_type_Map_hpp
+#define oatpp_data_mapping_type_Map_hpp
+
+#include "./Type.hpp"
+#include <list>
+
+namespace oatpp { namespace data { namespace mapping { namespace type {
+
+namespace __class {
+
+/**
+ * Abstract Map. <br>
+ * Ex.: UnorderedMap, Fields.
+ */
+class Map {
+public:
+
+  /**
+   * Iterator.
+   */
+  struct Iterator {
+
+    /**
+     * Default virtual destructor.
+     */
+    virtual ~Iterator() = default;
+
+    /**
+     * Get current item key.
+     * @return
+     */
+    virtual type::Void getKey() = 0;
+
+    /**
+     * Get current item value.
+     * @return
+     */
+    virtual type::Void getValue() = 0;
+
+    /**
+     * Iterate to next item.
+     */
+    virtual void next() = 0;
+
+    /**
+     * Check if iterator finished.
+     * @return
+     */
+    virtual bool finished() = 0;
+
+  };
+
+public:
+
+  /**
+   * Polymorphic Dispatcher
+   */
+  class PolymorphicDispatcher {
+  public:
+
+    /**
+     * Virtual destructor.
+     */
+    virtual ~PolymorphicDispatcher() = default;
+
+    /**
+     * Create Map.
+     * @return
+     */
+    virtual type::Void createObject() const = 0;
+
+    /**
+     * Get type of map keys.
+     * @return
+     */
+    virtual const type::Type* getKeyType() const = 0;
+
+    /**
+     * Get type of map values.
+     * @return
+     */
+    virtual const type::Type* getValueType() const = 0;
+
+    /**
+     * Add item.
+     * @param object - Map.
+     * @param key
+     * @param value
+     */
+    virtual void addItem(const type::Void& object, const type::Void& key, const type::Void& value) const = 0;
+
+    /**
+     * Begin map iteration.
+     * @param object - Map.
+     * @return
+     */
+    virtual std::unique_ptr<Iterator> beginIteration(const type::Void& object) const = 0;
+
+  };
+
+  template<class ContainerType, class KeyType, class ValueType>
+  struct Inserter {
+
+    static void insert(ContainerType* c, const KeyType& k, const ValueType& v) {
+      (*c)[k] = v;
+    }
+
+  };
+
+};
+
+template<class ContainerType, class KeyType, class ValueType, class Clazz>
+class StandardMap {
+public:
+
+  struct Iterator : public Map::Iterator {
+
+    typename ContainerType::iterator iterator;
+    typename ContainerType::iterator end;
+
+    type::Void getKey() override {
+      return iterator->first;
+    }
+
+    type::Void getValue() override {
+      return iterator->second;
+    }
+
+    void next() override {
+      std::advance(iterator, 1);
+    }
+
+    bool finished() override {
+      return iterator == end;
+    }
+
+  };
+
+public:
+
+  class PolymorphicDispatcher : public Map::PolymorphicDispatcher {
+  public:
+
+    type::Void createObject() const override {
+      return type::Void(std::make_shared<ContainerType>(), Clazz::getType());
+    }
+
+    const type::Type* getKeyType() const override {
+      const type::Type* mapType = Clazz::getType();
+      return mapType->params[0];
+    }
+
+    const type::Type* getValueType() const override {
+      const type::Type* mapType = Clazz::getType();
+      return mapType->params[1];
+    }
+
+    void addItem(const type::Void& object, const type::Void& key, const type::Void& value) const override {
+      ContainerType* map = static_cast<ContainerType*>(object.get());
+      const auto& mapKey = key.template cast<KeyType>();
+      const auto& mapValue = value.template cast<ValueType>();
+      Map::Inserter<ContainerType, KeyType, ValueType>::insert(map, mapKey, mapValue);
+    }
+
+    std::unique_ptr<Map::Iterator> beginIteration(const type::Void& object) const override {
+      ContainerType* map = static_cast<ContainerType*>(object.get());
+      auto iterator = new Iterator();
+      iterator->iterator = map->begin();
+      iterator->end = map->end();
+      return std::unique_ptr<Map::Iterator>(iterator);
+    }
+
+  };
+
+};
+
+template<class KeyType, class ValueType>
+struct Map::Inserter<std::list<std::pair<KeyType, ValueType>>, KeyType, ValueType> {
+  static void insert(std::list<std::pair<KeyType, ValueType>>* c, const KeyType& k, const ValueType& v) {
+    c->push_back({k, v});
+  }
+};
+
+}
+
+}}}}
+
+#endif //oatpp_data_mapping_type_Map_hpp

--- a/src/oatpp/core/data/mapping/type/Object.hpp
+++ b/src/oatpp/core/data/mapping/type/Object.hpp
@@ -62,11 +62,28 @@ public:
     public:
 
       /**
+       * Default destructor.
+       */
+      virtual ~TypeSelector() = default;
+
+      /**
        * Select property type.
        * @param self - pointer to `this` object.
        * @return - &id:oatpp::Type;.
        */
       virtual const type::Type* selectType(BaseObject* self) = 0;
+    };
+
+    template<class DTOType>
+    class FieldTypeSelector : public TypeSelector {
+    public:
+
+      const type::Type* selectType(BaseObject* self) override {
+        return selectFieldType(static_cast<DTOType*>(self));
+      }
+
+      virtual const type::Type* selectFieldType(DTOType* self) = 0;
+
     };
 
   public:

--- a/src/oatpp/core/data/mapping/type/Object.hpp
+++ b/src/oatpp/core/data/mapping/type/Object.hpp
@@ -56,15 +56,47 @@ public:
   public:
 
     /**
+     * Property Type Selector.
+     */
+    class TypeSelector {
+    public:
+
+      /**
+       * Select property type.
+       * @param self - pointer to `this` object.
+       * @return - &id:oatpp::Type;.
+       */
+      virtual const type::Type* selectType(BaseObject* self) = 0;
+    };
+
+  public:
+
+    /**
      * Editional Info about Property.
      */
     struct Info {
+
       /**
        * Description.
        */
       std::string description = "";
+
+      /**
+       * Pattern.
+       */
       std::string pattern = "";
+
+      /**
+       * Required.
+       */
       bool required = false;
+
+      /**
+       * Type selector.
+       * &l:Property::TypeSelector;.
+       */
+      TypeSelector* typeSelector = nullptr;
+
     };
 
   private:
@@ -271,6 +303,8 @@ namespace __class {
  */
 template<class ObjT>
 class DTOWrapper : public ObjectWrapper<ObjT, __class::Object<ObjT>> {
+  template<class Type>
+  friend class DTOWrapper;
 public:
   typedef ObjT TemplateObjectType;
   typedef __class::Object<ObjT> TemplateObjectClass;
@@ -278,8 +312,30 @@ public:
 
   OATPP_DEFINE_OBJECT_WRAPPER_DEFAULTS(DTOWrapper, TemplateObjectType, TemplateObjectClass)
 
+  template<class OtherT>
+  DTOWrapper(const OtherT& other)
+    : type::ObjectWrapper<ObjT, __class::Object<ObjT>>(other.m_ptr)
+  {}
+
+  template<class OtherT>
+  DTOWrapper(OtherT&& other)
+    : type::ObjectWrapper<ObjT, __class::Object<ObjT>>(std::move(other.m_ptr))
+  {}
+
   static DTOWrapper createShared() {
     return std::make_shared<TemplateObjectType>();
+  }
+
+  template<class T>
+  DTOWrapper& operator = (const DTOWrapper<T>& other) {
+    this->m_ptr = other.m_ptr;
+    return *this;
+  }
+
+  template<class T>
+  DTOWrapper& operator = (DTOWrapper<T>&& other) {
+    this->m_ptr = std::move(other.m_ptr);
+    return *this;
   }
 
   template<typename T,
@@ -310,6 +366,31 @@ public:
   >
   inline bool operator != (const T &other) const {
     return !operator == (other);
+  }
+
+  static const std::unordered_map<std::string, BaseObject::Property*>& getPropertiesMap() {
+    auto dispatcher = static_cast<const __class::AbstractObject::PolymorphicDispatcher*>(
+      __class::Object<ObjT>::getType()->polymorphicDispatcher
+    );
+    return dispatcher->getProperties()->getMap();
+  }
+
+  static const std::list<BaseObject::Property*>& getPropertiesList() {
+    auto dispatcher = static_cast<const __class::AbstractObject::PolymorphicDispatcher*>(
+      __class::Object<ObjT>::getType()->polymorphicDispatcher
+    );
+    return dispatcher->getProperties()->getList();
+  }
+
+  static v_int64 getPropertiesCount() {
+    auto dispatcher = static_cast<const __class::AbstractObject::PolymorphicDispatcher*>(
+      __class::Object<ObjT>::getType()->polymorphicDispatcher
+    );
+    return dispatcher->getProperties()->getList().size();
+  }
+
+  ObjectWrapper<void>& operator[](const std::string& propertyName) {
+    return getPropertiesMap().at(propertyName)->getAsRef(this->m_ptr.get());
   }
 
 };

--- a/src/oatpp/core/data/mapping/type/PairList.hpp
+++ b/src/oatpp/core/data/mapping/type/PairList.hpp
@@ -25,6 +25,7 @@
 #ifndef oatpp_data_mapping_type_PairList_hpp
 #define oatpp_data_mapping_type_PairList_hpp
 
+#include "./Map.hpp"
 #include "./Type.hpp"
 
 #include <list>
@@ -44,27 +45,6 @@ namespace __class {
      * Class id.
      */
     static const ClassId CLASS_ID;
-  public:
-
-    /**
-     * Polymorphic Dispatcher.
-     */
-    class PolymorphicDispatcher {
-    public:
-
-      virtual ~PolymorphicDispatcher() = default;
-
-      virtual type::Void createObject() const = 0;
-
-      /**
-       * Add key-value pair to pair-list.
-       * @param object - pair list.
-       * @param key - key.
-       * @param value - value.
-       */
-      virtual void addPolymorphicItem(const type::Void& object, const type::Void& key, const type::Void& value) const = 0;
-    };
-
   };
 
   template<class Key, class Value>
@@ -147,31 +127,15 @@ namespace __class {
 
 template<class Key, class Value>
 class PairList : public AbstractPairList {
-public:
-
-  class PolymorphicDispatcher : public AbstractPairList::PolymorphicDispatcher {
-  public:
-
-    type::Void createObject() const override {
-      return type::Void(std::make_shared<std::list<std::pair<Key, Value>>>(), getType());
-    }
-
-    void addPolymorphicItem(const type::Void& object, const type::Void& key, const type::Void& value) const override {
-      const auto& map = object.staticCast<type::PairList<Key, Value>>();
-      const auto& k = key.staticCast<Key>();
-      const auto& v = value.staticCast<Value>();
-      map->push_back({k, v});
-    }
-
-  };
-
 private:
 
   static Type createType() {
     Type::Info info;
     info.params.push_back(Key::Class::getType());
     info.params.push_back(Value::Class::getType());
-    info.polymorphicDispatcher = new PolymorphicDispatcher();
+    info.polymorphicDispatcher = info.polymorphicDispatcher =
+      new typename __class::StandardMap<std::list<std::pair<Key, Value>>, Key, Value, PairList>::PolymorphicDispatcher();
+    info.isMap = true;
     return Type(__class::AbstractPairList::CLASS_ID, info);
   }
 

--- a/src/oatpp/core/data/mapping/type/Type.cpp
+++ b/src/oatpp/core/data/mapping/type/Type.cpp
@@ -81,6 +81,8 @@ Type::Type(const ClassId& pClassId, const Info& typeInfo)
   , polymorphicDispatcher(typeInfo.polymorphicDispatcher)
   , interpretationMap(typeInfo.interpretationMap)
   , parent(typeInfo.parent)
+  , isCollection(typeInfo.isCollection)
+  , isMap(typeInfo.isMap)
 {}
 
 const Type::AbstractInterpretation* Type::findInterpretation(const std::vector<std::string>& names) const {

--- a/src/oatpp/core/data/mapping/type/UnorderedMap.hpp
+++ b/src/oatpp/core/data/mapping/type/UnorderedMap.hpp
@@ -25,6 +25,7 @@
 #ifndef oatpp_data_mapping_type_UnorderedMap_hpp
 #define oatpp_data_mapping_type_UnorderedMap_hpp
 
+#include "./Map.hpp"
 #include "./Type.hpp"
 
 #include <unordered_map>
@@ -44,27 +45,6 @@ namespace __class {
      * Class Id.
      */
     static const ClassId CLASS_ID;
-  public:
-
-    /**
-     * Polymorphic Dispatcher.
-     */
-    class PolymorphicDispatcher {
-    public:
-      
-      virtual ~PolymorphicDispatcher() = default;
-
-      virtual type::Void createObject() const = 0;
-
-      /**
-       * Add item.
-       * @param object - Unordered Map.
-       * @param key - Key.
-       * @param value - Value.
-       */
-      virtual void addPolymorphicItem(const type::Void& object, const type::Void& key, const type::Void& value) const = 0;
-    };
-
   };
 
   template<class Key, class Value>
@@ -120,31 +100,15 @@ namespace __class {
 
   template<class Key, class Value>
   class UnorderedMap : public AbstractUnorderedMap {
-  public:
-
-    class PolymorphicDispatcher : public AbstractUnorderedMap::PolymorphicDispatcher {
-    public:
-
-      type::Void createObject() const override {
-        return type::Void(std::make_shared<std::unordered_map<Key, Value>>(), getType());
-      }
-
-      void addPolymorphicItem(const type::Void& object, const type::Void& key, const type::Void& value) const override {
-        const auto& map = object.staticCast<type::UnorderedMap<Key, Value>>();
-        const auto& k = key.staticCast<Key>();
-        const auto& v = value.staticCast<Value>();
-        map[k] = v;
-      }
-
-    };
-
   private:
 
     static Type createType() {
       Type::Info info;
       info.params.push_back(Key::Class::getType());
       info.params.push_back(Value::Class::getType());
-      info.polymorphicDispatcher = new PolymorphicDispatcher();
+      info.polymorphicDispatcher =
+        new typename __class::StandardMap<std::unordered_map<Key, Value>, Key, Value, UnorderedMap>::PolymorphicDispatcher();
+      info.isMap = true;
       return Type(__class::AbstractUnorderedMap::CLASS_ID, info);
     }
 

--- a/src/oatpp/core/data/mapping/type/UnorderedSet.hpp
+++ b/src/oatpp/core/data/mapping/type/UnorderedSet.hpp
@@ -25,6 +25,7 @@
 #ifndef oatpp_data_mapping_type_UnorderedSet_hpp
 #define oatpp_data_mapping_type_UnorderedSet_hpp
 
+#include "./Collection.hpp"
 #include "./Type.hpp"
 
 #include <unordered_set>
@@ -43,26 +44,6 @@ namespace __class {
      * Class Id.
      */
     static const ClassId CLASS_ID;
-  public:
-
-    /**
-     * Polymorphic Dispatcher.
-     */
-    class PolymorphicDispatcher {
-    public:
-
-      virtual ~PolymorphicDispatcher() = default;
-
-      virtual type::Void createObject() const = 0;
-
-      /**
-       * Add Item.
-       * @param object - UnorderedSet.
-       * @param item - Item.
-       */
-      virtual void addPolymorphicItem(const type::Void& object, const type::Void& item) const = 0;
-    };
-
   };
 
   template<class T>
@@ -117,35 +98,19 @@ public:
 template<class T>
 using UnorderedSet = UnorderedSetObjectWrapper<T, __class::UnorderedSet<T>>;
 
-typedef UnorderedSetObjectWrapper<type::Void, __class::AbstractUnorderedSet> AbstractUnorderedSet;
+typedef UnorderedSet<Void> AbstractUnorderedSet;
 
 namespace __class {
 
 template<class T>
 class UnorderedSet : public AbstractUnorderedSet {
-public:
-
-  class PolymorphicDispatcher : public AbstractUnorderedSet::PolymorphicDispatcher {
-  public:
-
-    type::Void createObject() const override {
-      return type::Void(std::make_shared<std::unordered_set<T>>(), getType());
-    }
-
-    void addPolymorphicItem(const type::Void& object, const type::Void& item) const override {
-      const auto& set = object.staticCast<type::UnorderedSet<T>>();
-      const auto& setItem = item.staticCast<T>();
-      set->insert(setItem);
-    }
-
-  };
-
 private:
 
   static Type createType() {
     Type::Info info;
     info.params.push_back(T::Class::getType());
-    info.polymorphicDispatcher = new PolymorphicDispatcher();
+    info.polymorphicDispatcher = new typename StandardCollection<std::unordered_set<T>, T, UnorderedSet>::PolymorphicDispatcher();
+    info.isCollection = true;
     return Type(__class::AbstractUnorderedSet::CLASS_ID, info);
   }
 

--- a/src/oatpp/core/data/mapping/type/Vector.hpp
+++ b/src/oatpp/core/data/mapping/type/Vector.hpp
@@ -25,6 +25,7 @@
 #ifndef oatpp_data_mapping_type_Vector_hpp
 #define oatpp_data_mapping_type_Vector_hpp
 
+#include "./Collection.hpp"
 #include "./Type.hpp"
 
 #include <vector>
@@ -43,26 +44,6 @@ namespace __class {
      * Class Id.
      */
     static const ClassId CLASS_ID;
-  public:
-
-    /**
-     * Polymorphic Dispatcher.
-     */
-    class PolymorphicDispatcher {
-    public:
-
-      virtual ~PolymorphicDispatcher() = default;
-
-      virtual type::Void createObject() const = 0;
-
-      /**
-       * Add Item.
-       * @param object - Vector.
-       * @param item - Item to add.
-       */
-      virtual void addPolymorphicItem(const type::Void& object, const type::Void& item) const = 0;
-    };
-
   };
 
   template<class T>
@@ -113,35 +94,19 @@ public:
 template<class T>
 using Vector = VectorObjectWrapper<T, __class::Vector<T>>;
 
-typedef VectorObjectWrapper<type::Void, __class::AbstractVector> AbstractVector;
+typedef Vector<Void> AbstractVector;
 
 namespace __class {
 
   template<class T>
   class Vector : public AbstractVector {
-  public:
-
-    class PolymorphicDispatcher : public AbstractVector::PolymorphicDispatcher {
-    public:
-
-      type::Void createObject() const override {
-        return type::Void(std::make_shared<std::vector<T>>(), getType());
-      }
-
-      void addPolymorphicItem(const type::Void& object, const type::Void& item) const override {
-        const auto& vector = object.staticCast<type::Vector<T>>();
-        const auto& vectorItem = item.staticCast<T>();
-        vector->push_back(vectorItem);
-      }
-
-    };
-
   private:
 
     static Type createType() {
       Type::Info info;
       info.params.push_back(T::Class::getType());
-      info.polymorphicDispatcher = new PolymorphicDispatcher();
+      info.polymorphicDispatcher = new typename StandardCollection<std::vector<T>, T, Vector>::PolymorphicDispatcher();
+      info.isCollection = true;
       return Type(__class::AbstractVector::CLASS_ID, info);
     }
 

--- a/src/oatpp/orm/QueryResult.hpp
+++ b/src/oatpp/orm/QueryResult.hpp
@@ -94,7 +94,7 @@ public:
    */
   template<class Wrapper>
   Wrapper fetch(v_int64 count = -1) {
-    return fetch(Wrapper::Class::getType(), count).template staticCast<Wrapper>();
+    return fetch(Wrapper::Class::getType(), count).template cast<Wrapper>();
   }
 
 };

--- a/src/oatpp/parser/json/mapping/Deserializer.cpp
+++ b/src/oatpp/parser/json/mapping/Deserializer.cpp
@@ -432,7 +432,7 @@ oatpp::Void Deserializer::deserializeObject(Deserializer* deserializer, parser::
 
         auto field = fieldIterator->second;
 
-        if(field->info.typeSelector) {
+        if(field->info.typeSelector && field->type == oatpp::Any::Class::getType()) {
           auto label = caret.putLabel();
           skipValue(caret);
           polymorphs.emplace_back(field, label.toString()); // store polymorphs for later processing.
@@ -469,7 +469,8 @@ oatpp::Void Deserializer::deserializeObject(Deserializer* deserializer, parser::
       parser::Caret polyCaret(p.second);
       auto selectedType = p.first->info.typeSelector->selectType(static_cast<oatpp::BaseObject *>(object.get()));
       auto value = deserializer->deserialize(polyCaret, selectedType);
-      p.first->set(static_cast<oatpp::BaseObject *>(object.get()), oatpp::Void(value.getPtr(), p.first->type));
+      oatpp::Any any(value);
+      p.first->set(static_cast<oatpp::BaseObject *>(object.get()), oatpp::Void(any.getPtr(), p.first->type));
     }
 
     return object;

--- a/src/oatpp/parser/json/mapping/Deserializer.hpp
+++ b/src/oatpp/parser/json/mapping/Deserializer.hpp
@@ -164,53 +164,6 @@ private:
   }
 
   template<class Collection>
-  static oatpp::Void deserializeList(Deserializer* deserializer, parser::Caret& caret, const Type* const type) {
-
-    if(caret.isAtText("null", true)){
-      return oatpp::Void(type);
-    }
-
-    if(caret.canContinueAtChar('[', 1)) {
-
-      auto polymorphicDispatcher = static_cast<const typename Collection::Class::PolymorphicDispatcher*>(type->polymorphicDispatcher);
-      auto listWrapper = polymorphicDispatcher->createObject();
-      const auto& list = listWrapper.template staticCast<Collection>();
-
-      auto itemType = *type->params.begin();
-
-      caret.skipBlankChars();
-
-      while(!caret.isAtChar(']') && caret.canContinue()){
-
-        caret.skipBlankChars();
-        auto item = deserializer->deserialize(caret, itemType);
-        if(caret.hasError()){
-          return nullptr;
-        }
-
-        polymorphicDispatcher->addPolymorphicItem(listWrapper, item);
-        caret.skipBlankChars();
-
-        caret.canContinueAtChar(',', 1);
-
-      }
-
-      if(!caret.canContinueAtChar(']', 1)){
-        if(!caret.hasError()){
-          caret.setError("[oatpp::parser::json::mapping::Deserializer::deserializeList()]: Error. ']' - expected", ERROR_CODE_ARRAY_SCOPE_CLOSE);
-        }
-        return nullptr;
-      };
-
-      return oatpp::Void(list.getPtr(), list.getValueType());
-    } else {
-      caret.setError("[oatpp::parser::json::mapping::Deserializer::deserializeList()]: Error. '[' - expected", ERROR_CODE_ARRAY_SCOPE_OPEN);
-      return nullptr;
-    }
-
-  }
-
-  template<class Collection>
   static oatpp::Void deserializeKeyValue(Deserializer* deserializer, parser::Caret& caret, const Type* const type) {
 
     if(caret.isAtText("null", true)){
@@ -221,7 +174,7 @@ private:
 
       auto polymorphicDispatcher = static_cast<const typename Collection::Class::PolymorphicDispatcher*>(type->polymorphicDispatcher);
       auto mapWrapper = polymorphicDispatcher->createObject();
-      const auto& map = mapWrapper.template staticCast<Collection>();
+      const auto& map = mapWrapper.template cast<Collection>();
 
       auto it = type->params.begin();
       auto keyType = *it ++;
@@ -282,6 +235,10 @@ private:
   static oatpp::Void deserializeString(Deserializer* deserializer, parser::Caret& caret, const Type* const type);
   static oatpp::Void deserializeAny(Deserializer* deserializer, parser::Caret& caret, const Type* const type);
   static oatpp::Void deserializeEnum(Deserializer* deserializer, parser::Caret& caret, const Type* const type);
+
+  static oatpp::Void deserializeCollection(Deserializer* deserializer, parser::Caret& caret, const Type* type);
+  static oatpp::Void deserializeMap(Deserializer* deserializer, parser::Caret& caret, const Type* const type);
+
   static oatpp::Void deserializeObject(Deserializer* deserializer, parser::Caret& caret, const Type* const type);
 
 private:

--- a/src/oatpp/parser/json/mapping/Serializer.cpp
+++ b/src/oatpp/parser/json/mapping/Serializer.cpp
@@ -158,7 +158,13 @@ void Serializer::serializeObject(Serializer* serializer,
 
   for (auto const& field : fields) {
 
-    auto value = field->get(object);
+    oatpp::Void value;
+    if(field->info.typeSelector) {
+      value = oatpp::Void(field->get(object).getPtr(), field->info.typeSelector->selectType(object));
+    } else {
+      value = field->get(object);
+    }
+
     if (value || config->includeNullFields || (field->info.required && config->alwaysIncludeRequired)) {
       (first) ? first = false : stream->writeSimple(",", 1);
       serializeString(stream, field->name, std::strlen(field->name), serializer->m_config->escapeFlags);

--- a/src/oatpp/parser/json/mapping/Serializer.cpp
+++ b/src/oatpp/parser/json/mapping/Serializer.cpp
@@ -253,7 +253,7 @@ void Serializer::serializeObject(Serializer* serializer,
 }
 
 void Serializer::serialize(data::stream::ConsistentOutputStream* stream,
-                            const oatpp::Void& polymorph)
+                           const oatpp::Void& polymorph)
 {
   auto id = polymorph.getValueType()->classId.id;
   auto& method = m_methods[id];

--- a/src/oatpp/parser/json/mapping/Serializer.cpp
+++ b/src/oatpp/parser/json/mapping/Serializer.cpp
@@ -232,8 +232,9 @@ void Serializer::serializeObject(Serializer* serializer,
   for (auto const& field : fields) {
 
     oatpp::Void value;
-    if(field->info.typeSelector) {
-      value = oatpp::Void(field->get(object).getPtr(), field->info.typeSelector->selectType(object));
+    if(field->info.typeSelector && field->type == oatpp::Any::Class::getType()) {
+      const auto& any = field->get(object).cast<oatpp::Any>();
+      value = any.retrieve(field->info.typeSelector->selectType(object));
     } else {
       value = field->get(object);
     }

--- a/src/oatpp/parser/json/mapping/Serializer.hpp
+++ b/src/oatpp/parser/json/mapping/Serializer.hpp
@@ -132,58 +132,6 @@ private:
       stream->writeSimple("null", 4);
     }
   }
-
-  template<class Collection>
-  static void serializeList(Serializer* serializer, data::stream::ConsistentOutputStream* stream, const oatpp::Void& polymorph) {
-
-    if(!polymorph) {
-      stream->writeSimple("null", 4);
-      return;
-    }
-
-    const auto& list = polymorph.staticCast<Collection>();
-
-    stream->writeCharSimple('[');
-    bool first = true;
-
-    for(auto& value : *list) {
-      if(value || serializer->getConfig()->includeNullFields || serializer->getConfig()->alwaysIncludeNullCollectionElements) {
-        (first) ? first = false : stream->writeSimple(",", 1);
-        serializer->serialize(stream, value);
-      }
-    }
-
-    stream->writeCharSimple(']');
-
-  }
-
-  template<class Collection>
-  static void serializeKeyValue(Serializer* serializer, data::stream::ConsistentOutputStream* stream, const oatpp::Void& polymorph) {
-
-    if(!polymorph) {
-      stream->writeSimple("null", 4);
-      return;
-    }
-
-    const auto& map = polymorph.staticCast<Collection>();
-
-    stream->writeCharSimple('{');
-    bool first = true;
-
-    for(auto& pair : *map) {
-      const auto& value = pair.second;
-      if(value || serializer->m_config->includeNullFields || serializer->m_config->alwaysIncludeNullCollectionElements) {
-        (first) ? first = false : stream->writeSimple(",", 1);
-        const auto& key = pair.first;
-        serializeString(stream, key->data(), key->size(), serializer->m_config->escapeFlags);
-        stream->writeSimple(":", 1);
-        serializer->serialize(stream, value);
-      }
-    }
-
-    stream->writeCharSimple('}');
-
-  }
   
   static void serializeString(oatpp::data::stream::ConsistentOutputStream* stream,
                               const char* data,
@@ -201,6 +149,14 @@ private:
   static void serializeEnum(Serializer* serializer,
                             data::stream::ConsistentOutputStream* stream,
                             const oatpp::Void& polymorph);
+
+  static void serializeCollection(Serializer* serializer,
+                                  data::stream::ConsistentOutputStream* stream,
+                                  const oatpp::Void& polymorph);
+
+  static void serializeMap(Serializer* serializer,
+                           data::stream::ConsistentOutputStream* stream,
+                           const oatpp::Void& polymorph);
 
   static void serializeObject(Serializer* serializer,
                               data::stream::ConsistentOutputStream* stream,

--- a/src/oatpp/web/client/ApiClient.hpp
+++ b/src/oatpp/web/client/ApiClient.hpp
@@ -391,7 +391,7 @@ struct ApiClient::TypeInterpretation<data::mapping::type::EnumObjectWrapper<T, I
         );
     }
 
-    return ApiClient::TypeInterpretation<UTOW>::toString(typeName, value.template staticCast<UTOW>());
+    return ApiClient::TypeInterpretation<UTOW>::toString(typeName, value.template cast<UTOW>());
 
   }
 

--- a/src/oatpp/web/server/api/ApiController.hpp
+++ b/src/oatpp/web/server/api/ApiController.hpp
@@ -562,7 +562,7 @@ struct ApiController::TypeInterpretation <data::mapping::type::EnumObjectWrapper
       data::mapping::type::EnumInterpreterError error = data::mapping::type::EnumInterpreterError::OK;
       const auto& result = I::fromInterpretation(parsedValue, error);
       if(error == data::mapping::type::EnumInterpreterError::OK) {
-        return result.template staticCast<EnumOW>();
+        return result.template cast<EnumOW>();
       }
       success = false;
     }

--- a/test/oatpp/core/data/mapping/type/EnumTest.cpp
+++ b/test/oatpp/core/data/mapping/type/EnumTest.cpp
@@ -169,14 +169,14 @@ void EnumTest::onRun() {
     OATPP_ASSERT(inter.getValueType() == oatpp::String::Class::getType());
     OATPP_ASSERT(e == oatpp::data::mapping::type::EnumInterpreterError::OK);
 
-    auto interValue = inter.staticCast<oatpp::String>();
+    auto interValue = inter.cast<oatpp::String>();
     OATPP_ASSERT(interValue == "name-1");
 
     oatpp::Void voidValue = oatpp::Enum<Enum2>::AsString::Interpreter::fromInterpretation(interValue, e);
     OATPP_ASSERT(voidValue.getValueType() == oatpp::Enum<Enum2>::AsString::Class::getType());
     OATPP_ASSERT(e == oatpp::data::mapping::type::EnumInterpreterError::OK);
 
-    auto value = voidValue.staticCast<oatpp::Enum<Enum2>::AsString>();
+    auto value = voidValue.cast<oatpp::Enum<Enum2>::AsString>();
     OATPP_ASSERT(value == Enum2::NAME_1);
     OATPP_LOGI(TAG, "OK");
   }
@@ -188,14 +188,14 @@ void EnumTest::onRun() {
     OATPP_ASSERT(inter.getValueType() == oatpp::Int32::Class::getType());
     OATPP_ASSERT(e == oatpp::data::mapping::type::EnumInterpreterError::OK);
 
-    auto interValue = inter.staticCast<oatpp::Int32>();
+    auto interValue = inter.cast<oatpp::Int32>();
     OATPP_ASSERT(interValue == static_cast<v_int32>(Enum2::NAME_1));
 
     oatpp::Void voidValue = oatpp::Enum<Enum2>::AsNumber::Interpreter::fromInterpretation(interValue, e);
     OATPP_ASSERT(voidValue.getValueType() == oatpp::Enum<Enum2>::AsNumber::Class::getType());
     OATPP_ASSERT(e == oatpp::data::mapping::type::EnumInterpreterError::OK);
 
-    auto value = voidValue.staticCast<oatpp::Enum<Enum2>::AsNumber>();
+    auto value = voidValue.cast<oatpp::Enum<Enum2>::AsNumber>();
     OATPP_ASSERT(value == Enum2::NAME_1);
     OATPP_LOGI(TAG, "OK");
   }

--- a/test/oatpp/core/data/mapping/type/InterpretationTest.cpp
+++ b/test/oatpp/core/data/mapping/type/InterpretationTest.cpp
@@ -214,7 +214,7 @@ void InterpretationTest::onRun() {
     auto v = tr.resolveObjectPropertyValue(l, {"p1", "x"}, cache);
     OATPP_ASSERT(v);
     OATPP_ASSERT(v.getValueType() == oatpp::Int32::Class::getType());
-    OATPP_ASSERT(v.staticCast<oatpp::Int32>() == 1);
+    OATPP_ASSERT(v.cast<oatpp::Int32>() == 1);
   }
 
   {
@@ -226,7 +226,7 @@ void InterpretationTest::onRun() {
     auto v = tr.resolveObjectPropertyValue(l, {"p1", "y"}, cache);
     OATPP_ASSERT(v);
     OATPP_ASSERT(v.getValueType() == oatpp::Int32::Class::getType());
-    OATPP_ASSERT(v.staticCast<oatpp::Int32>() == 2);
+    OATPP_ASSERT(v.cast<oatpp::Int32>() == 2);
   }
 
   {
@@ -238,7 +238,7 @@ void InterpretationTest::onRun() {
     auto v = tr.resolveObjectPropertyValue(l, {"p1", "z"}, cache);
     OATPP_ASSERT(v);
     OATPP_ASSERT(v.getValueType() == oatpp::Int32::Class::getType());
-    OATPP_ASSERT(v.staticCast<oatpp::Int32>() == 3);
+    OATPP_ASSERT(v.cast<oatpp::Int32>() == 3);
   }
 
 }

--- a/test/oatpp/core/data/mapping/type/ListTest.cpp
+++ b/test/oatpp/core/data/mapping/type/ListTest.cpp
@@ -140,11 +140,11 @@ void ListTest::onRun() {
     OATPP_LOGI(TAG, "test polymorphicDispatcher...");
     oatpp::List<oatpp::String> list = {"a", "b", "c"};
 
-    auto polymorphicDispatcher = static_cast<const typename oatpp::List<oatpp::String>::Class::PolymorphicDispatcher*>(
+    auto polymorphicDispatcher = static_cast<const oatpp::data::mapping::type::__class::Collection::PolymorphicDispatcher*>(
       list.getValueType()->polymorphicDispatcher
     );
 
-    polymorphicDispatcher->addPolymorphicItem(list, oatpp::String("d"));
+    polymorphicDispatcher->addItem(list, oatpp::String("d"));
 
     OATPP_ASSERT(list->size() == 4);
 

--- a/test/oatpp/core/data/mapping/type/ObjectTest.cpp
+++ b/test/oatpp/core/data/mapping/type/ObjectTest.cpp
@@ -120,8 +120,8 @@ class PolymorphicDto1 : public oatpp::DTO {
   DTO_FIELD(Any, polymorph);
 
   DTO_FIELD_TYPE_SELECTOR(polymorph) {
-    if(self->type == "A") return Object<DtoTypeA>::Class::getType();
-    if(self->type == "B") return Object<DtoTypeB>::Class::getType();
+    if(type == "A") return Object<DtoTypeA>::Class::getType();
+    if(type == "B") return Object<DtoTypeB>::Class::getType();
     return Object<DTO>::Class::getType();
   }
 
@@ -139,8 +139,8 @@ class PolymorphicDto2 : public oatpp::DTO {
   DTO_FIELD(Any, polymorph);
 
   DTO_FIELD_TYPE_SELECTOR(polymorph) {
-    if(self->type == "A") return Object<DtoTypeA>::Class::getType();
-    if(self->type == "B") return Object<DtoTypeB>::Class::getType();
+    if(type == "A") return Object<DtoTypeA>::Class::getType();
+    if(type == "B") return Object<DtoTypeB>::Class::getType();
     return Object<DTO>::Class::getType();
   }
 
@@ -154,8 +154,8 @@ class PolymorphicDto3 : public oatpp::DTO {
   DTO_FIELD(Any, polymorph);
 
   DTO_FIELD_TYPE_SELECTOR(polymorph) {
-    if(self->type == "str") return String::Class::getType();
-    if(self->type == "int") return Int32::Class::getType();
+    if(type == "str") return String::Class::getType();
+    if(type == "int") return Int32::Class::getType();
     return Void::Class::getType();
   }
 

--- a/test/oatpp/core/data/mapping/type/ObjectTest.cpp
+++ b/test/oatpp/core/data/mapping/type/ObjectTest.cpp
@@ -117,7 +117,7 @@ class PolymorphicDto1 : public oatpp::DTO {
   DTO_INIT(PolymorphicDto1, DTO)
 
   DTO_FIELD(String, type);
-  DTO_FIELD(Object<DTO>, polymorph);
+  DTO_FIELD(Any, polymorph);
 
   DTO_FIELD_TYPE_SELECTOR(polymorph) {
     if(self->type == "A") return Object<DtoTypeA>::Class::getType();
@@ -136,7 +136,7 @@ class PolymorphicDto2 : public oatpp::DTO {
   DTO_FIELD_INFO(polymorph) {
     info->description = "description";
   }
-  DTO_FIELD(Object<DTO>, polymorph);
+  DTO_FIELD(Any, polymorph);
 
   DTO_FIELD_TYPE_SELECTOR(polymorph) {
     if(self->type == "A") return Object<DtoTypeA>::Class::getType();
@@ -151,7 +151,7 @@ class PolymorphicDto3 : public oatpp::DTO {
   DTO_INIT(PolymorphicDto3, DTO)
 
   DTO_FIELD(String, type);
-  DTO_FIELD(Void, polymorph);
+  DTO_FIELD(Any, polymorph);
 
   DTO_FIELD_TYPE_SELECTOR(polymorph) {
     if(self->type == "str") return String::Class::getType();
@@ -484,7 +484,7 @@ void ObjectTest::onRun() {
     dto->type = "A";
     dto->polymorph = DtoTypeA::createShared();
 
-    OATPP_ASSERT(dto->polymorph.getValueType() == oatpp::Object<oatpp::DTO>::Class::getType())
+    OATPP_ASSERT(dto->polymorph.getValueType() == oatpp::Any::Class::getType())
 
     auto json = mapper.writeToString(dto);
     OATPP_LOGD(TAG, "json0='%s'", json->c_str())
@@ -497,9 +497,9 @@ void ObjectTest::onRun() {
     OATPP_ASSERT(json == jsonClone)
 
     OATPP_ASSERT(dtoClone->polymorph)
-    OATPP_ASSERT(dtoClone->polymorph.getValueType() == oatpp::Object<oatpp::DTO>::Class::getType())
+    OATPP_ASSERT(dtoClone->polymorph.getValueType() == oatpp::Any::Class::getType())
 
-    auto polymorphClone = dtoClone->polymorph.cast<oatpp::Object<DtoTypeA>>();
+    auto polymorphClone = dtoClone->polymorph.retrieve<oatpp::Object<DtoTypeA>>();
 
     OATPP_ASSERT(polymorphClone->fieldA == "type-A")
 
@@ -516,7 +516,7 @@ void ObjectTest::onRun() {
     dto->type = "str";
     dto->polymorph = oatpp::String("Hello World!");
 
-    OATPP_ASSERT(dto->polymorph.getValueType() == oatpp::String::Class::getType())
+    OATPP_ASSERT(dto->polymorph.getValueType() == oatpp::Any::Class::getType())
 
     auto json = mapper.writeToString(dto);
     OATPP_LOGD(TAG, "json0='%s'", json->c_str())
@@ -529,9 +529,9 @@ void ObjectTest::onRun() {
     OATPP_ASSERT(json == jsonClone)
 
     OATPP_ASSERT(dtoClone->polymorph)
-    OATPP_ASSERT(dtoClone->polymorph.getValueType() == oatpp::Void::Class::getType())
+    OATPP_ASSERT(dtoClone->polymorph.getValueType() == oatpp::Any::Class::getType())
 
-    auto polymorphClone = dtoClone->polymorph.cast<oatpp::String>();
+    auto polymorphClone = dtoClone->polymorph.retrieve<oatpp::String>();
 
     OATPP_ASSERT(polymorphClone == "Hello World!")
 

--- a/test/oatpp/core/data/mapping/type/ObjectTest.cpp
+++ b/test/oatpp/core/data/mapping/type/ObjectTest.cpp
@@ -24,6 +24,8 @@
 
 #include "ObjectTest.hpp"
 
+#include "oatpp/parser/json/mapping/ObjectMapper.hpp"
+
 #include "oatpp/core/macro/codegen.hpp"
 #include "oatpp/core/Types.hpp"
 
@@ -91,6 +93,56 @@ class DtoD : public DtoA {
   DTO_INIT(DtoD, DtoA)
 
   DTO_FIELD(Int32, a) = Int64(64);
+
+};
+
+class DtoTypeA : public oatpp::DTO {
+
+  DTO_INIT(DtoTypeA, DTO)
+
+  DTO_FIELD(String, fieldA) = "type-A";
+
+};
+
+class DtoTypeB : public oatpp::DTO {
+
+  DTO_INIT(DtoTypeB, DTO)
+
+  DTO_FIELD(String, fieldB) = "type-B";
+
+};
+
+class PolymorphicDto1 : public oatpp::DTO {
+
+  DTO_INIT(PolymorphicDto1, DTO)
+
+  DTO_FIELD(String, type);
+  DTO_FIELD(Object<DTO>, polymorph);
+
+  DTO_FIELD_TYPE_SELECTOR(polymorph) {
+    if(self->type == "A") return Object<DtoTypeA>::Class::getType();
+    if(self->type == "B") return Object<DtoTypeB>::Class::getType();
+    return Object<DTO>::Class::getType();
+  }
+
+};
+
+class PolymorphicDto2 : public oatpp::DTO {
+
+  DTO_INIT(PolymorphicDto2, DTO)
+
+  DTO_FIELD(String, type);
+
+  DTO_FIELD_INFO(polymorph) {
+    info->description = "description";
+  }
+  DTO_FIELD(Object<DTO>, polymorph);
+
+  DTO_FIELD_TYPE_SELECTOR(polymorph) {
+    if(self->type == "A") return Object<DtoTypeA>::Class::getType();
+    if(self->type == "B") return Object<DtoTypeB>::Class::getType();
+    return Object<DTO>::Class::getType();
+  }
 
 };
 
@@ -328,6 +380,114 @@ void ObjectTest::onRun() {
     OATPP_ASSERT(oatpp::Object<DtoC>::Class::getType()->extends(oatpp::Object<DtoA>::Class::getType()))
     OATPP_ASSERT(oatpp::Object<DtoD>::Class::getType()->extends(oatpp::Object<DtoA>::Class::getType()))
     OATPP_ASSERT(!oatpp::Object<DtoC>::Class::getType()->extends(oatpp::Object<DtoB>::Class::getType()))
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "Test 11...");
+
+    auto map = oatpp::Object<PolymorphicDto1>::getPropertiesMap();
+    auto p = map["polymorph"];
+
+    OATPP_ASSERT(p->info.description == "");
+    OATPP_ASSERT(p->info.typeSelector != nullptr);
+
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "Test 12...");
+
+    auto map = oatpp::Object<PolymorphicDto2>::getPropertiesMap();
+    auto p = map["polymorph"];
+
+    OATPP_ASSERT(p->info.description == "description");
+    OATPP_ASSERT(p->info.typeSelector != nullptr);
+
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "Test 13...");
+
+    auto dto = oatpp::Object<PolymorphicDto2>::createShared();
+    OATPP_ASSERT(dto->type == nullptr)
+    OATPP_ASSERT(dto->type.getValueType() == oatpp::String::Class::getType())
+    OATPP_ASSERT(dto["type"] == nullptr)
+    OATPP_ASSERT(dto["type"].getValueType() == oatpp::String::Class::getType())
+
+    dto["type"] = oatpp::String("hello");
+    OATPP_ASSERT(dto->type == "hello");
+    OATPP_ASSERT(dto->type.getValueType() == oatpp::String::Class::getType())
+
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "Test 14...");
+
+    auto dto = oatpp::Object<PolymorphicDto2>::createShared();
+    bool thrown = false;
+
+    try{
+      dto["type"] = oatpp::Int32(32);
+    } catch(std::runtime_error e) {
+      OATPP_LOGD(TAG, "error='%s'", e.what());
+      thrown = true;
+    }
+
+    OATPP_ASSERT(thrown)
+
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "Test 15...");
+
+    auto dto = oatpp::Object<PolymorphicDto2>::createShared();
+    bool thrown = false;
+
+    try{
+      dto["non-existing"];
+    } catch(std::out_of_range e) {
+      OATPP_LOGD(TAG, "error='%s'", e.what());
+      thrown = true;
+    }
+
+    OATPP_ASSERT(thrown)
+
+    OATPP_LOGI(TAG, "OK");
+  }
+
+  {
+    OATPP_LOGI(TAG, "Test 16...");
+
+    oatpp::parser::json::mapping::ObjectMapper mapper;
+
+    auto dto = PolymorphicDto1::createShared();
+
+    dto->type = "A";
+    dto->polymorph = DtoTypeA::createShared();
+
+    OATPP_ASSERT(dto->polymorph.getValueType() == oatpp::Object<oatpp::DTO>::Class::getType())
+
+    auto json = mapper.writeToString(dto);
+    OATPP_LOGD(TAG, "json0='%s'", json->c_str())
+
+    auto dtoClone = mapper.readFromString<oatpp::Object<PolymorphicDto1>>(json);
+
+    auto jsonClone = mapper.writeToString(dtoClone);
+    OATPP_LOGD(TAG, "json1='%s'", jsonClone->c_str())
+
+    OATPP_ASSERT(json == jsonClone)
+
+    OATPP_ASSERT(dtoClone->polymorph)
+    OATPP_ASSERT(dtoClone->polymorph.getValueType() == oatpp::Object<oatpp::DTO>::Class::getType())
+
+    auto polymorphClone = dtoClone->polymorph.staticCast<oatpp::Object<DtoTypeA>>();
+
+    OATPP_ASSERT(polymorphClone->fieldA == "type-A")
+
     OATPP_LOGI(TAG, "OK");
   }
 

--- a/test/oatpp/core/data/mapping/type/ObjectWrapperTest.cpp
+++ b/test/oatpp/core/data/mapping/type/ObjectWrapperTest.cpp
@@ -83,8 +83,14 @@ void ObjectWrapperTest::onRun() {
     OATPP_LOGI(TAG, "Check valueType is NOT assigned from copy-assign operator...");
     ObjectWrapper<std::string> pw1(oatpp::data::mapping::type::__class::String::getType());
     ObjectWrapper<std::string> pw2;
-    pw2 = pw1;
+    bool throws = false;
+    try {
+      pw2 = pw1;
+    } catch (std::runtime_error& e) {
+      throws = true;
+    }
     OATPP_ASSERT(pw2.getValueType() == oatpp::data::mapping::type::__class::Void::getType());
+    OATPP_ASSERT(throws)
     OATPP_LOGI(TAG, "OK");
   }
 
@@ -92,8 +98,14 @@ void ObjectWrapperTest::onRun() {
     OATPP_LOGI(TAG, "Check valueType is NOT assigned from move-assign operator...");
     ObjectWrapper<std::string> pw1(oatpp::data::mapping::type::__class::String::getType());
     ObjectWrapper<std::string> pw2;
-    pw2 = std::move(pw1);
+    bool throws = false;
+    try {
+      pw2 = std::move(pw1);
+    } catch (std::runtime_error& e) {
+      throws = true;
+    }
     OATPP_ASSERT(pw2.getValueType() == oatpp::data::mapping::type::__class::Void::getType());
+    OATPP_ASSERT(throws)
     OATPP_LOGI(TAG, "OK");
   }
 
@@ -176,7 +188,7 @@ void ObjectWrapperTest::onRun() {
 
     OATPP_ASSERT(v.getValueType() == oatpp::Int32::Class::getType());
 
-    oatpp::Int32 i = v.staticCast<oatpp::Int32>();
+    oatpp::Int32 i = v.cast<oatpp::Int32>();
 
     OATPP_ASSERT(i.getValueType() == oatpp::Int32::Class::getType());
     OATPP_ASSERT(i == 32);

--- a/test/oatpp/core/data/mapping/type/PairListTest.cpp
+++ b/test/oatpp/core/data/mapping/type/PairListTest.cpp
@@ -148,11 +148,11 @@ void PairListTest::onRun() {
     OATPP_LOGI(TAG, "test polymorphicDispatcher...");
     oatpp::Fields<String> map = {{"key1", "a"}, {"key2", "b"}, {"key3", "c"}};
 
-    auto polymorphicDispatcher = static_cast<const typename oatpp::Fields<String>::Class::PolymorphicDispatcher*>(
+    auto polymorphicDispatcher = static_cast<const typename oatpp::data::mapping::type::__class::Map::PolymorphicDispatcher*>(
       map.getValueType()->polymorphicDispatcher
     );
 
-    polymorphicDispatcher->addPolymorphicItem(map, oatpp::String("key1"), oatpp::String("d"));
+    polymorphicDispatcher->addItem(map, oatpp::String("key1"), oatpp::String("d"));
 
     OATPP_ASSERT(map->size() == 4);
 

--- a/test/oatpp/core/data/mapping/type/UnorderedMapTest.cpp
+++ b/test/oatpp/core/data/mapping/type/UnorderedMapTest.cpp
@@ -144,11 +144,11 @@ void UnorderedMapTest::onRun() {
     OATPP_LOGI(TAG, "test polymorphicDispatcher...");
     oatpp::UnorderedFields<String> map = {{"key1", "a"}, {"key2", "b"}, {"key3", "c"}};
 
-    auto polymorphicDispatcher = static_cast<const typename oatpp::UnorderedFields<String>::Class::PolymorphicDispatcher*>(
+    auto polymorphicDispatcher = static_cast<const typename oatpp::data::mapping::type::__class::Map::PolymorphicDispatcher*>(
       map.getValueType()->polymorphicDispatcher
     );
 
-    polymorphicDispatcher->addPolymorphicItem(map, oatpp::String("key1"), oatpp::String("d"));
+    polymorphicDispatcher->addItem(map, oatpp::String("key1"), oatpp::String("d"));
 
     OATPP_ASSERT(map->size() == 3);
 

--- a/test/oatpp/core/data/mapping/type/UnorderedSetTest.cpp
+++ b/test/oatpp/core/data/mapping/type/UnorderedSetTest.cpp
@@ -120,15 +120,15 @@ void UnorderedSetTest::onRun() {
     OATPP_LOGI(TAG, "test polymorphicDispatcher...");
     oatpp::UnorderedSet<oatpp::String> set = {"a", "b", "c"};
 
-    auto polymorphicDispatcher = static_cast<const typename oatpp::UnorderedSet<oatpp::String>::Class::PolymorphicDispatcher*>(
+    auto polymorphicDispatcher = static_cast<const typename oatpp::data::mapping::type::__class::Collection::PolymorphicDispatcher*>(
       set.getValueType()->polymorphicDispatcher
     );
 
-    polymorphicDispatcher->addPolymorphicItem(set, oatpp::String("a"));
-    polymorphicDispatcher->addPolymorphicItem(set, oatpp::String("b"));
-    polymorphicDispatcher->addPolymorphicItem(set, oatpp::String("c"));
+    polymorphicDispatcher->addItem(set, oatpp::String("a"));
+    polymorphicDispatcher->addItem(set, oatpp::String("b"));
+    polymorphicDispatcher->addItem(set, oatpp::String("c"));
 
-    polymorphicDispatcher->addPolymorphicItem(set, oatpp::String("d"));
+    polymorphicDispatcher->addItem(set, oatpp::String("d"));
 
     OATPP_ASSERT(set->size() == 4);
 

--- a/test/oatpp/core/data/mapping/type/VectorTest.cpp
+++ b/test/oatpp/core/data/mapping/type/VectorTest.cpp
@@ -140,11 +140,11 @@ void VectorTest::onRun() {
     OATPP_LOGI(TAG, "test polymorphicDispatcher...");
     oatpp::Vector<oatpp::String> vector = {"a", "b", "c"};
 
-    auto polymorphicDispatcher = static_cast<const typename oatpp::Vector<oatpp::String>::Class::PolymorphicDispatcher*>(
+    auto polymorphicDispatcher = static_cast<const oatpp::data::mapping::type::__class::Collection::PolymorphicDispatcher*>(
       vector.getValueType()->polymorphicDispatcher
     );
 
-    polymorphicDispatcher->addPolymorphicItem(vector, oatpp::String("d"));
+    polymorphicDispatcher->addItem(vector, oatpp::String("d"));
 
     OATPP_ASSERT(vector->size() == 4);
 


### PR DESCRIPTION
**Updated.**

Polymorphic `DTO_FIELD` (https://github.com/oatpp/oatpp/issues/405)

```cpp
class MyDto : public oatpp::DTO {

  DTO_INIT(MyDto, DTO)

  /* field that defines 'polymorph' type */
  DTO_FIELD(String, type);

  /* polymorphic field */
  DTO_FIELD(Any, polymorph);

  /* type selector for polymorphic field */
  DTO_FIELD_TYPE_SELECTOR(polymorph) {
    if(type == "str") return String::Class::getType();
    if(type == "int") return Int32::Class::getType();
    return Void::Class::getType();
  }

};
```

Type selectors are allowed for `oatpp::Any` only - for safety reasons.