### PR TITLE
QUERY: fix default value type (#411). QueryParams/Headers: use unorde…

### DIFF
--- a/src/oatpp/codegen/api_controller/base_define.hpp
+++ b/src/oatpp/codegen/api_controller/base_define.hpp
@@ -187,14 +187,17 @@ if(!__param_validation_check_##NAME){ \
 }
 
 #define OATPP_MACRO_API_CONTROLLER_QUERY_3(TYPE, NAME, QUALIFIER, DEFAULT) \
-const auto& __param_str_val_##NAME = __request->getQueryParameter(QUALIFIER, DEFAULT); \
-bool __param_validation_check_##NAME; \
-const auto& NAME = ApiController::TypeInterpretation<TYPE>::fromString(#TYPE, __param_str_val_##NAME, __param_validation_check_##NAME); \
-if(!__param_validation_check_##NAME){ \
-  return ApiController::handleError(Status::CODE_400, \
-                                    oatpp::String("Invalid QUERY parameter '") + \
-                                    QUALIFIER + \
-                                    "'. Expected type is '" #TYPE "'"); \
+TYPE NAME = DEFAULT; \
+const auto& __param_str_val_##NAME = __request->getQueryParameter(QUALIFIER); \
+if(__param_str_val_##NAME) { \
+  bool __param_validation_check_##NAME; \
+  NAME = ApiController::TypeInterpretation<TYPE>::fromString(#TYPE, __param_str_val_##NAME, __param_validation_check_##NAME); \
+  if(!__param_validation_check_##NAME){ \
+    return ApiController::handleError(Status::CODE_400, \
+                                      oatpp::String("Invalid QUERY parameter '") + \
+                                      QUALIFIER + \
+                                      "'. Expected type is '" #TYPE "'"); \
+  } \
 }
 
 #define OATPP_MACRO_API_CONTROLLER_QUERY(TYPE, PARAM_LIST) \

--- a/src/oatpp/core/data/mapping/type/Primitive.cpp
+++ b/src/oatpp/core/data/mapping/type/Primitive.cpp
@@ -79,7 +79,7 @@ bool String::equalsCI_ASCII(const char* other) {
   return ciLabel == other;
 }
 
-std::string String::getValue(const std::string& defaultValue) {
+std::string String::getValue(const std::string& defaultValue) const {
   if(m_ptr) {
     return *m_ptr;
   }

--- a/src/oatpp/core/data/mapping/type/Primitive.hpp
+++ b/src/oatpp/core/data/mapping/type/Primitive.hpp
@@ -218,7 +218,7 @@ public:
    * @param defaultValue - value to return in case stored value is `nullptr`.
    * @return - value or `defaultValue` if stored value is `nullptr`.
    */
-  std::string getValue(const std::string& defaultValue);
+  std::string getValue(const std::string& defaultValue) const;
 
   template<typename T,
     typename enabled = typename std::enable_if<std::is_same<T, std::nullptr_t>::value, void>::type
@@ -357,7 +357,7 @@ public:
     return *this->m_ptr;
   }
 
-  TValueType getValue(const TValueType& defaultValue) {
+  TValueType getValue(const TValueType& defaultValue) const {
     if(this->m_ptr) {
       return *this->m_ptr;
     }
@@ -434,6 +434,13 @@ public:
       return *(this->m_ptr);
     }
     return false;
+  }
+
+  bool getValue(bool defaultValue) const {
+    if(this->m_ptr) {
+      return *this->m_ptr;
+    }
+    return defaultValue;
   }
 
 };

--- a/src/oatpp/core/data/share/LazyStringMap.hpp
+++ b/src/oatpp/core/data/share/LazyStringMap.hpp
@@ -28,7 +28,6 @@
 #include "./MemoryLabel.hpp"
 #include "oatpp/core/concurrency/SpinLock.hpp"
 
-#include <map>
 #include <unordered_map>
 
 namespace oatpp { namespace data { namespace share {
@@ -337,7 +336,7 @@ using LazyStringMap = LazyStringMapTemplate<Key, std::unordered_map<Key, Value>>
  * Convenience template for &l:LazyStringMapTemplate;. Based on `std::unordered_map`.
  */
 template<typename Key, typename Value = StringKeyLabel>
-using LazyStringMultimap = LazyStringMapTemplate<Key, std::multimap<Key, Value>>;
+using LazyStringMultimap = LazyStringMapTemplate<Key, std::unordered_multimap<Key, Value>>;
 
 }}}
 

--- a/src/oatpp/network/Url.hpp
+++ b/src/oatpp/network/Url.hpp
@@ -43,9 +43,9 @@ public:
   typedef oatpp::data::share::StringKeyLabel StringKeyLabel;
 public:
   /**
-   * Parameters - map string to string.
+   * Parameters - map string to string. &id:oatpp::data::share::LazyStringMultimap;.
    */
-  typedef oatpp::data::share::LazyStringMap<oatpp::data::share::StringKeyLabel> Parameters;
+  typedef oatpp::data::share::LazyStringMultimap<oatpp::data::share::StringKeyLabel> Parameters;
 
 public:
 

--- a/src/oatpp/web/protocol/http/Http.hpp
+++ b/src/oatpp/web/protocol/http/Http.hpp
@@ -40,15 +40,15 @@ namespace oatpp { namespace web { namespace protocol { namespace http {
 
 /**
  * Typedef for headers map. Headers map key is case-insensitive.
- * For more info see &id:oatpp::data::share::LazyStringMap;.
+ * For more info see &id:oatpp::data::share::LazyStringMultimap;.
  */
 typedef oatpp::data::share::LazyStringMultimap<oatpp::data::share::StringKeyLabelCI> Headers;
 
 /**
  * Typedef for query parameters map.
- * For more info see &id:oatpp::data::share::LazyStringMap;.
+ * For more info see &id:oatpp::data::share::LazyStringMultimap;.
  */
-typedef oatpp::data::share::LazyStringMap<oatpp::data::share::StringKeyLabel> QueryParams;
+typedef oatpp::data::share::LazyStringMultimap<oatpp::data::share::StringKeyLabel> QueryParams;
 
 /**
  * Http status.

--- a/src/oatpp/web/protocol/http/outgoing/BufferBody.cpp
+++ b/src/oatpp/web/protocol/http/outgoing/BufferBody.cpp
@@ -27,7 +27,7 @@
 namespace oatpp { namespace web { namespace protocol { namespace http { namespace outgoing {
 
 BufferBody::BufferBody(const oatpp::String &buffer, const data::share::StringKeyLabel &contentType)
-  : m_buffer(buffer)
+  : m_buffer(buffer ? buffer : "")
   , m_contentType(contentType)
   , m_inlineData((void*) m_buffer->data(), m_buffer->size())
 {}

--- a/test/oatpp/web/app/Controller.hpp
+++ b/test/oatpp/web/app/Controller.hpp
@@ -119,7 +119,7 @@ public:
   }
 
   ENDPOINT("GET", "queries/optional", getWithOptQueries,
-           QUERY(String, name, "name", "Default"), QUERY(Int32, age, "age", "101")) {
+           QUERY(String, name, "name", "Default"), QUERY(Int32, age, "age", 101)) {
     auto dto = TestDto::createShared();
     dto->testValue = "name=" + name + "&age=" + oatpp::utils::conversion::int32ToStr(*age);
     return createDtoResponse(Status::CODE_200, dto);


### PR DESCRIPTION
…red_multimap (#402)