### PR TITLE
fix negativ number parsing in oatpp::Any

### DIFF
--- a/src/oatpp/parser/json/Utils.cpp
+++ b/src/oatpp/parser/json/Utils.cpp
@@ -480,12 +480,12 @@ std::string Utils::parseStringToStdString(ParsingCaret& caret){
 bool Utils::findDecimalSeparatorInCurrentNumber(ParsingCaret& caret) {
   parser::Caret::StateSaveGuard stateGuard(caret);
 
-  // search until a decimal separator is found or no more digits are found or no more data available
+  // search until a decimal separator is found or no more digits/sign are found or no more data available
   while(caret.canContinue()) {
     if (caret.isAtChar(JSON_DECIMAL_SEPARATOR)) {
       return true;
     }
-    if (!caret.isAtDigitChar()) {
+    if (!caret.isAtDigitChar() && !caret.isAtChar('-')) {
       return false;
     }
     caret.inc();

--- a/test/oatpp/parser/json/mapping/DeserializerTest.cpp
+++ b/test/oatpp/parser/json/mapping/DeserializerTest.cpp
@@ -197,12 +197,33 @@ void DeserializerTest::onRun(){
     OATPP_ASSERT(dto->any.getStoredType() == Boolean::Class::getType());
     OATPP_ASSERT(dto->any.retrieve<Boolean>() == false);
   }
-  OATPP_LOGD(TAG, "Any: Float")
+  OATPP_LOGD(TAG, "Any: Negative Float")
+  {
+    auto dto = mapper->readFromString<oatpp::Object<AnyDto>>(R"({"any":-1.23456789,"another":1.1})");
+    OATPP_ASSERT(dto);
+    OATPP_ASSERT(dto->any.getStoredType() == Float64::Class::getType());
+    OATPP_ASSERT(dto->any.retrieve<Float64>() == -1.23456789);
+  }
+  OATPP_LOGD(TAG, "Any: Positive Float")
   {
     auto dto = mapper->readFromString<oatpp::Object<AnyDto>>(R"({"any":1.23456789,"another":1.1})");
     OATPP_ASSERT(dto);
     OATPP_ASSERT(dto->any.getStoredType() == Float64::Class::getType());
     OATPP_ASSERT(dto->any.retrieve<Float64>() == 1.23456789);
+  }
+  OATPP_LOGD(TAG, "Any: Negative exponential Float")
+  {
+    auto dto = mapper->readFromString<oatpp::Object<AnyDto>>(R"({"any":-1.2345e30,"another":1.1})");
+    OATPP_ASSERT(dto);
+    OATPP_ASSERT(dto->any.getStoredType() == Float64::Class::getType());
+    OATPP_ASSERT(dto->any.retrieve<Float64>() == -1.2345e30);
+  }
+  OATPP_LOGD(TAG, "Any: Positive exponential Float")
+  {
+    auto dto = mapper->readFromString<oatpp::Object<AnyDto>>(R"({"any":1.2345e30,"another":1.1})");
+    OATPP_ASSERT(dto);
+    OATPP_ASSERT(dto->any.getStoredType() == Float64::Class::getType());
+    OATPP_ASSERT(dto->any.retrieve<Float64>() == 1.2345e30);
   }
   OATPP_LOGD(TAG, "Any: Unsigned Integer")
   {


### PR DESCRIPTION
I noticed that my last PR (https://github.com/oatpp/oatpp/pull/529) introduced a bug when parsing a negative number in oatpp::Any. This commit fixes this and adds more tests to ensure all cases are correctly handled.