### PR TITLE
Only build oatpp-test if OATPP_BUILD_TESTS is YES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,6 @@ string(REGEX REPLACE "#define OATPP_VERSION \"([0-9]+.[0-9]+.[0-9]+)\"$" "\\1" o
 
 set(OATPP_THIS_MODULE_NAME oatpp) ## name of the module (also name of folders in installation dirs)
 set(OATPP_THIS_MODULE_VERSION ${oatpp_VERSION}) ## version of the module (also sufix of folders in installation dirs)
-set(OATPP_THIS_MODULE_LIBRARIES oatpp oatpp-test) ## list of libraries to find when find_package is called
-set(OATPP_THIS_MODULE_TARGETS oatpp oatpp-test) ## list of targets to install
-set(OATPP_THIS_MODULE_DIRECTORIES oatpp oatpp-test) ## list of directories to install
 
 ###################################################################################################
 
@@ -26,6 +23,16 @@ option(OATPP_MSVC_LINK_STATIC_RUNTIME "MSVC: Link with static runtime (/MT and /
 ###################################################################################################
 ## COMPILATION CONFIG #############################################################################
 ###################################################################################################
+
+if(OATPP_BUILD_TESTS)
+	set(OATPP_THIS_MODULE_LIBRARIES oatpp oatpp-test) ## list of libraries to find when find_package is called
+	set(OATPP_THIS_MODULE_TARGETS oatpp oatpp-test) ## list of targets to install
+	set(OATPP_THIS_MODULE_DIRECTORIES oatpp oatpp-test) ## list of directories to install
+else()
+	set(OATPP_THIS_MODULE_LIBRARIES oatpp) ## list of libraries to find when find_package is called
+	set(OATPP_THIS_MODULE_TARGETS oatpp) ## list of targets to install
+	set(OATPP_THIS_MODULE_DIRECTORIES oatpp) ## list of directories to install
+endif()
 
 option(OATPP_DISABLE_ENV_OBJECT_COUNTERS "Disable object counting for Release builds for better performance" OFF)
 option(OATPP_DISABLE_POOL_ALLOCATIONS "This will make oatpp::base::memory::MemoryPool, method obtain and free call new and delete directly" OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -330,30 +330,34 @@ target_include_directories(oatpp PUBLIC
 #######################################################################################################
 ## oatpp-test
 
-add_library(oatpp-test
-        oatpp-test/Checker.cpp
-        oatpp-test/Checker.hpp
-        oatpp-test/UnitTest.cpp
-        oatpp-test/UnitTest.hpp
-        oatpp-test/web/ClientServerTestRunner.hpp
-)
+if(OATPP_BUILD_TESTS)
 
-set_target_properties(oatpp-test PROPERTIES
-        CXX_STANDARD 11
-        CXX_EXTENSIONS OFF
-        CXX_STANDARD_REQUIRED ON
-)
-if (MSVC)
-    target_compile_options(oatpp-test PRIVATE /permissive-)
+	add_library(oatpp-test
+			oatpp-test/Checker.cpp
+			oatpp-test/Checker.hpp
+			oatpp-test/UnitTest.cpp
+			oatpp-test/UnitTest.hpp
+			oatpp-test/web/ClientServerTestRunner.hpp
+	)
+
+	set_target_properties(oatpp-test PROPERTIES
+			CXX_STANDARD 11
+			CXX_EXTENSIONS OFF
+			CXX_STANDARD_REQUIRED ON
+	)
+	if (MSVC)
+		target_compile_options(oatpp-test PRIVATE /permissive-)
+	endif()
+
+	target_link_libraries(oatpp-test PUBLIC oatpp)
+
+	target_include_directories(oatpp-test PUBLIC
+			$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+	)
+
+	add_dependencies(oatpp-test oatpp)
+
 endif()
-
-target_link_libraries(oatpp-test PUBLIC oatpp)
-
-target_include_directories(oatpp-test PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-)
-
-add_dependencies(oatpp-test oatpp)
 
 #######################################################################################################
 ## Install targets


### PR DESCRIPTION
I noticed that even when building with OATPP_BUILD_TESTS = NO, an oatpp-test library would still be built and other oatpp modules would still depend on it.

So these modifications remove all oatpp-test, when  OATPP_BUILD_TESTS = NO.

I will have similar pull requests for oatpp-mbedtls and oatpp-websocket.

I am not using the remaining oatpp modules, so I have not checked how this would affect them.