### PR TITLE
Cross-compile Windows Fix

### DIFF
--- a/src/oatpp/core/IODefinitions.cpp
+++ b/src/oatpp/core/IODefinitions.cpp
@@ -25,7 +25,7 @@
 #include "IODefinitions.hpp"
 
 #if defined(WIN32) || defined(_WIN32)
-  #include <WinSock2.h>
+  #include <winsock2.h>
 #endif
 
 namespace oatpp {

--- a/src/oatpp/core/base/Environment.cpp
+++ b/src/oatpp/core/base/Environment.cpp
@@ -33,7 +33,7 @@
 #include <cstdarg>
 
 #if defined(WIN32) || defined(_WIN32)
-	#include <WinSock2.h>
+	#include <winsock2.h>
 
   struct tm* localtime_r(time_t *_clock, struct tm *_result) {
       localtime_s(_result, _clock);

--- a/src/oatpp/encoding/Hex.cpp
+++ b/src/oatpp/encoding/Hex.cpp
@@ -25,7 +25,7 @@
 #include "Hex.hpp"
 
 #if defined(WIN32) || defined(_WIN32)
-  #include <WinSock2.h>
+  #include <winsock2.h>
 #else
   #include <arpa/inet.h>
 #endif

--- a/src/oatpp/encoding/Unicode.cpp
+++ b/src/oatpp/encoding/Unicode.cpp
@@ -25,7 +25,7 @@
 #include "Unicode.hpp"
 
 #if defined(WIN32) || defined(_WIN32)
-  #include <Winsock2.h>
+  #include <winsock2.h>
 #else
   #include <arpa/inet.h>
 #endif

--- a/src/oatpp/network/tcp/Connection.cpp
+++ b/src/oatpp/network/tcp/Connection.cpp
@@ -26,7 +26,7 @@
 
 #if defined(WIN32) || defined(_WIN32)
   #include <io.h>
-  #include <WinSock2.h>
+  #include <winsock2.h>
 #else
   #include <unistd.h>
   #include <sys/socket.h>

--- a/src/oatpp/network/tcp/client/ConnectionProvider.cpp
+++ b/src/oatpp/network/tcp/client/ConnectionProvider.cpp
@@ -31,8 +31,8 @@
 
 #if defined(WIN32) || defined(_WIN32)
   #include <io.h>
-  #include <WinSock2.h>
-  #include <WS2tcpip.h>
+  #include <winsock2.h>
+  #include <ws2tcpip.h>
 #else
   #include <netdb.h>
   #include <arpa/inet.h>

--- a/src/oatpp/network/tcp/server/ConnectionProvider.cpp
+++ b/src/oatpp/network/tcp/server/ConnectionProvider.cpp
@@ -30,8 +30,8 @@
 
 #if defined(WIN32) || defined(_WIN32)
   #include <io.h>
-  #include <WinSock2.h>
-  #include <WS2tcpip.h>
+  #include <winsock2.h>
+  #include <ws2tcpip.h>
 #else
   #include <netdb.h>
   #include <arpa/inet.h>


### PR DESCRIPTION
When cross-compiling using clang on Linux to target Windows, the build fails due to the mixed case spelling of the header includes. Clang expects the headers to be all lowercase.