### PR TITLE
Fix #633: Check if this extends wrapper

### DIFF
--- a/src/oatpp/core/data/mapping/type/Type.cpp
+++ b/src/oatpp/core/data/mapping/type/Type.cpp
@@ -96,12 +96,10 @@ const Type::AbstractInterpretation* Type::findInterpretation(const std::vector<s
 }
 
 bool Type::extends(const Type* other) const {
-  const Type* curr = this;
-  while(curr != nullptr) {
+  for(const Type* curr = this; curr != nullptr; curr = curr->parent) {
     if(curr == other) {
       return true;
     }
-    curr = curr->parent;
   }
   return false;
 }

--- a/src/oatpp/core/data/mapping/type/Type.hpp
+++ b/src/oatpp/core/data/mapping/type/Type.hpp
@@ -556,7 +556,7 @@ public:
 template <class T, class Clazz>
 template<class Wrapper>
 Wrapper ObjectWrapper<T, Clazz>::cast() const {
-  if(!Wrapper::Class::getType()->extends(m_valueType)) {
+  if(!m_valueType->extends(Wrapper::Class::getType())) {
     if(Wrapper::Class::getType() != __class::Void::getType() && m_valueType != __class::Void::getType()) {
       throw std::runtime_error("[oatpp::data::mapping::type::ObjectWrapper::cast()]: Error. Invalid cast "
                                "from '" + std::string(m_valueType->classId.name) + "' to '" +


### PR DESCRIPTION
Invert the extend check in Type::cast so that it is checking if this instance extends wrapper and therefor this can be cast to Wrapper.