### PR TITLE
allow readBodyToStringAsync to support empty body

### DIFF
--- a/src/oatpp/web/protocol/http/incoming/SimpleBodyDecoder.cpp
+++ b/src/oatpp/web/protocol/http/incoming/SimpleBodyDecoder.cpp
@@ -189,6 +189,9 @@ async::CoroutineStarter SimpleBodyDecoder::decodeAsync(const Headers& headers,
         return std::move(pipeline.next(data::stream::transferAsync(bodyStream, writeCallback, contentLength, buffer, processor)));
 
       }
+      else if (success) {
+        return nullptr;
+      }
 
     } else {
 


### PR DESCRIPTION
A null string can properly get using macro BODY_STRING at sync mode, but at async mode, an exception is thrown and the next processing flow is interrupted. Sync and async mode should be in a unified way.