### PR TITLE
kushnertodd fix to issue #724 Remove warnings from Windows build

### DIFF
--- a/src/oatpp/core/data/mapping/type/Type.cpp
+++ b/src/oatpp/core/data/mapping/type/Type.cpp
@@ -53,7 +53,7 @@ std::vector<const char*>& ClassId::getClassNames() {
 v_int32 ClassId::registerClassName(const char* name) {
   std::lock_guard<std::mutex> lock(getClassMutex());
   getClassNames().push_back(name);
-  return getClassNames().size() - 1;
+  return (v_int32) getClassNames().size() - 1;
 }
 
 ClassId::ClassId(const char* pName)
@@ -63,7 +63,7 @@ ClassId::ClassId(const char* pName)
 
 int ClassId::getClassCount() {
   std::lock_guard<std::mutex> lock(getClassMutex());
-  return getClassNames().size();
+  return (int) getClassNames().size();
 }
 
 std::vector<const char*> ClassId::getRegisteredClassNames() {

--- a/src/oatpp/core/data/share/StringTemplate.cpp
+++ b/src/oatpp/core/data/share/StringTemplate.cpp
@@ -76,7 +76,7 @@ StringTemplate::StringTemplate(const oatpp::String& text, std::vector<Variable>&
       throw std::runtime_error("[oatpp::data::share::StringTemplate::StringTemplate()]: Error. The template variable can't have a negative size.");
     }
 
-    if(var.posEnd >= m_text->size()) {
+    if((size_t) var.posEnd >= m_text->size()) {
       throw std::runtime_error("[oatpp::data::share::StringTemplate::StringTemplate()]: Error. The template variable can't out-bound the template text.");
     }
   }
@@ -105,7 +105,7 @@ void StringTemplate::format(stream::ConsistentOutputStream* stream, ValueProvide
 
   }
 
-  if(prevPos < m_text->size()) {
+  if((size_t) prevPos < m_text->size()) {
     stream->writeSimple(m_text->data() + prevPos, m_text->size() - prevPos);
   }
 

--- a/src/oatpp/core/data/stream/FileStream.cpp
+++ b/src/oatpp/core/data/stream/FileStream.cpp
@@ -22,6 +22,9 @@
  *
  ***************************************************************************/
 
+#if defined(WIN32) || defined(_WIN32)
+_Pragma("warning(disable : 4996)")
+#endif
 #include "FileStream.hpp"
 
 namespace oatpp { namespace data{ namespace stream {

--- a/src/oatpp/network/monitor/ConnectionMonitor.cpp
+++ b/src/oatpp/network/monitor/ConnectionMonitor.cpp
@@ -143,7 +143,7 @@ void ConnectionMonitor::Monitor::monitorTask(std::shared_ptr<Monitor> monitor) {
   }
 
   {
-    std::lock_guard<std::mutex>(monitor->m_runMutex);
+    std::lock_guard<std::mutex> lock(monitor->m_runMutex);
     monitor->m_stopped = true;
   }
 

--- a/src/oatpp/network/tcp/server/ConnectionProvider.cpp
+++ b/src/oatpp/network/tcp/server/ConnectionProvider.cpp
@@ -188,9 +188,11 @@ oatpp::v_io_handle ConnectionProvider::instantiateServer(){
 
       if (hints.ai_family == AF_UNSPEC || hints.ai_family == AF_INET6) {
         if (setsockopt(serverHandle, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&no, sizeof( int ) ) != 0 ) {
+          const size_t buflen = 500;
+          char buf[buflen];
           OATPP_LOGW("[oatpp::network::tcp::server::ConnectionProvider::instantiateServer()]",
                      "Warning. Failed to set %s for accepting socket: %s", "IPV6_V6ONLY",
-                     strerror(errno));
+                     strerror_s(buf, buflen, errno));
         }
       }
 

--- a/src/oatpp/parser/json/Utils.cpp
+++ b/src/oatpp/parser/json/Utils.cpp
@@ -304,7 +304,7 @@ oatpp::String Utils::escapeString(const char* data, v_buff_size size, v_uint32 f
   }
   
   if(size > safeSize){
-    for(v_buff_size i = pos; i < result->size(); i ++){
+    for(v_buff_size i = pos; (size_t) i < result->size(); i ++){
       resultData[i] = '?';
     }
   }

--- a/src/oatpp/web/server/handler/ErrorHandler.cpp
+++ b/src/oatpp/web/server/handler/ErrorHandler.cpp
@@ -32,6 +32,9 @@ std::shared_ptr<protocol::http::outgoing::Response> ErrorHandler::handleError(co
 
   std::shared_ptr<protocol::http::outgoing::Response> response;
 
+#if defined(WIN32) || defined(_WIN32)
+  _Pragma("warning(disable : 4068 4996)")
+#endif
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /* Default impl for backwards compatibility until the deprecated methods are removed */

--- a/test/oatpp/core/data/mapping/type/ObjectTest.cpp
+++ b/test/oatpp/core/data/mapping/type/ObjectTest.cpp
@@ -92,7 +92,7 @@ class DtoD : public DtoA {
 
   DTO_INIT(DtoD, DtoA)
 
-  DTO_FIELD(Int32, a) = Int64(64);
+  DTO_FIELD(Int32, a) = Int32(64);
 
 };
 

--- a/test/oatpp/core/data/mapping/type/ObjectWrapperTest.cpp
+++ b/test/oatpp/core/data/mapping/type/ObjectWrapperTest.cpp
@@ -22,6 +22,9 @@
  *
  ***************************************************************************/
 
+#if defined(WIN32) || defined(_WIN32)
+_Pragma("warning(disable : 4101)")
+#endif
 #include "ObjectWrapperTest.hpp"
 #include "oatpp/core/Types.hpp"
 

--- a/test/oatpp/core/data/mapping/type/StringTest.cpp
+++ b/test/oatpp/core/data/mapping/type/StringTest.cpp
@@ -22,6 +22,9 @@
  *
  ***************************************************************************/
 
+#if defined(WIN32) || defined(_WIN32)
+_Pragma("warning(disable : 4101)")
+#endif
 #include "StringTest.hpp"
 
 #include "oatpp/core/Types.hpp"


### PR DESCRIPTION
Notes on build-warning-changes branch pull request.

_Pragma keyword
https://learn.microsoft.com/en-us/cpp/preprocessor/pragma-directives-and-the-pragma-keyword

src/oatpp/core/data/stream/FileStream.cpp

disable 'fopen vs fopen_s' warning
https://en.cppreference.com/w/c/io/fopen

#if defined(WIN32) || defined(_WIN32)
_Pragma("warning(disable : 4996)")
#endif

test/oatpp/core/data/mapping/type/ObjectWrapperTest.cpp
test/oatpp/core/data/mapping/type/StringTest.cpp

disable warning:
warning C4101: 'e': unreferenced local variable

#if defined(WIN32) || defined(_WIN32)
_Pragma("warning(disable : 4101)")
#endif

src/oatpp/web/server/handler/ErrorHandler.cpp
disable warnings: 
warning C4068: unknown pragma 'GCC'
warning C4996: 'oatpp::web::server::handler::ErrorHandler::handleError': was declared deprecated

#if defined(WIN32) || defined(_WIN32)
  _Pragma("warning(disable : 4068 4996)")
#endif

src\oatpp\network\tcp\server\ConnectionProvider.cpp

fixed warning:
 C4996: 'strerror': This function or variable may be unsafe. Consider using strerror_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
(or add _Pragma("warning(disable : 4996)" as above)

       if (hints.ai_family == AF_UNSPEC || hints.ai_family == AF_INET6) {
         if (setsockopt(serverHandle, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&no, sizeof( int ) ) != 0 ) {
+          const size_t buflen = 500;
+          char buf[buflen];
           OATPP_LOGW("[oatpp::network::tcp::server::ConnectionProvider::instantiateServer()]",
                      "Warning. Failed to set %s for accepting socket: %s", "IPV6_V6ONLY",
-                     strerror(errno));
+                     strerror_s(buf, buflen, errno));
         }
       }

tests:

build windows
run oatppAllTests.exe
build unix
run oatppAllTests