### PR TITLE
Fix CMake regular expression injection

### DIFF
--- a/cmake/project.cmake
+++ b/cmake/project.cmake
@@ -75,28 +75,28 @@ function(set_target_source_groups arg_TARGET)
   endforeach()
 
   set(filterSources ${sourceFiles})
-  list(FILTER filterSources INCLUDE REGEX "^${sourceDir}/.+\\.h(h|pp)?$")
+  list(FILTER filterSources INCLUDE REGEX "/.+\\.h(h|pp)?$")
   source_group(
     TREE "${sourceTreeDir}"
     PREFIX "Header Files"
     FILES ${filterSources}
   )
   set(filterSources ${sourceFiles})
-  list(FILTER filterSources INCLUDE REGEX "^${sourceDir}/.+\\.h(h|pp)?\\.in$")
+  list(FILTER filterSources INCLUDE REGEX "/.+\\.h(h|pp)?\\.in$")
   source_group(
     TREE "${sourceTreeDir}"
     PREFIX "Header Templates"
     FILES ${filterSources}
   )
   set(filterSources ${sourceFiles})
-  list(FILTER filterSources INCLUDE REGEX "^${sourceDir}/.+\\.c(c|xx|pp)?$")
+  list(FILTER filterSources INCLUDE REGEX "/.+\\.c(c|xx|pp)?$")
   source_group(
     TREE "${sourceTreeDir}"
     PREFIX "Source Files"
     FILES ${filterSources}
   )
   set(filterSources ${sourceFiles})
-  list(FILTER filterSources INCLUDE REGEX "^${sourceDir}/.+\\.c(c|xx|pp)?\\.in$")
+  list(FILTER filterSources INCLUDE REGEX "/.+\\.c(c|xx|pp)?\\.in$")
   source_group(
     TREE "${sourceTreeDir}"
     PREFIX "Source Templates"
@@ -104,7 +104,6 @@ function(set_target_source_groups arg_TARGET)
   )
 
   set(filterSources ${binaryFiles})
-  list(FILTER filterSources INCLUDE REGEX "^${binaryDir}/")
   source_group(
     TREE "${binaryTreeDir}"
     PREFIX "Generated Files"


### PR DESCRIPTION
Don't insert paths into regular expressions,
paths can contain regular expression meta characters which will get evaluated.
Process file lists manually and use cmake_path(IS_PREFIX) to filter paths.

Closes #761