### PR TITLE
Fix web server spuriously failing to start on 32-bit ARM

### DIFF
--- a/src/oatpp/network/Server.cpp
+++ b/src/oatpp/network/Server.cpp
@@ -156,7 +156,7 @@ void Server::stop() {
 
 bool Server::setStatus(v_int32 expectedStatus, v_int32 newStatus) {
   v_int32 expected = expectedStatus;
-  return m_status.compare_exchange_weak(expected, newStatus);
+  return m_status.compare_exchange_strong(expected, newStatus);
 }
 
 void Server::setStatus(v_int32 status) {


### PR DESCRIPTION
Hello,

We use Oatpp on a 32-bit ARM platform, and recently noticed that the web server would occasionally fail to start. After investigating, the cause was found to be the use of `compare_exchange_weak` during the server start up. As I understand it, `Server::setStatus` will set the new status, provided the existing value of status is equal to the expected value. During start up, the status will transition from `CREATED` to `STARTING` to `RUNNING`, and the web server will continue to run while the status is `RUNNING`.

The issue is that the comparison between the existing and expected state is done via `compare_exchange_weak`, and according to the [documentation](https://en.cppreference.com/w/cpp/atomic/atomic/compare_exchange):

> The weak forms (1-2) of the functions are allowed to fail spuriously, that is, act as if `*this != expected` even if they are equal. 

Thus, going from `CREATED` to `STARTING` or from `STARTING` to `RUNNING` may spuriously fail. This means the state won't be in the `RUNNING` state in `Server::mainLoop`, and the server will instantly close. Instead, `compare_exchange_strong` should be used, as the comparison is not allowed to spuriously fail.

Note that if you only run on x86, you will never see this spuriously failure due to the platform's stronger memory model. However, 32-bit ARM has a weaker memory model, and spurious failures will be seen when using `compare_exchange_weak`. Note how `compare_exchange_weak` and `compare_exchange_strong` generate the same code on x86, but different code on 32-bit ARM ([link](https://godbolt.org/z/W3fechMa6))

Since deploying this fix locally, we have stopped seeing spuriously failures and the web server starts reliably.