### PR TITLE
Fix compiler warnings (-Wuseless-cast)

### DIFF
--- a/src/oatpp/core/data/mapping/type/Type.cpp
+++ b/src/oatpp/core/data/mapping/type/Type.cpp
@@ -68,7 +68,7 @@ int ClassId::getClassCount() {
 
 std::vector<const char*> ClassId::getRegisteredClassNames() {
   std::lock_guard<std::mutex> lock(getClassMutex());
-  return std::vector<const char*>(getClassNames());
+  return getClassNames();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/oatpp/core/data/share/MemoryLabel.hpp
+++ b/src/oatpp/core/data/share/MemoryLabel.hpp
@@ -115,7 +115,7 @@ public:
   void captureToOwnMemory() const {
     if(!m_memoryHandle || m_memoryHandle->data() != reinterpret_cast<const char*>(m_data) || m_memoryHandle->size() != m_size) {
       m_memoryHandle = std::make_shared<std::string>(reinterpret_cast<const char*>(m_data), m_size);
-      m_data = reinterpret_cast<p_char8>(const_cast<char*>(m_memoryHandle->data()));
+      m_data = m_memoryHandle->data();
     }
   }
 


### PR DESCRIPTION
The compiler didn't catch this one in the oatpp build, but did catch it in the project in which we integrated oatpp.

See #784