### PR TITLE
Add Interface ConnectionConfigurer

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -171,6 +171,7 @@ add_library(oatpp
         oatpp/network/monitor/StatCollector.hpp
         oatpp/network/tcp/Connection.cpp
         oatpp/network/tcp/Connection.hpp
+		oatpp/network/tcp/ConnectionConfigurer.hpp
         oatpp/network/tcp/client/ConnectionProvider.cpp
         oatpp/network/tcp/client/ConnectionProvider.hpp
         oatpp/network/tcp/server/ConnectionProvider.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -171,7 +171,7 @@ add_library(oatpp
         oatpp/network/monitor/StatCollector.hpp
         oatpp/network/tcp/Connection.cpp
         oatpp/network/tcp/Connection.hpp
-		oatpp/network/tcp/ConnectionConfigurer.hpp
+        oatpp/network/tcp/ConnectionConfigurer.hpp
         oatpp/network/tcp/client/ConnectionProvider.cpp
         oatpp/network/tcp/client/ConnectionProvider.hpp
         oatpp/network/tcp/server/ConnectionProvider.cpp

--- a/src/oatpp/network/tcp/ConnectionConfigurer.hpp
+++ b/src/oatpp/network/tcp/ConnectionConfigurer.hpp
@@ -1,0 +1,49 @@
+/***************************************************************************
+*
+* Project         _____    __   ____   _      _
+*                (  _  )  /__\ (_  _)_| |_  _| |_
+*                 )(_)(  /(__)\  )( (_   _)(_   _)
+*                (_____)(__)(__)(__)  |_|    |_|
+*
+*
+* Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+***************************************************************************/
+
+#ifndef oatpp_network_tcp_ConnectionConfigurer_hpp
+#define oatpp_network_tcp_ConnectionConfigurer_hpp
+
+namespace oatpp { namespace network { namespace tcp {
+
+/**
+ * Connection configurer
+ */
+class ConnectionConfigurer {
+public:
+  /**
+   * Constructor.
+   */
+  virtual ~ConnectionConfigurer() = default;
+
+  /**
+   * Configure connection options.
+   * @param connection
+   */
+  virtual void configure(oatpp::v_io_handle handle) = 0;
+};
+
+}}}
+
+#endif

--- a/src/oatpp/network/tcp/ConnectionConfigurer.hpp
+++ b/src/oatpp/network/tcp/ConnectionConfigurer.hpp
@@ -25,6 +25,8 @@
 #ifndef oatpp_network_tcp_ConnectionConfigurer_hpp
 #define oatpp_network_tcp_ConnectionConfigurer_hpp
 
+#include <oatpp/core/IODefinitions.hpp>
+
 namespace oatpp { namespace network { namespace tcp {
 
 /**

--- a/src/oatpp/network/tcp/server/ConnectionProvider.cpp
+++ b/src/oatpp/network/tcp/server/ConnectionProvider.cpp
@@ -133,6 +133,10 @@ ConnectionProvider::ConnectionProvider(const network::Address& address, bool use
   m_serverHandle = instantiateServer();
 }
 
+void ConnectionProvider::setConnectionConfigurer(const std::shared_ptr<ConnectionConfigurer> &connectionConfigurer) {
+  m_connectionConfigurer = connectionConfigurer;
+}
+
 ConnectionProvider::~ConnectionProvider() {
   stop();
 }
@@ -328,6 +332,10 @@ void ConnectionProvider::prepareConnectionHandle(oatpp::v_io_handle handle) {
     OATPP_LOGD("[oatpp::network::tcp::server::ConnectionProvider::prepareConnectionHandle()]", "Warning. Failed to set %s for socket", "SO_NOSIGPIPE")
   }
 #endif
+
+  if(m_connectionConfigurer) {
+    m_connectionConfigurer->configure(handle);
+  }
 
 }
 

--- a/src/oatpp/network/tcp/server/ConnectionProvider.hpp
+++ b/src/oatpp/network/tcp/server/ConnectionProvider.hpp
@@ -22,12 +22,13 @@
  *
  ***************************************************************************/
 
-#ifndef oatpp_netword_tcp_server_ConnectionProvider_hpp
-#define oatpp_netword_tcp_server_ConnectionProvider_hpp
+#ifndef oatpp_network_tcp_server_ConnectionProvider_hpp
+#define oatpp_network_tcp_server_ConnectionProvider_hpp
 
 #include "oatpp/network/Address.hpp"
 #include "oatpp/network/ConnectionProvider.hpp"
 #include "oatpp/network/tcp/Connection.hpp"
+#include "oatpp/network/tcp/ConnectionConfigurer.hpp"
 
 #include "oatpp/core/Types.hpp"
 
@@ -89,6 +90,7 @@ private:
   std::atomic<bool> m_closed;
   oatpp::v_io_handle m_serverHandle;
   bool m_useExtendedConnections;
+  std::shared_ptr<ConnectionConfigurer> m_connectionConfigurer;
 private:
   oatpp::v_io_handle instantiateServer();
 private:
@@ -117,6 +119,12 @@ public:
   static std::shared_ptr<ConnectionProvider> createShared(const network::Address& address, bool useExtendedConnections = false){
     return std::make_shared<ConnectionProvider>(address, useExtendedConnections);
   }
+
+  /**
+   * Set connection configurer.
+   * @param connectionConfigurer
+   */
+  void setConnectionConfigurer(const std::shared_ptr<ConnectionConfigurer>& connectionConfigurer);
 
   /**
    * Virtual destructor.


### PR DESCRIPTION
fix #775
User can implement `ConnectionConfigurer`, and add it to `ConnectionProvider` by `setConnectionConfigurer` method to achieve the setting of the Socket options