### PR TITLE
Ignore more build directory patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,8 @@
 cmake-build-debug/
 
 # local build
-build/
-build-xcode/
+build*/
+_build*/
 srt/build/
 test/build/
 

--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,6 @@ cmake-build-debug/
 # local build
 build*/
 _build*/
-srt/build/
-test/build/
 
 # Docker
 Dockerfile


### PR DESCRIPTION
This allows to use multiple build directories easily, the underscore pattern is for my very own selfish needs 😄. The removed patterns contain a typo and shouldn't be required for CMake builds anyway.