### PR TITLE
New fix to issue 872

### DIFF
--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -255,7 +255,9 @@ if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
   # Issue 872: https://github.com/oatpp/oatpp/issues/872
   # -fcf-protection is supported only on x86 GNU/Linux per this gcc doc:
   # https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fcf-protection
-  # add_compiler_flags(4.6 "-fcf-protection")
+  if ((CMAKE_SYSTEM_NAME STREQUAL "Linux") AND (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)"))
+    add_compiler_flags(4.6 "-fcf-protection")
+  endif ()
   add_compiler_flags(4.6 "-pipe")
   add_compiler_flags(4.6 "-Werror=format-security")
   add_compiler_flags(4.6 "-Wno-format-nonliteral")


### PR DESCRIPTION
New fix of [872](https://github.com/oatpp/oatpp/issues/872) based on discussion with @fhuberts .

This fix tries to enable `-fcf-protection` when conditions are met, instead of simply disabling it all the time.

Tried building on a typical x86_64 Debian 12 (on which `-fcf-protection` is supported) and a Raspberry Pi (Raspberry Pi OS 12, on which `-fcf-protection` is not supported) and both are successful. `make test` on both devices are also successful.