### PR TITLE
Try to fix cross-compile for Raspberry Pi with GCC version < 8.1

### DIFF
--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -249,7 +249,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
   add_cxx_compiler_flags_no_test(CMAKE_CXX_FLAGS "-D_GLIBCXX_ASSERTIONS")
   add_compiler_flags(4.6 "-fasynchronous-unwind-tables")
   add_compiler_flags(4.6 "-fexceptions")
-  add_compiler_flags(4.6 "-fstack-clash-protection")
+  add_compiler_flags(8.1 "-fstack-clash-protection")
   add_compiler_flags(4.6 "-fstack-protector-strong")
   add_compiler_flags(4.6 "-grecord-gcc-switches")
   # Issue 872: https://github.com/oatpp/oatpp/issues/872


### PR DESCRIPTION
I was not able to cross-build for Raspberry Pi from Ubuntu with GCC 4.9 (symptoms were very similar to [this issue](https://github.com/oatpp/oatpp/issues/872)).
I found that `-fstack-clash-protection` flag was added to GCC in v8.1.
This PR intends to fix this. It works now on my GCC 4.9 based cross-build.