### PR TITLE
Fix compilation on GCC 4.6

### DIFF
--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -256,7 +256,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
   # -fcf-protection is supported only on x86 GNU/Linux per this gcc doc:
   # https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fcf-protection
   if ((CMAKE_SYSTEM_NAME STREQUAL "Linux") AND (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)"))
-    add_compiler_flags(4.6 "-fcf-protection")
+    add_compiler_flags(8.1 "-fcf-protection")
   endif ()
   add_compiler_flags(4.6 "-pipe")
   add_compiler_flags(4.6 "-Werror=format-security")


### PR DESCRIPTION
The compiler flag `-fcf-protection` is only available since GCC 8.1.

Closes #892