### PR TITLE
src/oatpp/core/base/Environment.hpp: include cstdarg

### DIFF
--- a/src/oatpp/core/base/Environment.hpp
+++ b/src/oatpp/core/base/Environment.hpp
@@ -29,6 +29,7 @@
 #include "./Compiler.hpp"
 #include "./Config.hpp"
 
+#include <cstdarg>
 #include <cstdio>
 #include <atomic>
 #include <mutex>


### PR DESCRIPTION
Include `cstdarg` to fix the following build failure with uclibc-ng:

```
In file included from /home/autobuild/autobuild/instance-4/output-1/build/oatpp-1.3.0/src/oatpp/algorithm/CRC.hpp:28,
                 from /home/autobuild/autobuild/instance-4/output-1/build/oatpp-1.3.0/src/oatpp/algorithm/CRC.cpp:25:
/home/autobuild/autobuild/instance-4/output-1/build/oatpp-1.3.0/src/oatpp/core/base/Environment.hpp:359:93: error: 'va_list' has not been declared
  359 |   static void vlogFormatted(v_uint32 priority, const std::string& tag, const char* message, va_list args);
      |                                                                                             ^~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/bcdf7548ff752f936defd111d13c63245ea70cbe