### PR TITLE
Fix a potential crash, indicated by a compiler warning (#894)

### DIFF
--- a/src/oatpp/network/monitor/ConnectionMonitor.cpp
+++ b/src/oatpp/network/monitor/ConnectionMonitor.cpp
@@ -187,7 +187,7 @@ void ConnectionMonitor::Monitor::freeConnectionStats(ConnectionStats& stats) {
       it->second->deleteMetricData(metric.second);
     } else {
       OATPP_LOGE("[oatpp::network::ConnectionMonitor::Monitor::freeConnectionStats]",
-                 "Error. Can't free Metric data. Unknown Metric: name - '%s'", it->first->c_str())
+                 "Error. Can't free Metric data. Unknown Metric: name - '%s'", metric.first->c_str())
     }
   }
 


### PR DESCRIPTION
At this point in the code it == m_statCollectors.end() and therefore it->first has no meaning and can not be used.

Building CXX object lib/oatpp/src/CMakeFiles/oatpp.dir/oatpp/web/protocol/CommunicationError.cpp.o In file included from /usr/include/c++/13/bits/shared_ptr.h:53,
                 from /usr/include/c++/13/memory:80,
                 from oatpp/src/oatpp/core/base/Countable.hpp:28,
                 from oatpp/src/oatpp/core/data/mapping/type/./Type.hpp:28,
                 from oatpp/src/oatpp/core/data/mapping/type/Object.hpp:28,
                 from oatpp/src/oatpp/core/Types.hpp:28,
                 from oatpp/src/oatpp/network/monitor/StatCollector.hpp:28,
                 from oatpp/src/oatpp/network/monitor/MetricsChecker.hpp:28,
                 from oatpp/src/oatpp/network/monitor/ConnectionMonitor.hpp:28,
                 from oatpp/src/oatpp/network/monitor/ConnectionMonitor.cpp:25:
In member function ‘std::__shared_ptr<_Tp, _Lp>::element_type* std::__shared_ptr<_Tp, _Lp>::get() const [with _Tp = std::__cxx11::basic_string<char>; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’,
    inlined from ‘std::__shared_ptr_access<_Tp, _Lp, <anonymous>, <anonymous> >::element_type* std::__shared_ptr_access<_Tp, _Lp, <anonymous>, <anonymous> >::_M_get() const [with _Tp = std::__cxx11::basic_string<char>; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic; bool <anonymous> = false; bool <anonymous> = false]’ at /usr/include/c++/13/bits/shared_ptr_base.h:1363:69,
    inlined from ‘std::__shared_ptr_access<_Tp, _Lp, <anonymous>, <anonymous> >::element_type* std::__shared_ptr_access<_Tp, _Lp, <anonymous>, <anonymous> >::operator->() const [with _Tp = std::__cxx11::basic_string<char>; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic; bool <anonymous> = false; bool <anonymous> = false]’ at /usr/include/c++/13/bits/shared_ptr_base.h:1357:15,
    inlined from ‘T* oatpp::data::mapping::type::ObjectWrapper<T, Clazz>::operator->() const [with T = std::__cxx11::basic_string<char>; Clazz = oatpp::data::mapping::type::__class::String]’ at oatpp/src/oatpp/core/data/mapping/type/./Type.hpp:223:28,
    inlined from ‘void oatpp::network::monitor::ConnectionMonitor::Monitor::freeConnectionStats(oatpp::network::monitor::ConnectionStats&)’ at oatpp/src/oatpp/network/monitor/ConnectionMonitor.cpp:189:7:
/usr/include/c++/13/bits/shared_ptr_base.h:1666:16: warning: array subscript 0 is outside array bounds of ‘std::aligned_storage<40, 8>::type [0]’ [-Warray-bounds=]
 1666 |       { return _M_ptr; }
      |                ^~~~~~
In member function ‘void oatpp::network::monitor::ConnectionMonitor::Monitor::freeConnectionStats(oatpp::network::monitor::ConnectionStats&)’:
cc1plus: note: source object is likely at address zero