### PR TITLE
Reduce CMake message() verbosity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,12 +51,12 @@ option(OATPP_DISABLE_LOGE "DISABLE logs priority E" OFF)
 
 ## Print config ##################################################################################
 
-message("\n############################################################################")
-message("## oatpp module compilation config:\n")
+message(TRACE "\n############################################################################")
+message(TRACE "## oatpp module compilation config:\n")
 
-message("OATPP_DISABLE_ENV_OBJECT_COUNTERS=${OATPP_DISABLE_ENV_OBJECT_COUNTERS}")
-message("OATPP_THREAD_HARDWARE_CONCURRENCY=${OATPP_THREAD_HARDWARE_CONCURRENCY}")
-message("OATPP_COMPAT_BUILD_NO_THREAD_LOCAL=${OATPP_COMPAT_BUILD_NO_THREAD_LOCAL}")
+message(TRACE "OATPP_DISABLE_ENV_OBJECT_COUNTERS=${OATPP_DISABLE_ENV_OBJECT_COUNTERS}")
+message(TRACE "OATPP_THREAD_HARDWARE_CONCURRENCY=${OATPP_THREAD_HARDWARE_CONCURRENCY}")
+message(TRACE "OATPP_COMPAT_BUILD_NO_THREAD_LOCAL=${OATPP_COMPAT_BUILD_NO_THREAD_LOCAL}")
 
 ## Set definitions ###############################################################################
 
@@ -66,7 +66,7 @@ endif()
 
 if(OATPP_DISABLE_POOL_ALLOCATIONS)
     add_definitions (-DOATPP_DISABLE_POOL_ALLOCATIONS)
-    message("WARNING: OATPP_DISABLE_POOL_ALLOCATIONS option is deprecated and has no effect.")
+    message(WARNING "OATPP_DISABLE_POOL_ALLOCATIONS option is deprecated and has no effect.")
 endif()
 
 set(AUTO_VALUE AUTO)
@@ -76,7 +76,7 @@ endif()
 
 if(OATPP_THREAD_DISTRIBUTED_MEM_POOL_SHARDS_COUNT)
     add_definitions (-DOATPP_THREAD_DISTRIBUTED_MEM_POOL_SHARDS_COUNT=${OATPP_THREAD_DISTRIBUTED_MEM_POOL_SHARDS_COUNT})
-    message("WARNING: OATPP_THREAD_DISTRIBUTED_MEM_POOL_SHARDS_COUNT option is deprecated and has no effect.")
+    message(WARNING "OATPP_THREAD_DISTRIBUTED_MEM_POOL_SHARDS_COUNT option is deprecated and has no effect.")
 endif()
 
 if(OATPP_COMPAT_BUILD_NO_THREAD_LOCAL)
@@ -111,11 +111,11 @@ if(CMAKE_COMPILER_IS_GNUCXX AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 5.0)
     add_definitions(-DOATPP_DISABLE_STD_PUT_TIME)
 endif()
 
-message("\n############################################################################\n")
+message(TRACE "\n############################################################################\n")
 
 ###################################################################################################
 
-message("oatpp version: '${OATPP_THIS_MODULE_VERSION}'")
+message(TRACE "oatpp version: '${OATPP_THIS_MODULE_VERSION}'")
 
 include(cmake/compiler-flags.cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20)
 
 file(STRINGS "${CMAKE_CURRENT_LIST_DIR}/src/oatpp/core/base/Environment.hpp" OATPP_VERSION_MACRO REGEX "#define OATPP_VERSION \"[0-9]+.[0-9]+.[0-9]+\"$")
 string(REGEX REPLACE "#define OATPP_VERSION \"([0-9]+.[0-9]+.[0-9]+)\"$" "\\1" oatpp_VERSION "${OATPP_VERSION_MACRO}")

--- a/cmake/module-install.cmake
+++ b/cmake/module-install.cmake
@@ -22,16 +22,16 @@
 ##
 ######################################################################################
 
-message("\n############################################################################")
-message("## oatpp-module-install.cmake\n")
+message(TRACE "\n############################################################################")
+message(TRACE "## oatpp-module-install.cmake\n")
 
-message("OATPP_THIS_MODULE_NAME=${OATPP_THIS_MODULE_NAME}")
-message("OATPP_THIS_MODULE_VERSION=${OATPP_THIS_MODULE_VERSION}")
-message("OATPP_THIS_MODULE_LIBRARIES=${OATPP_THIS_MODULE_LIBRARIES}")
-message("OATPP_THIS_MODULE_TARGETS=${OATPP_THIS_MODULE_TARGETS}")
-message("OATPP_THIS_MODULE_DIRECTORIES=${OATPP_THIS_MODULE_DIRECTORIES}")
+message(TRACE "OATPP_THIS_MODULE_NAME=${OATPP_THIS_MODULE_NAME}")
+message(TRACE "OATPP_THIS_MODULE_VERSION=${OATPP_THIS_MODULE_VERSION}")
+message(TRACE "OATPP_THIS_MODULE_LIBRARIES=${OATPP_THIS_MODULE_LIBRARIES}")
+message(TRACE "OATPP_THIS_MODULE_TARGETS=${OATPP_THIS_MODULE_TARGETS}")
+message(TRACE "OATPP_THIS_MODULE_DIRECTORIES=${OATPP_THIS_MODULE_DIRECTORIES}")
 
-message("\n############################################################################\n")
+message(TRACE "\n############################################################################\n")
 
 #######################################################################################
 ## Set cache variables to configure module-config.cmake.in template

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -323,7 +323,7 @@ elseif(NOT APPLE AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
         endif()
 endif()
 
-message("OATPP_ADD_LINK_LIBS=${OATPP_ADD_LINK_LIBS}")
+message(TRACE "OATPP_ADD_LINK_LIBS=${OATPP_ADD_LINK_LIBS}")
 
 target_link_libraries(oatpp PUBLIC ${CMAKE_THREAD_LIBS_INIT}
         ${OATPP_ADD_LINK_LIBS}


### PR DESCRIPTION
Reduces CMake message() verbosity to TRACE for dev-related variables.
You can of course still get them by calling `cmake .. --log-level TRACE`

**BEFORE**
![image](https://github.com/oatpp/oatpp/assets/703240/6c4687ee-acf3-4ec0-972f-9f0d9535d714)

**AFTER**
![image](https://github.com/oatpp/oatpp/assets/703240/4eb5001a-efd7-4c3e-b402-72100b1af761)
