### PR TITLE
feat(Caret) Store std::string error messages

### DIFF
--- a/src/oatpp/json/Deserializer.cpp
+++ b/src/oatpp/json/Deserializer.cpp
@@ -465,7 +465,7 @@ oatpp::Void Deserializer::deserializeObject(Deserializer* deserializer, utils::p
         caret.skipBlankChars();
         skipValue(caret);
       } else {
-        caret.setError("[oatpp::json::Deserializer::readObject()]: Error. Unknown field", ERROR_CODE_OBJECT_SCOPE_UNKNOWN_FIELD);
+        caret.setError(std::string{"[oatpp::json::Deserializer::readObject()]: Error. Unknown field - "} + key, ERROR_CODE_OBJECT_SCOPE_UNKNOWN_FIELD);
         return nullptr;
       }
 

--- a/src/oatpp/utils/parser/Caret.cpp
+++ b/src/oatpp/utils/parser/Caret.cpp
@@ -28,7 +28,7 @@
 #include <algorithm>
 
 namespace oatpp { namespace utils { namespace parser {
-  
+
   const char* const Caret::ERROR_INVALID_INTEGER = "ERROR_INVALID_INTEGER";
   const char* const Caret::ERROR_INVALID_FLOAT = "ERROR_INVALID_FLOAT";
   const char* const Caret::ERROR_INVALID_BOOLEAN = "ERROR_INVALID_BOOLEAN";
@@ -109,15 +109,15 @@ Caret::StateSaveGuard::~StateSaveGuard() {
   m_caret.m_errorCode = m_savedErrorCode;
 }
 
-v_buff_size Caret::StateSaveGuard::getSavedPosition() {
+v_buff_size Caret::StateSaveGuard::getSavedPosition() const {
   return m_savedPosition;
 }
 
-const char* Caret::StateSaveGuard::getSavedErrorMessage() {
+std::string Caret::StateSaveGuard::getSavedErrorMessage() const {
   return m_savedErrorMessage;
 }
 
-v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
+v_int64 Caret::StateSaveGuard::getSavedErrorCode() const {
   return m_savedErrorCode;
 }
 
@@ -127,45 +127,44 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
   Caret::Caret(const char* text)
     : Caret(text, static_cast<v_buff_size>(std::strlen(text)))
   {}
-  
+
   Caret::Caret(const char* parseData, v_buff_size dataSize)
     : m_data(parseData)
     , m_size(dataSize)
     , m_pos(0)
-    , m_errorMessage(nullptr)
     , m_errorCode(0)
   {}
-  
+
   Caret::Caret(const oatpp::String& str)
     : Caret(str->data(), static_cast<v_buff_size>(str->size()))
   {
     m_dataMemoryHandle = str.getPtr();
   }
-  
+
   std::shared_ptr<Caret> Caret::createShared(const char* text){
     return std::make_shared<Caret>(text);
   }
-  
+
   std::shared_ptr<Caret> Caret::createShared(const char* parseData, v_buff_size dataSize){
     return std::make_shared<Caret>(parseData, dataSize);
   }
-  
+
   std::shared_ptr<Caret> Caret::createShared(const oatpp::String& str){
     return std::make_shared<Caret>(str->data(), str->size());
   }
-  
+
   Caret::~Caret(){
   }
-  
+
   const char* Caret::getData(){
     return m_data;
   }
-  
-  const char* Caret::getCurrData(){
+
+  const char* Caret::getCurrData() {
     return &m_data[m_pos];
   }
-  
-  v_buff_size Caret::getDataSize(){
+
+  v_buff_size Caret::getDataSize() const {
     return m_size;
   }
 
@@ -176,28 +175,28 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
   void Caret::setPosition(v_buff_size position){
     m_pos = position;
   }
-  
-  v_buff_size Caret::getPosition(){
+
+  v_buff_size Caret::getPosition() const {
     return m_pos;
   }
-  
-  void Caret::setError(const char* errorMessage, v_int64 errorCode){
+
+  void Caret::setError(const std::string& errorMessage, v_int64 errorCode){
     m_errorMessage = errorMessage;
     m_errorCode = errorCode;
   }
-  
-  const char* Caret::getErrorMessage() {
-    return m_errorMessage;
+
+  const char* Caret::getErrorMessage() const {
+    return m_errorMessage.c_str();
   }
 
-  v_int64 Caret::getErrorCode() {
+  v_int64 Caret::getErrorCode() const {
     return m_errorCode;
   }
-  
-  bool Caret::hasError() {
-    return m_errorMessage != nullptr;
+
+  bool Caret::hasError() const {
+    return !m_errorMessage.empty();
   }
-  
+
   void Caret::clearError() {
     m_errorMessage = nullptr;
     m_errorCode = 0;
@@ -206,27 +205,27 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
   Caret::Label Caret::putLabel() {
     return Label(this);
   }
-  
+
   void Caret::inc(){
     m_pos ++;
   }
-  
+
   void Caret::inc(v_buff_size amount){
     m_pos+= amount;
   }
-  
+
   bool Caret::skipBlankChars(){
-    
+
     while(m_pos < m_size){
       char a = m_data[m_pos];
       if(a != ' ' && a != '\t' && a != '\n' && a != '\r' && a != '\f')
         return true;
       m_pos ++;
     }
-    
+
     return false;
   }
-  
+
   bool Caret::skipChar(char c) {
     while(m_pos < m_size){
       if(m_data[m_pos] != c)
@@ -235,59 +234,59 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     }
     return false;
   }
-  
+
   bool Caret::findChar(char c){
-    
+
     while(m_pos < m_size){
       if(m_data[m_pos] == c)
         return true;
       m_pos ++;
     }
-    
+
     return false;
   }
-  
+
   bool Caret::skipCharsFromSet(const char* set){
     return skipCharsFromSet(set, static_cast<v_buff_size>(std::strlen(set)));
   }
-  
+
   bool Caret::skipCharsFromSet(const char* set, v_buff_size setSize){
-    
+
     while(m_pos < m_size){
       if(!isAtCharFromSet(set, setSize)){
         return true;
       }
       m_pos++;
     }
-    
+
     return false;
-    
+
   }
-  
+
   v_buff_size Caret::findCharFromSet(const char* set){
     return findCharFromSet(set, static_cast<v_buff_size>(std::strlen(set)));
   }
-  
+
   v_buff_size Caret::findCharFromSet(const char* set, v_buff_size setSize){
-    
+
     while(m_pos < m_size){
-      
+
       char a = m_data[m_pos];
-      
+
       for(v_buff_size i = 0; i < setSize; i++){
         if(set[i] == a)
           return a;
       }
-      
+
       m_pos ++;
     }
-    
+
     return -1;
-    
+
   }
-  
+
   bool Caret::findRN() {
-    
+
     while(m_pos < m_size){
       if(m_data[m_pos] == '\r'){
         if(m_pos + 1 < m_size && m_data[m_pos + 1] == '\n'){
@@ -296,10 +295,10 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
       }
       m_pos ++;
     }
-    
+
     return false;
   }
-  
+
   bool Caret::skipRN() {
     if(m_pos + 1 < m_size && m_data[m_pos] == '\r' && m_data[m_pos + 1] == '\n'){
       m_pos += 2;
@@ -307,7 +306,7 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     }
     return false;
   }
-  
+
   bool Caret::isAtRN() {
     return (m_pos + 1 < m_size && m_data[m_pos] == '\r' && m_data[m_pos + 1] == '\n');
   }
@@ -371,7 +370,7 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     m_pos = (reinterpret_cast<v_buff_size>(end) - reinterpret_cast<v_buff_size>(m_data));
     return result;
   }
-  
+
   v_float32 Caret::parseFloat32(){
     char* end;
     char* start = const_cast<char*>(&m_data[m_pos]);
@@ -382,7 +381,7 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     m_pos = (reinterpret_cast<v_buff_size>(end) - reinterpret_cast<v_buff_size>(m_data));
     return result;
   }
-  
+
   v_float64 Caret::parseFloat64(){
     char* end;
     char* start = const_cast<char*>(&m_data[m_pos]);
@@ -393,78 +392,78 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     m_pos = (reinterpret_cast<v_buff_size>(end) - reinterpret_cast<v_buff_size>(m_data));
     return result;
   }
-  
+
   bool Caret::isAtText(const char* text, bool skipIfTrue){
     return isAtText(text, static_cast<v_buff_size>(std::strlen(text)), skipIfTrue);
   }
-  
+
   bool Caret::isAtText(const char* text, v_buff_size textSize, bool skipIfTrue){
-    
+
     if(textSize <= m_size - m_pos){
-      
+
       for(v_buff_size i = 0; i < textSize; i++){
-        
+
         if(text[i] != m_data[m_pos + i]){
           return false;
         }
-        
+
       }
 
       if(skipIfTrue) {
         m_pos = m_pos + textSize;
       }
-      
+
       return true;
-      
+
     }else{
       return false;
     }
-    
+
   }
-  
+
   bool Caret::isAtTextNCS(const char* text, bool skipIfTrue){
     return isAtTextNCS(text, static_cast<v_buff_size>(std::strlen(text)), skipIfTrue);
   }
-  
+
   bool Caret::isAtTextNCS(const char* text, v_buff_size textSize, bool skipIfTrue){
-    
+
     if(textSize <= m_size - m_pos){
-      
+
       for(v_buff_size i = 0; i < textSize; i++){
-        
+
         char c1 = text[i];
         char c2 = m_data[m_pos + i];
-        
+
         if(c1 >= 'a' && c1 <= 'z'){
           c1 = static_cast<char>(c1 - 'a' + 'A');
         }
-        
+
         if(c2 >= 'a' && c2 <= 'z'){
           c2 = static_cast<char>(c2 - 'a' + 'A');
         }
-        
+
         if(c1 != c2){
           return false;
         }
-        
+
       }
 
       if(skipIfTrue) {
         m_pos = m_pos + textSize;
       }
-      
+
       return true;
-      
+
     }else{
       return false;
     }
-    
+
   }
-  
+
   Caret::Label Caret::parseStringEnclosed(char openChar, char closeChar, char escapeChar){
-    
+
     if(canContinueAtChar(openChar, 1)){
-      
+
       auto label = putLabel();
       while(canContinue()){
 
@@ -477,7 +476,7 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
           m_pos++;
           return label;
         }
-        
+
         m_pos++;
       }
 
@@ -486,15 +485,15 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
     }else{
       m_errorMessage = ERROR_NO_OPEN_TAG;
     }
-    
+
     return Label(nullptr);
-    
+
   }
 
   bool Caret::findText(const char* text) {
     return findText(text, static_cast<v_buff_size>(std::strlen(text)));
   }
-  
+
   bool Caret::findText(const char* text, v_buff_size textSize) {
     m_pos = (std::search(&m_data[m_pos], &m_data[m_size], text, text + textSize) - m_data);
     return m_pos != m_size;
@@ -503,50 +502,50 @@ v_int64 Caret::StateSaveGuard::getSavedErrorCode() {
   bool Caret::isAtCharFromSet(const char* set) const{
     return isAtCharFromSet(set, static_cast<v_buff_size>(std::strlen(set)));
   }
-  
+
   bool Caret::isAtCharFromSet(const char* set, v_buff_size setSize) const{
-    
+
     char a = m_data[m_pos];
-    
+
     for(v_buff_size i = 0; i < setSize; i++){
       if(a == set[i]){
         return true;
       }
     }
-    
+
     return false;
-    
+
   }
-  
+
   bool Caret::isAtChar(char c) const{
     return m_data[m_pos] == c;
   }
-  
+
   bool Caret::isAtBlankChar() const{
     char a = m_data[m_pos];
     return (a == ' ' || a == '\t' || a == '\n' || a == '\r' || a == '\b' || a == '\f');
   }
-  
+
   bool Caret::isAtDigitChar() const{
     char a = m_data[m_pos];
     return (a >= '0' && a <= '9');
   }
-  
+
   bool Caret::canContinueAtChar(char c) const{
-    return m_pos < m_size && m_errorMessage == nullptr && m_data[m_pos] == c;
+    return m_pos < m_size && m_errorMessage.empty() && m_data[m_pos] == c;
   }
-  
+
   bool Caret::canContinueAtChar(char c, v_buff_size skipChars){
-    
-    if(m_pos < m_size && m_errorMessage == nullptr && m_data[m_pos] == c){
+
+    if(m_pos < m_size && m_errorMessage.empty() && m_data[m_pos] == c){
       m_pos = m_pos + skipChars;
       return true;
     }
     return false;
   }
-  
+
   bool Caret::canContinue() const{
-    return m_pos < m_size && m_errorMessage == nullptr;
+    return m_pos < m_size && m_errorMessage.empty();
   }
-  
+
 }}}

--- a/src/oatpp/utils/parser/Caret.hpp
+++ b/src/oatpp/utils/parser/Caret.hpp
@@ -105,7 +105,7 @@ public:
     std::string std_str();
 
     explicit operator bool() const;
-    
+
   };
 
   /**
@@ -115,7 +115,7 @@ public:
   private:
     Caret& m_caret;
     v_buff_size m_savedPosition;
-    const char* m_savedErrorMessage;
+    std::string m_savedErrorMessage;
     v_int64 m_savedErrorCode;
   public:
 
@@ -134,19 +134,19 @@ public:
      * Get caret saved position.
      * @return
      */
-    v_buff_size getSavedPosition();
+    v_buff_size getSavedPosition() const;
 
     /**
      * Get caret saved error message.
      * @return
      */
-    const char* getSavedErrorMessage();
+    std::string getSavedErrorMessage() const;
 
     /**
      * Get caret saved error code.
      * @return
      */
-    v_int64 getSavedErrorCode();
+    v_int64 getSavedErrorCode() const;
 
   };
 
@@ -154,7 +154,7 @@ private:
   const char* m_data;
   v_buff_size m_size;
   v_buff_size m_pos;
-  const char* m_errorMessage;
+  std::string m_errorMessage;
   v_int64 m_errorCode;
   std::shared_ptr<std::string> m_dataMemoryHandle;
 public:
@@ -162,7 +162,7 @@ public:
   Caret(const char* parseData, v_buff_size dataSize);
   Caret(const oatpp::String& str);
 public:
-  
+
   static std::shared_ptr<Caret> createShared(const char* text);
   static std::shared_ptr<Caret> createShared(const char* parseData, v_buff_size dataSize);
   static std::shared_ptr<Caret> createShared(const oatpp::String& str);
@@ -185,7 +185,7 @@ public:
    * Get size of a data
    * @return
    */
-  v_buff_size getDataSize();
+  v_buff_size getDataSize() const;
 
   /**
    * Get data memoryHandle.
@@ -203,7 +203,7 @@ public:
    * Get caret position relative to data
    * @return
    */
-  v_buff_size getPosition();
+  v_buff_size getPosition() const;
 
   /**
    * Set error message and error code.
@@ -211,25 +211,25 @@ public:
    * @param errorMessage
    * @param errorCode
    */
-  void setError(const char* errorMessage, v_int64 errorCode = 0);
+  void setError(const std::string& errorMessage, v_int64 errorCode = 0);
 
   /**
    * Get error message
    * @return error message
    */
-  const char* getErrorMessage();
+  const char* getErrorMessage() const;
 
   /**
    * Get error code
    * @return error code
    */
-  v_int64 getErrorCode();
+  v_int64 getErrorCode() const;
 
   /**
    * Check if error is set for the Caret
    * @return
    */
-  bool hasError();
+  bool hasError() const;
 
   /**
    * Clear error message and error code
@@ -504,7 +504,7 @@ public:
   bool canContinue() const;
 
 };
-  
+
 }}}
 
 #endif /* oatpp_utils_parser_Caret_hpp */

--- a/test/oatpp/json/DeserializerTest.cpp
+++ b/test/oatpp/json/DeserializerTest.cpp
@@ -46,27 +46,27 @@ class EmptyDto : public oatpp::DTO {
 };
 
 class Test1 : public oatpp::DTO {
-  
+
   DTO_INIT(Test1, DTO)
-  
+
   DTO_FIELD(String, strF);
-  
+
 };
-  
+
 class Test2 : public oatpp::DTO {
-  
+
   DTO_INIT(Test2, DTO)
-  
+
   DTO_FIELD(Int32, int32F);
-  
+
 };
-  
+
 class Test3 : public oatpp::DTO {
-  
+
   DTO_INIT(Test3, DTO)
-  
+
   DTO_FIELD(Float32, float32F);
-  
+
 };
 
 class Test4 : public oatpp::DTO {
@@ -140,80 +140,80 @@ class AnyDto : public oatpp::DTO {
 };
 
 #include OATPP_CODEGEN_END(DTO)
-  
+
 }
-  
+
 void DeserializerTest::onRun(){
-  
+
   auto mapper = oatpp::json::ObjectMapper::createShared();
-  
+
   auto obj1 = mapper->readFromString<oatpp::Object<Test1>>("{}");
-  
+
   OATPP_ASSERT(obj1)
   OATPP_ASSERT(!obj1->strF)
-  
+
   obj1 = mapper->readFromString<oatpp::Object<Test1>>(R"({"strF":"value1"})");
-  
+
   OATPP_ASSERT(obj1)
   OATPP_ASSERT(obj1->strF)
   OATPP_ASSERT(obj1->strF == "value1")
-  
+
   obj1 = mapper->readFromString<oatpp::Object<Test1>>("{\n\r\t\f\"strF\"\n\r\t\f:\n\r\t\f\"value1\"\n\r\t\f}");
-  
+
   OATPP_ASSERT(obj1)
   OATPP_ASSERT(obj1->strF)
   OATPP_ASSERT(obj1->strF == "value1")
-  
+
   auto obj2 = mapper->readFromString<oatpp::Object<Test2>>("{\"int32F\": null}");
-  
+
   OATPP_ASSERT(obj2)
   OATPP_ASSERT(!obj2->int32F)
-  
+
   obj2 = mapper->readFromString<oatpp::Object<Test2>>("{\"int32F\": 32}");
-  
+
   OATPP_ASSERT(obj2)
   OATPP_ASSERT(obj2->int32F == 32)
-  
+
   obj2 = mapper->readFromString<oatpp::Object<Test2>>("{\"int32F\":    -32}");
-  
+
   OATPP_ASSERT(obj2)
   OATPP_ASSERT(obj2->int32F == -32)
-  
+
   auto obj3 = mapper->readFromString<oatpp::Object<Test3>>("{\"float32F\": null}");
-  
+
   OATPP_ASSERT(obj3)
   OATPP_ASSERT(!obj3->float32F)
-  
+
   obj3 = mapper->readFromString<oatpp::Object<Test3>>("{\"float32F\": 32}");
-  
+
   OATPP_ASSERT(obj3)
   OATPP_ASSERT(fabsf(obj3->float32F - 32) < std::numeric_limits<float>::epsilon())
-  
+
   obj3 = mapper->readFromString<oatpp::Object<Test3>>("{\"float32F\": 1.32e1}");
-  
+
   OATPP_ASSERT(obj3)
   OATPP_ASSERT(obj3->float32F)
-  
+
   obj3 = mapper->readFromString<oatpp::Object<Test3>>("{\"float32F\": 1.32e+1 }");
-  
+
   OATPP_ASSERT(obj3)
   OATPP_ASSERT(obj3->float32F)
-  
+
   obj3 = mapper->readFromString<oatpp::Object<Test3>>("{\"float32F\": 1.32e-1 }");
-  
+
   OATPP_ASSERT(obj3)
   OATPP_ASSERT(obj3->float32F)
-  
+
   obj3 = mapper->readFromString<oatpp::Object<Test3>>("{\"float32F\": -1.32E-1 }");
-  
+
   OATPP_ASSERT(obj3)
   OATPP_ASSERT(obj3->float32F)
-  
+
   obj3 = mapper->readFromString<oatpp::Object<Test3>>("{\"float32F\": -1.32E1 }");
-  
+
   OATPP_ASSERT(obj3)
   OATPP_ASSERT(obj3->float32F)
-  
+
   auto list = mapper->readFromString<oatpp::List<oatpp::Int32>>("[1, 2, 3]");
   OATPP_ASSERT(list)
   OATPP_ASSERT(list->size() == 3)
@@ -322,6 +322,22 @@ void DeserializerTest::onRun(){
     OATPP_ASSERT(dto->any.retrieve<Int64>() == -1234567890)
   }
 
+  OATPP_LOGD(TAG, "Unknown field")
+  {
+    auto strictMapper = oatpp::json::ObjectMapper::createShared();
+    strictMapper->getDeserializer()->getConfig()->allowUnknownFields = false;
+
+    data::mapping::type::DTOWrapper<Test1> testObj1;
+    try {
+      testObj1 = strictMapper->readFromString<oatpp::Object<Test1>>(R"({"strF":"value1", "unexpectedField":"value2"})");
+    } catch (oatpp::utils::parser::ParsingError& e) {
+      // Error message should contain the unknown field key
+      OATPP_ASSERT(e.getMessage()->find("unexpectedField") != std::string::npos)
+    }
+
+    OATPP_ASSERT(testObj1 == nullptr)
+  }
+
 }
-  
+
 }}


### PR DESCRIPTION
To enhance unknown field handling by adding the field's key to the error message, the Caret now stores std::string error message.

Resolves #911

(Also cleaned up unnecessary whitespace in line endings and added a test checking if the error message contains the unknown field key)