### PR TITLE
FileBody to created responses with files

### DIFF
--- a/src/oatpp/web/protocol/http/outgoing/FileBody.cpp
+++ b/src/oatpp/web/protocol/http/outgoing/FileBody.cpp
@@ -1,0 +1,125 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2024-present, MrBesen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#include "FileBody.hpp"
+
+#if !defined(WIN32) && !defined(_WIN32)
+#include <fcntl.h> // open
+#include <sys/mman.h> // mmap, madvise
+#include <unistd.h> // lseek
+#endif
+
+namespace oatpp { namespace web { namespace protocol { namespace http { namespace outgoing {
+
+FileBody::FileBody(const oatpp::String &filepath, const data::share::StringKeyLabel &contentType)
+  : m_filepath(filepath)
+#if defined(WIN32) || defined(_WIN32)
+  , m_buffer(oatpp::String::loadFromFile(filepath->c_str()))
+#else
+  , m_ptr(nullptr)
+  , m_initial_size(-1)
+#endif
+  , m_contentType(contentType)
+  , m_inlineData(nullptr, 0)
+{
+#if defined(WIN32) || defined(_WIN32)
+  m_inlineData = InlineReadData(reinterpret_cast<void*>(m_buffer->data()), static_cast<v_buff_size>(m_buffer->size()));
+#else
+  int fd = ::open(m_filepath->c_str(), O_RDONLY | O_CLOEXEC);
+  if(fd == -1) {
+    return;
+  }
+
+  // map file
+  m_initial_size = ::lseek64(fd, 0, SEEK_END);
+  m_ptr = ::mmap(nullptr, m_initial_size, PROT_READ, MAP_SHARED, fd, 0);
+  ::close(fd);
+  if(m_ptr == MAP_FAILED) {
+    return;
+  }
+
+  // set some hints for the kernel
+  ::madvise(m_ptr, m_initial_size, MADV_SEQUENTIAL);
+  ::madvise(m_ptr, m_initial_size, MADV_WILLNEED);
+
+  m_inlineData = InlineReadData(m_ptr, m_initial_size);
+#endif
+}
+
+FileBody::~FileBody() {
+#if !defined(WIN32) && !defined(_WIN32)
+  // remove mapping
+  ::munmap(m_ptr, m_initial_size);
+#endif
+}
+
+std::shared_ptr<FileBody> FileBody::createShared(const oatpp::String &filepath,
+                                                     const data::share::StringKeyLabel &contentType) {
+  return std::make_shared<FileBody>(filepath, contentType);
+}
+
+v_io_size FileBody::read(void *buffer, v_buff_size count, async::Action &action) {
+
+  (void) action;
+
+  v_buff_size desiredToRead = m_inlineData.bytesLeft;
+
+  if (desiredToRead > 0) {
+
+    if (desiredToRead > count) {
+      desiredToRead = count;
+    }
+
+    std::memcpy(buffer, m_inlineData.currBufferPtr, static_cast<size_t>(desiredToRead));
+    m_inlineData.inc(desiredToRead);
+
+    return desiredToRead;
+  }
+
+  return 0;
+}
+
+void FileBody::declareHeaders(Headers &headers) {
+  if (m_contentType) {
+    headers.putIfNotExists(Header::CONTENT_TYPE, m_contentType);
+  }
+}
+
+p_char8 FileBody::getKnownData() {
+#if defined(WIN32) || defined(_WIN32)
+  return reinterpret_cast<p_char8>(m_buffer->data());
+#else
+  return reinterpret_cast<p_char8>(m_ptr);
+#endif
+}
+
+v_int64 FileBody::getKnownSize() {
+#if defined(WIN32) || defined(_WIN32)
+  return static_cast<v_int64>(m_buffer->size());
+#else
+  return static_cast<v_int64>(m_initial_size);
+#endif
+}
+
+}}}}}

--- a/src/oatpp/web/protocol/http/outgoing/FileBody.hpp
+++ b/src/oatpp/web/protocol/http/outgoing/FileBody.hpp
@@ -1,0 +1,94 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2024-present, MrBesen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#ifndef oatpp_web_protocol_http_outgoing_FileBody_hpp
+#define oatpp_web_protocol_http_outgoing_FileBody_hpp
+
+#include "./Body.hpp"
+#include "oatpp/web/protocol/http/Http.hpp"
+
+namespace oatpp { namespace web { namespace protocol { namespace http { namespace outgoing {
+
+/**
+ * Implementation of &id:oatpp::web::protocol::http::outgoing::Body; class.
+ * Implements functionality to use a file as data source for http body.
+ */
+class FileBody : public oatpp::base::Countable, public Body {
+private:
+  oatpp::String m_filepath;
+#if defined(WIN32) || defined(_WIN32)
+  oatpp::String m_buffer;
+#else
+  p_char8 m_ptr;
+  v_int64 m_initial_size;
+#endif
+  oatpp::data::share::StringKeyLabel m_contentType;
+  data::buffer::InlineReadData m_inlineData;
+public:
+  FileBody(const oatpp::String& filepath, const data::share::StringKeyLabel& contentType);
+  virtual ~FileBody() override;
+public:
+
+  /**
+   * Create shared FileBody.
+   * @param buffer - &id:oatpp::String;.
+   * @param contentType - type of the content.
+   * @return - `std::shared_ptr` to FileBody.
+   */
+  static std::shared_ptr<FileBody> createShared(const oatpp::String& filepath,
+                                                  const data::share::StringKeyLabel& contentType = data::share::StringKeyLabel());
+
+  /**
+   * Read operation callback.
+   * @param buffer - pointer to buffer.
+   * @param count - size of the buffer in bytes.
+   * @param action - async specific action. If action is NOT &id:oatpp::async::Action::TYPE_NONE;, then
+   * caller MUST return this action on coroutine iteration.
+   * @return - actual number of bytes written to buffer. 0 - to indicate end-of-file.
+   */
+  v_io_size read(void *buffer, v_buff_size count, async::Action& action) override;
+
+  /**
+   * Declare `Content-Length` header.
+   * @param headers - &id:oatpp::web::protocol::http::Headers;.
+   */
+  void declareHeaders(Headers& headers) override;
+
+  /**
+   * Pointer to the body known data.
+   * @return - `p_char8`.
+   */
+  p_char8 getKnownData() override;
+
+  /**
+   * Return known size of the body.
+   * @return - `v_buff_size`.
+   */
+  v_int64 getKnownSize() override;
+  
+};
+  
+}}}}}
+
+#endif /* oatpp_web_protocol_http_outgoing_FileBody_hpp */

--- a/src/oatpp/web/protocol/http/outgoing/ResponseFactory.cpp
+++ b/src/oatpp/web/protocol/http/outgoing/ResponseFactory.cpp
@@ -25,6 +25,7 @@
 #include "./ResponseFactory.hpp"
 
 #include "./BufferBody.hpp"
+#include "./FileBody.hpp"
 
 namespace oatpp { namespace web { namespace protocol { namespace http { namespace outgoing {
 
@@ -36,6 +37,11 @@ ResponseFactory::createResponse(const Status& status) {
 std::shared_ptr<Response>
 ResponseFactory::createResponse(const Status& status, const oatpp::String& text) {
   return Response::createShared(status, BufferBody::createShared(text));
+}
+
+std::shared_ptr<Response>
+ResponseFactory::createFileResponse(const Status& status, const oatpp::String& filepath) {
+  return Response::createShared(status, FileBody::createShared(filepath));
 }
 
 std::shared_ptr<Response>

--- a/src/oatpp/web/protocol/http/outgoing/ResponseFactory.hpp
+++ b/src/oatpp/web/protocol/http/outgoing/ResponseFactory.hpp
@@ -54,6 +54,14 @@ public:
   static std::shared_ptr<Response> createResponse(const Status& status, const oatpp::String& text);
 
   /**
+   * Create &id:oatpp::web::protocol::http::outgoing::Response; with &id:oatpp::web::protocol::http::outgoing::FileBody;.
+   * @param status - &id:oatpp::web::protocol::http::Status;.
+   * @param filepath - &id:oatpp::String;.
+   * @return - `std::shared_ptr` to &id:oatpp::web::protocol::http::outgoing::Response;.
+   */
+  static std::shared_ptr<Response> createFileResponse(const Status& status, const oatpp::String& filepath);
+
+  /**
    * Create &id:oatpp::web::protocol::http::outgoing::Response; with &id:oatpp::web::protocol::http::outgoing::DtoBody;.
    * @param status - &id:oatpp::web::protocol::http::Status;.
    * @param dto - see [Data Transfer Object (DTO)](https://oatpp.io/docs/components/dto/).


### PR DESCRIPTION
This adresses #859 and #912.

Currently you have to load a file into a `oatpp::String` to use it as a response. This gets expensive fast if you have files that can be up to a few GB in size.
So i implemented a `FileBody` that creates the response from a memory mapped file. I am not familiar with Windows systemcalls when it comes to file access so i just implemented it using the simple `oatpp::String::loadFromFile` approach. 

Mapping the file into memory is very efficent on linux, as it allows the kernel to evict the memory pages on high memory pressure and repopulate them later. The memory of the mapped file can also be shared between processes reading the same file, reducing the memory pressure of the system even further.