### PR TITLE
#793 #913 Use unique pointers to avoid memory leaks

### DIFF
--- a/src/oatpp/codegen/dto/base_define.hpp
+++ b/src/oatpp/codegen/dto/base_define.hpp
@@ -71,12 +71,12 @@ static v_int64 Z__PROPERTY_OFFSET_##NAME() { \
 } \
 \
 static oatpp::data::type::BaseObject::Property* Z__PROPERTY_SINGLETON_##NAME() { \
-  static oatpp::data::type::BaseObject::Property* property = \
+  static std::unique_ptr<oatpp::data::type::BaseObject::Property> property( \
       new oatpp::data::type::BaseObject::Property(Z__PROPERTY_OFFSET_##NAME(), \
                                                   #NAME, \
                                                   #NAME, \
-                                                  TYPE::Class::getType()); \
-  return property; \
+                                                  TYPE::Class::getType())); \
+  return property.get(); \
 } \
 \
 static bool Z__PROPERTY_INIT_##NAME(... /* default initializer for all cases */) { \
@@ -103,12 +103,12 @@ static v_int64 Z__PROPERTY_OFFSET_##NAME() { \
 } \
 \
 static oatpp::data::type::BaseObject::Property* Z__PROPERTY_SINGLETON_##NAME() { \
-  static oatpp::data::type::BaseObject::Property* property = \
+  static std::unique_ptr<oatpp::data::type::BaseObject::Property> property( \
       new oatpp::data::type::BaseObject::Property(Z__PROPERTY_OFFSET_##NAME(), \
                                                   QUALIFIER, \
                                                   #NAME, \
-                                                  TYPE::Class::getType()); \
-  return property; \
+                                                  TYPE::Class::getType())); \
+  return property.get(); \
 } \
 \
 static bool Z__PROPERTY_INIT_##NAME(... /* default initializer for all cases */) { \

--- a/src/oatpp/data/type/Enum.hpp
+++ b/src/oatpp/data/type/Enum.hpp
@@ -651,7 +651,8 @@ namespace __class {
     static Type createType() {
       Type::Info info;
       info.nameQualifier = type::EnumMeta<T>::getInfo()->nameQualifier;
-      info.polymorphicDispatcher = new PolymorphicDispatcher();
+      static std::unique_ptr<PolymorphicDispatcher> disp(new PolymorphicDispatcher());
+      info.polymorphicDispatcher = disp.get();
       return Type(__class::AbstractEnum::CLASS_ID, info);
     }
 

--- a/src/oatpp/data/type/List.hpp
+++ b/src/oatpp/data/type/List.hpp
@@ -109,7 +109,8 @@ namespace __class {
     static Type createType() {
       Type::Info info;
       info.params.push_back(T::Class::getType());
-      info.polymorphicDispatcher = new typename StandardCollection<std::list<T>, T, List>::PolymorphicDispatcher();
+      static std::unique_ptr<typename StandardCollection<std::list<T>, T, List>::PolymorphicDispatcher> disp(new typename StandardCollection<std::list<T>, T, List>::PolymorphicDispatcher());
+      info.polymorphicDispatcher = disp.get();
       info.isCollection = true;
       return Type(__class::AbstractList::CLASS_ID, info);
     }

--- a/src/oatpp/data/type/Object.hpp
+++ b/src/oatpp/data/type/Object.hpp
@@ -301,12 +301,13 @@ namespace __class {
       return properties;
     }
 
-    static Type* createType() {
+    static std::unique_ptr<Type> createType() {
       Type::Info info;
       info.nameQualifier = T::Z__CLASS_TYPE_NAME();
-      info.polymorphicDispatcher = new PolymorphicDispatcher();
+      static std::unique_ptr<PolymorphicDispatcher> disp(new PolymorphicDispatcher());
+      info.polymorphicDispatcher = disp.get();
       info.parent = T::getParentType();
-      return new Type(CLASS_ID, info);
+      return std::unique_ptr<Type>(new Type(CLASS_ID, info));
     }
 
   public:
@@ -316,8 +317,8 @@ namespace __class {
      * @return - &id:oatpp::data::type::Type;
      */
     static Type* getType() {
-      static Type* type = createType();
-      return type;
+      static std::unique_ptr<Type> type = createType();
+      return type.get();
     }
     
   };

--- a/src/oatpp/data/type/PairList.hpp
+++ b/src/oatpp/data/type/PairList.hpp
@@ -133,8 +133,8 @@ private:
     Type::Info info;
     info.params.push_back(Key::Class::getType());
     info.params.push_back(Value::Class::getType());
-    info.polymorphicDispatcher =
-      new typename __class::StandardMap<std::list<std::pair<Key, Value>>, Key, Value, PairList>::PolymorphicDispatcher();
+    static std::unique_ptr<typename __class::StandardMap<std::list<std::pair<Key, Value>>, Key, Value, PairList>::PolymorphicDispatcher> disp(new typename __class::StandardMap<std::list<std::pair<Key, Value>>, Key, Value, PairList>::PolymorphicDispatcher());
+    info.polymorphicDispatcher = disp.get();
     info.isMap = true;
     return Type(__class::AbstractPairList::CLASS_ID, info);
   }

--- a/src/oatpp/data/type/UnorderedSet.hpp
+++ b/src/oatpp/data/type/UnorderedSet.hpp
@@ -109,7 +109,8 @@ private:
   static Type createType() {
     Type::Info info;
     info.params.push_back(T::Class::getType());
-    info.polymorphicDispatcher = new typename StandardCollection<std::unordered_set<T>, T, UnorderedSet>::PolymorphicDispatcher();
+    static std::unique_ptr<typename StandardCollection<std::unordered_set<T>, T, UnorderedSet>::PolymorphicDispatcher> disp(new typename StandardCollection<std::unordered_set<T>, T, UnorderedSet>::PolymorphicDispatcher());
+    info.polymorphicDispatcher = disp.get();
     info.isCollection = true;
     return Type(__class::AbstractUnorderedSet::CLASS_ID, info);
   }

--- a/src/oatpp/data/type/Vector.hpp
+++ b/src/oatpp/data/type/Vector.hpp
@@ -105,7 +105,8 @@ namespace __class {
     static Type createType() {
       Type::Info info;
       info.params.push_back(T::Class::getType());
-      info.polymorphicDispatcher = new typename StandardCollection<std::vector<T>, T, Vector>::PolymorphicDispatcher();
+      static std::unique_ptr<typename StandardCollection<std::vector<T>, T, Vector>::PolymorphicDispatcher> disp(new typename StandardCollection<std::vector<T>, T, Vector>::PolymorphicDispatcher());
+      info.polymorphicDispatcher = disp.get();
       info.isCollection = true;
       return Type(__class::AbstractVector::CLASS_ID, info);
     }


### PR DESCRIPTION
This pull request addresses the issues #793 and #913

By the use of std::unique_ptr, memory leaks are avoided.