### PR TITLE
ej proposal

### DIFF
--- a/src/oatpp/network/tcp/Connection.cpp
+++ b/src/oatpp/network/tcp/Connection.cpp
@@ -180,7 +180,6 @@ v_io_size Connection::read(void *buff, v_buff_size count, async::Action& action)
       return IOError::BROKEN_PIPE; // Consider all other errors as a broken pipe.
     }
   }
-  return result;
 
 #else
 
@@ -211,9 +210,10 @@ v_io_size Connection::read(void *buff, v_buff_size count, async::Action& action)
     //OATPP_LOGD("Connection", "write errno=%d", e)
     return IOError::BROKEN_PIPE; // Consider all other errors as a broken pipe.
   }
-  return result;
 
 #endif
+  if (!result) return IOError::BROKEN_PIPE;
+  return result;
 
 }
 

--- a/src/oatpp/network/virtual_/Interface.hpp
+++ b/src/oatpp/network/virtual_/Interface.hpp
@@ -193,7 +193,9 @@ public:
   oatpp::String getName() {
     return m_name;
   }
-  
+
+  oatpp::async::CoroutineWaitList m_serverWaitList, m_clientWaitList;
+
 };
   
 }}}

--- a/src/oatpp/network/virtual_/server/ConnectionProvider.hpp
+++ b/src/oatpp/network/virtual_/server/ConnectionProvider.hpp
@@ -94,18 +94,9 @@ public:
    * and then process connections in Asynchronous manner with non-blocking read/write.
    * <br>
    * *It may be implemented later.*
+   * EJ: We need to implement it because it will create too many threads for many interfaces
    */
-  oatpp::async::CoroutineStarterForResult<const provider::ResourceHandle<data::stream::IOStream>&> getAsync() override {
-    /*
-     *  No need to implement this.
-     *  For Asynchronous IO in oatpp it is considered to be a good practice
-     *  to accept connections in a seperate thread with the blocking accept()
-     *  and then process connections in Asynchronous manner with non-blocking read/write
-     *
-     *  It may be implemented later
-     */
-    throw std::runtime_error("[oatpp::network::virtual_::server::ConnectionProvider::getConnectionAsync()]: Error. Not implemented.");
-  }
+  oatpp::async::CoroutineStarterForResult<const provider::ResourceHandle<data::stream::IOStream>&> getAsync() override;
   
 };
   


### PR DESCRIPTION
In this proposed, I fixed the following issue:

In some rare cases in file async mode, the read may return 0 without WOULD_BLOCK errno which cause the OATPP to go into busy loop in executor. The fix is to return BROKEN_PIPE when ::recv return zero.
In virtual interface, the client ConnectionProvider::getAsync()'s delay was 100ms which mean the client side connect may delay in the multiple of 100ms which is not very efficient. And server ConnectionProvider::getAsync() was not implemented and its not very efficient when I have a lot of interfaces and each server side will need a separate thread to accept the connections. In this patch, at the server side, I add CoroutineWaitList to the interface and implement server ConnectionProvider::getAsync() using Action::createWaitListAction to wait for client side incoming connection. Also, I modify the client ConnectionProvider::getAsync() to make it faster. Right now, the time between interface connection and accept is around 232us in my environment.
In the outgoing Response, it does not support the ASYNC streaming which is needed by my project. Thus I implement it according to the incoming Response which support the ASYNC streaming.