### PR TITLE
web::server::api::Endpoint: ensure parameter order is maintained in P…

### DIFF
--- a/src/oatpp/web/server/api/Endpoint.cpp
+++ b/src/oatpp/web/server/api/Endpoint.cpp
@@ -50,6 +50,9 @@ Endpoint::Info::Param& Endpoint::Info::Params::add(const oatpp::String& aname, o
 }
 
 Endpoint::Info::Param& Endpoint::Info::Params::operator [](const oatpp::String& aname) {
+  if (std::find(m_order.begin(), m_order.end(), aname) == m_order.end()) {
+      m_order.push_back(aname);
+  }
   return m_params[aname];
 }
 


### PR DESCRIPTION
This problem was found in the following scenarios
[Show header parameters in Swagger UI](https://github.com/oatpp/oatpp-swagger/issues/65)

Now it can be displayed normally ~

```c++
        ENDPOINT_INFO(hello) {
            info->addTag("hello");
            info->summary = "Root endpoint with 'Hello World!!!' message";
            info->addResponse<Object<HelloDTO>>(
                Status::CODE_200,
                "application/json"
            );
            info->headers.add<String>("abc");
        }
        ENDPOINT("GET", "/hello", hello, REQUEST(std::shared_ptr<IncomingRequest>, request))
```

![image](https://github.com/user-attachments/assets/5a140d9e-4764-43f8-abb7-131a300942c1)
