### PR TITLE
remove political banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-
-[![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner2-direct.svg)](https://vshymanskyy.github.io/StandWithUkraine/)
-
----
-
 <div align="center">
   <img alt="Oat++ Logo" src="https://raw.githubusercontent.com/lganzzzo/oatpp-website-res/master/logo_x400.png" width="200px"/>
 </div>


### PR DESCRIPTION
keep politics out of technical code-repositories (avoid triggers, distraction).

if the maintainers decide to keep it, then (for consistency reasons) place the political banner on the website, too:

https://oatpp.io