### PR TITLE
Only use ContentEncoder if ContentEncoding header is not set

### DIFF
--- a/src/oatpp/web/server/HttpProcessor.cpp
+++ b/src/oatpp/web/server/HttpProcessor.cpp
@@ -25,6 +25,7 @@
 #include "HttpProcessor.hpp"
 
 #include "oatpp/web/server/HttpServerError.hpp"
+#include "oatpp/web/protocol/http/encoding/EncoderProvider.hpp"
 #include "oatpp/web/protocol/http/incoming/SimpleBodyDecoder.hpp"
 #include "oatpp/data/stream/BufferStream.hpp"
 
@@ -194,8 +195,11 @@ HttpProcessor::ConnectionState HttpProcessor::processNextRequest(ProcessingResou
 
   }
 
-  auto contentEncoderProvider =
-    protocol::http::utils::CommunicationUtils::selectEncoder(request, resources.components->contentEncodingProviders);
+  std::shared_ptr<protocol::http::encoding::EncoderProvider> contentEncoderProvider;
+  // only use compression if content encoding was not set yet
+  if(response->getHeader(protocol::http::Header::CONTENT_ENCODING) == nullptr) {
+    contentEncoderProvider = protocol::http::utils::CommunicationUtils::selectEncoder(request, resources.components->contentEncodingProviders);
+  }
 
   response->send(resources.connection.object.get(), &resources.headersOutBuffer, contentEncoderProvider.get());
 


### PR DESCRIPTION
I have a application that provides deflate compressed content on some of its endpoints. Because oat++ tried to add the deflate encoding provider anyways this caused a duplicate of the `Content-Encoding: deflate` header.
This check if a `Content-Encoding` header is already set avoids this.

Having a way to filter which response gets compressed and which does not would also be nice, to filter all responses < x Kb or have `Content-Type: image/jpeg` or similar.