### PR TITLE
allow comparing of DTOWrapper

### DIFF
--- a/src/oatpp/data/type/Object.hpp
+++ b/src/oatpp/data/type/Object.hpp
@@ -421,6 +421,12 @@ public:
     return getPropertiesMap().at(propertyName)->getAsRef(this->m_ptr.get());
   }
 
+  inline bool operator < (const DTOWrapper& other) const {
+    if(this->m_ptr.get() == other.m_ptr.get()) return false;
+    if(!this->m_ptr.get()) return true; // lhs is null
+    if(!other.m_ptr.get()) return false; // rhs is null
+    return *this->m_ptr < *other.m_ptr; // compare content
+  }
 };
 
 /**

--- a/src/oatpp/data/type/Primitive.hpp
+++ b/src/oatpp/data/type/Primitive.hpp
@@ -274,6 +274,12 @@ public:
     return !operator == (other);
   }
 
+  inline bool operator < (const String &other) const {
+    if(!m_ptr) return static_cast<bool>(other.m_ptr);
+    if(!other.m_ptr) return false;
+    return *m_ptr < *other.m_ptr;
+  }
+
 };
 
 String operator + (const char* a, const String& b);


### PR DESCRIPTION
This allows me to use the `oatpp::Object` type in the value and key of a `std::multimap` or other sorted container.

You may need to implement an `bool operator<` for the given DTO you use inside `oatpp::Object`. Maybe there is a way to generate that operator automatically using oatpp magic?