### PR TITLE
add `QueryResult::getRowsAffected()` to the API

### DIFF
--- a/src/oatpp/orm/QueryResult.cpp
+++ b/src/oatpp/orm/QueryResult.cpp
@@ -26,5 +26,8 @@
 
 namespace oatpp { namespace orm {
 
+  v_uint64 QueryResult::getRowsAffected() const {
+    throw std::runtime_error("[oatpp::orm::QueryResult::getRowsAffected()]: Error. Not implemented!");
+  }
 
 }}

--- a/src/oatpp/orm/QueryResult.hpp
+++ b/src/oatpp/orm/QueryResult.hpp
@@ -82,7 +82,7 @@ public:
    * Count of rows affected by the operation.
    * Might be 0
    */
-  virtual v_uint64 getRowsAffected() const = 0;
+  virtual v_uint64 getRowsAffected() const;
 
   /**
    * Fetch result entries.

--- a/src/oatpp/orm/QueryResult.hpp
+++ b/src/oatpp/orm/QueryResult.hpp
@@ -79,6 +79,12 @@ public:
   virtual bool hasMoreToFetch() const = 0;
 
   /**
+   * Count of rows affected by the operation.
+   * Might be 0
+   */
+  virtual v_uint64 getRowsAffected() const = 0;
+
+  /**
    * Fetch result entries.
    * @param resultType - wanted output type.
    * @param count - how many entries to fetch. Use `-1` to fetch all.


### PR DESCRIPTION
i know this breaks compatability with all database plugins.

Is there another way to expose this information?

Should it have an default implementation always returning 0? (To not break the compatability?)