### PR TITLE
expose Logging formatter

### DIFF
--- a/src/oatpp/base/Log.hpp
+++ b/src/oatpp/base/Log.hpp
@@ -81,6 +81,9 @@ public:
   LogMessage& operator << (const Float32& value);
   LogMessage& operator << (const Float64& value);
 
+  template<typename... Types>
+  LogMessage& fill(Types... args);
+
 };
 
 struct Log {
@@ -91,22 +94,24 @@ struct Log {
 
   template<typename ... Types>
   static void stream(v_uint32 priority, const std::string& tag, const oatpp::String& message, Types... args) {
-    oatpp::base::LogMessage msg(message);
-    ignore({std::addressof(msg << args)...});
-    log(priority, tag, msg);
+    log(priority, tag, LogMessage(message).fill(std::forward<Types>(args)...));
   }
 
   template<typename ... Types>
   static void stream(v_uint32 priority, const LogCategory& category, const oatpp::String& message, Types... args) {
-    oatpp::base::LogMessage msg(message);
-    ignore({std::addressof(msg << args)...});
-    log(priority, category, msg);
+    log(priority, category, LogMessage(message).fill(std::forward<Types>(args)...));
   }
 
   static void log(v_uint32 priority, const std::string& tag, const LogMessage& message);
   static void log(v_uint32 priority, const LogCategory& category, const LogMessage& message);
 
 };
+
+template<typename... Types>
+LogMessage& LogMessage::fill(Types... args) {
+  Log::ignore({std::addressof(*this << args)...});
+  return *this;
+}
 
 }}
 


### PR DESCRIPTION
this allows other classes to access the log formatting without implementing parts of it themselfs.

I wanted to use the formatting in other parts of the program as well. But having to implement the template overload every time is quite annoying and creates unreadable code. So i just packed it into a small function to reuse by others.